### PR TITLE
CLI utility for loading JSON schema and generating tokens

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -49,7 +49,7 @@ type_name:
   allowed_symbols: ["_"] # these are allowed in type names
 identifier_name:
   min_length: # only min_length
-    error: 3 # only error
+    error: 2 # only error
   excluded: # excluded via string array
     - id
     - URL

--- a/SDDS.xcworkspace/contents.xcworkspacedata
+++ b/SDDS.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:SDDSCore/SDDSCore.xcodeproj">
    </FileRef>
    <FileRef

--- a/SDDSCore/SDDSCore.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SDDSCore/SDDSCore.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SDDSThemeBuilder/SDDSTheme/SDDSTheme.docc/SDDSTheme.md
+++ b/SDDSThemeBuilder/SDDSTheme/SDDSTheme.docc/SDDSTheme.md
@@ -1,0 +1,13 @@
+# ``SDDSTheme``
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->

--- a/SDDSThemeBuilder/SDDSTheme/SDDSTheme.h
+++ b/SDDSThemeBuilder/SDDSTheme/SDDSTheme.h
@@ -1,0 +1,16 @@
+//
+//  Created by Калтырин Владимир Александрович on 11.04.2024.
+//  Copyright © 2024 Sberbank. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for SDDSTheme.
+FOUNDATION_EXPORT double SDDSThemeVersionNumber;
+
+//! Project version string for SDDSTheme.
+FOUNDATION_EXPORT const unsigned char SDDSThemeVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <SDDSTheme/PublicHeader.h>
+
+

--- a/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.pbxproj
+++ b/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.pbxproj
@@ -1,0 +1,678 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2489D0A52BC7F3790053AAB1 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489D0A42BC7F3790053AAB1 /* main.swift */; };
+		2489D0B42BC7F3850053AAB1 /* SDDSTheme.docc in Sources */ = {isa = PBXBuildFile; fileRef = 2489D0B32BC7F3850053AAB1 /* SDDSTheme.docc */; };
+		2489D0BA2BC7F3850053AAB1 /* SDDSTheme.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2489D0B02BC7F3850053AAB1 /* SDDSTheme.framework */; };
+		2489D0BF2BC7F3850053AAB1 /* SDDSThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489D0BE2BC7F3850053AAB1 /* SDDSThemeTests.swift */; };
+		2489D0C02BC7F3850053AAB1 /* SDDSTheme.h in Headers */ = {isa = PBXBuildFile; fileRef = 2489D0B22BC7F3850053AAB1 /* SDDSTheme.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2489D0C82BC7F3EC0053AAB1 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489D0C72BC7F3EC0053AAB1 /* Command.swift */; };
+		2489D0CE2BC7F5AD0053AAB1 /* DownloadSchemeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489D0CD2BC7F5AD0053AAB1 /* DownloadSchemeCommand.swift */; };
+		2489D0D12BC7F5EA0053AAB1 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489D0D02BC7F5EA0053AAB1 /* Constants.swift */; };
+		2489D0D62BC7F7E60053AAB1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489D0D52BC7F7E60053AAB1 /* Logger.swift */; };
+		24CB39092BC939E000B32463 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB39082BC939E000B32463 /* App.swift */; };
+		24CB390C2BC95BDF00B32463 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 24CB390B2BC95BDF00B32463 /* ArgumentParser */; };
+		24CB390E2BC963FF00B32463 /* ProcessParametersCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB390D2BC963FF00B32463 /* ProcessParametersCommand.swift */; };
+		24CB39102BC9646500B32463 /* PrepareCodeGenSchemaCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB390F2BC9646500B32463 /* PrepareCodeGenSchemaCommand.swift */; };
+		24CB39122BC964C000B32463 /* GenerateTokensCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB39112BC964C000B32463 /* GenerateTokensCommand.swift */; };
+		24CB39142BC964EA00B32463 /* BuildFrameworkCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB39132BC964EA00B32463 /* BuildFrameworkCommand.swift */; };
+		24CB39162BC96C4200B32463 /* Scheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB39152BC96C4200B32463 /* Scheme.swift */; };
+		24CB39182BC96CDE00B32463 /* DecodeSchemeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB39172BC96CDE00B32463 /* DecodeSchemeCommand.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		2489D0BB2BC7F3850053AAB1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2489D0992BC7F3790053AAB1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2489D0AF2BC7F3850053AAB1;
+			remoteInfo = SDDSTheme;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		2489D09F2BC7F3790053AAB1 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		2489D0A12BC7F3790053AAB1 /* SDDSThemeBuilder */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SDDSThemeBuilder; sourceTree = BUILT_PRODUCTS_DIR; };
+		2489D0A42BC7F3790053AAB1 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		2489D0B02BC7F3850053AAB1 /* SDDSTheme.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDDSTheme.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2489D0B22BC7F3850053AAB1 /* SDDSTheme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDDSTheme.h; sourceTree = "<group>"; };
+		2489D0B32BC7F3850053AAB1 /* SDDSTheme.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = SDDSTheme.docc; sourceTree = "<group>"; };
+		2489D0B92BC7F3850053AAB1 /* SDDSThemeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SDDSThemeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2489D0BE2BC7F3850053AAB1 /* SDDSThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDDSThemeTests.swift; sourceTree = "<group>"; };
+		2489D0C72BC7F3EC0053AAB1 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		2489D0CD2BC7F5AD0053AAB1 /* DownloadSchemeCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadSchemeCommand.swift; sourceTree = "<group>"; };
+		2489D0D02BC7F5EA0053AAB1 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		2489D0D52BC7F7E60053AAB1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		24CB39082BC939E000B32463 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		24CB390D2BC963FF00B32463 /* ProcessParametersCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessParametersCommand.swift; sourceTree = "<group>"; };
+		24CB390F2BC9646500B32463 /* PrepareCodeGenSchemaCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepareCodeGenSchemaCommand.swift; sourceTree = "<group>"; };
+		24CB39112BC964C000B32463 /* GenerateTokensCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateTokensCommand.swift; sourceTree = "<group>"; };
+		24CB39132BC964EA00B32463 /* BuildFrameworkCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildFrameworkCommand.swift; sourceTree = "<group>"; };
+		24CB39152BC96C4200B32463 /* Scheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheme.swift; sourceTree = "<group>"; };
+		24CB39172BC96CDE00B32463 /* DecodeSchemeCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeSchemeCommand.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2489D09E2BC7F3790053AAB1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24CB390C2BC95BDF00B32463 /* ArgumentParser in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2489D0AD2BC7F3850053AAB1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2489D0B62BC7F3850053AAB1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2489D0BA2BC7F3850053AAB1 /* SDDSTheme.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2489D0982BC7F3790053AAB1 = {
+			isa = PBXGroup;
+			children = (
+				2489D0A32BC7F3790053AAB1 /* SDDSThemeBuilder */,
+				2489D0B12BC7F3850053AAB1 /* SDDSTheme */,
+				2489D0BD2BC7F3850053AAB1 /* SDDSThemeTests */,
+				2489D0A22BC7F3790053AAB1 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		2489D0A22BC7F3790053AAB1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2489D0A12BC7F3790053AAB1 /* SDDSThemeBuilder */,
+				2489D0B02BC7F3850053AAB1 /* SDDSTheme.framework */,
+				2489D0B92BC7F3850053AAB1 /* SDDSThemeTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		2489D0A32BC7F3790053AAB1 /* SDDSThemeBuilder */ = {
+			isa = PBXGroup;
+			children = (
+				2489D0D22BC7F7C10053AAB1 /* Utilities */,
+				2489D0CF2BC7F5E10053AAB1 /* Constants */,
+				2489D0CA2BC7F45E0053AAB1 /* Commands */,
+				2489D0C92BC7F44F0053AAB1 /* Scheme */,
+				2489D0A42BC7F3790053AAB1 /* main.swift */,
+				24CB39082BC939E000B32463 /* App.swift */,
+			);
+			path = SDDSThemeBuilder;
+			sourceTree = "<group>";
+		};
+		2489D0B12BC7F3850053AAB1 /* SDDSTheme */ = {
+			isa = PBXGroup;
+			children = (
+				2489D0B22BC7F3850053AAB1 /* SDDSTheme.h */,
+				2489D0B32BC7F3850053AAB1 /* SDDSTheme.docc */,
+			);
+			path = SDDSTheme;
+			sourceTree = "<group>";
+		};
+		2489D0BD2BC7F3850053AAB1 /* SDDSThemeTests */ = {
+			isa = PBXGroup;
+			children = (
+				2489D0BE2BC7F3850053AAB1 /* SDDSThemeTests.swift */,
+			);
+			path = SDDSThemeTests;
+			sourceTree = "<group>";
+		};
+		2489D0C92BC7F44F0053AAB1 /* Scheme */ = {
+			isa = PBXGroup;
+			children = (
+				24CB39152BC96C4200B32463 /* Scheme.swift */,
+			);
+			path = Scheme;
+			sourceTree = "<group>";
+		};
+		2489D0CA2BC7F45E0053AAB1 /* Commands */ = {
+			isa = PBXGroup;
+			children = (
+				2489D0C72BC7F3EC0053AAB1 /* Command.swift */,
+				2489D0CD2BC7F5AD0053AAB1 /* DownloadSchemeCommand.swift */,
+				24CB39172BC96CDE00B32463 /* DecodeSchemeCommand.swift */,
+				24CB390D2BC963FF00B32463 /* ProcessParametersCommand.swift */,
+				24CB390F2BC9646500B32463 /* PrepareCodeGenSchemaCommand.swift */,
+				24CB39112BC964C000B32463 /* GenerateTokensCommand.swift */,
+				24CB39132BC964EA00B32463 /* BuildFrameworkCommand.swift */,
+			);
+			path = Commands;
+			sourceTree = "<group>";
+		};
+		2489D0CF2BC7F5E10053AAB1 /* Constants */ = {
+			isa = PBXGroup;
+			children = (
+				2489D0D02BC7F5EA0053AAB1 /* Constants.swift */,
+			);
+			path = Constants;
+			sourceTree = "<group>";
+		};
+		2489D0D22BC7F7C10053AAB1 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				2489D0D52BC7F7E60053AAB1 /* Logger.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		2489D0AB2BC7F3850053AAB1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2489D0C02BC7F3850053AAB1 /* SDDSTheme.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		2489D0A02BC7F3790053AAB1 /* SDDSThemeBuilder */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2489D0A82BC7F3790053AAB1 /* Build configuration list for PBXNativeTarget "SDDSThemeBuilder" */;
+			buildPhases = (
+				2489D09D2BC7F3790053AAB1 /* Sources */,
+				2489D09E2BC7F3790053AAB1 /* Frameworks */,
+				2489D09F2BC7F3790053AAB1 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SDDSThemeBuilder;
+			packageProductDependencies = (
+				24CB390B2BC95BDF00B32463 /* ArgumentParser */,
+			);
+			productName = SDDSThemeBuilder;
+			productReference = 2489D0A12BC7F3790053AAB1 /* SDDSThemeBuilder */;
+			productType = "com.apple.product-type.tool";
+		};
+		2489D0AF2BC7F3850053AAB1 /* SDDSTheme */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2489D0C12BC7F3850053AAB1 /* Build configuration list for PBXNativeTarget "SDDSTheme" */;
+			buildPhases = (
+				2489D0AB2BC7F3850053AAB1 /* Headers */,
+				2489D0AC2BC7F3850053AAB1 /* Sources */,
+				2489D0AD2BC7F3850053AAB1 /* Frameworks */,
+				2489D0AE2BC7F3850053AAB1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SDDSTheme;
+			productName = SDDSTheme;
+			productReference = 2489D0B02BC7F3850053AAB1 /* SDDSTheme.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		2489D0B82BC7F3850053AAB1 /* SDDSThemeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2489D0C42BC7F3850053AAB1 /* Build configuration list for PBXNativeTarget "SDDSThemeTests" */;
+			buildPhases = (
+				2489D0B52BC7F3850053AAB1 /* Sources */,
+				2489D0B62BC7F3850053AAB1 /* Frameworks */,
+				2489D0B72BC7F3850053AAB1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2489D0BC2BC7F3850053AAB1 /* PBXTargetDependency */,
+			);
+			name = SDDSThemeTests;
+			productName = SDDSThemeTests;
+			productReference = 2489D0B92BC7F3850053AAB1 /* SDDSThemeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2489D0992BC7F3790053AAB1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1520;
+				LastUpgradeCheck = 1520;
+				TargetAttributes = {
+					2489D0A02BC7F3790053AAB1 = {
+						CreatedOnToolsVersion = 15.2;
+					};
+					2489D0AF2BC7F3850053AAB1 = {
+						CreatedOnToolsVersion = 15.2;
+					};
+					2489D0B82BC7F3850053AAB1 = {
+						CreatedOnToolsVersion = 15.2;
+					};
+				};
+			};
+			buildConfigurationList = 2489D09C2BC7F3790053AAB1 /* Build configuration list for PBXProject "SDDSThemeBuilder" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2489D0982BC7F3790053AAB1;
+			packageReferences = (
+				24CB390A2BC95BDF00B32463 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
+			);
+			productRefGroup = 2489D0A22BC7F3790053AAB1 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2489D0A02BC7F3790053AAB1 /* SDDSThemeBuilder */,
+				2489D0AF2BC7F3850053AAB1 /* SDDSTheme */,
+				2489D0B82BC7F3850053AAB1 /* SDDSThemeTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		2489D0AE2BC7F3850053AAB1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2489D0B72BC7F3850053AAB1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2489D09D2BC7F3790053AAB1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24CB39162BC96C4200B32463 /* Scheme.swift in Sources */,
+				24CB39102BC9646500B32463 /* PrepareCodeGenSchemaCommand.swift in Sources */,
+				24CB39122BC964C000B32463 /* GenerateTokensCommand.swift in Sources */,
+				2489D0D12BC7F5EA0053AAB1 /* Constants.swift in Sources */,
+				24CB39182BC96CDE00B32463 /* DecodeSchemeCommand.swift in Sources */,
+				24CB39142BC964EA00B32463 /* BuildFrameworkCommand.swift in Sources */,
+				2489D0D62BC7F7E60053AAB1 /* Logger.swift in Sources */,
+				24CB390E2BC963FF00B32463 /* ProcessParametersCommand.swift in Sources */,
+				2489D0C82BC7F3EC0053AAB1 /* Command.swift in Sources */,
+				2489D0A52BC7F3790053AAB1 /* main.swift in Sources */,
+				24CB39092BC939E000B32463 /* App.swift in Sources */,
+				2489D0CE2BC7F5AD0053AAB1 /* DownloadSchemeCommand.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2489D0AC2BC7F3850053AAB1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2489D0B42BC7F3850053AAB1 /* SDDSTheme.docc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2489D0B52BC7F3850053AAB1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2489D0BF2BC7F3850053AAB1 /* SDDSThemeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		2489D0BC2BC7F3850053AAB1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2489D0AF2BC7F3850053AAB1 /* SDDSTheme */;
+			targetProxy = 2489D0BB2BC7F3850053AAB1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		2489D0A62BC7F3790053AAB1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.6;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		2489D0A72BC7F3790053AAB1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.6;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		2489D0A92BC7F3790053AAB1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KDMYYG676V;
+				ENABLE_HARDENED_RUNTIME = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		2489D0AA2BC7F3790053AAB1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KDMYYG676V;
+				ENABLE_HARDENED_RUNTIME = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		2489D0C22BC7F3850053AAB1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = KDMYYG676V;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.sd.SDDSTheme;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		2489D0C32BC7F3850053AAB1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = KDMYYG676V;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = com.sd.SDDSTheme;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		2489D0C52BC7F3850053AAB1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KDMYYG676V;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sd.SDDSThemeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2489D0C62BC7F3850053AAB1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KDMYYG676V;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sd.SDDSThemeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2489D09C2BC7F3790053AAB1 /* Build configuration list for PBXProject "SDDSThemeBuilder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2489D0A62BC7F3790053AAB1 /* Debug */,
+				2489D0A72BC7F3790053AAB1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2489D0A82BC7F3790053AAB1 /* Build configuration list for PBXNativeTarget "SDDSThemeBuilder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2489D0A92BC7F3790053AAB1 /* Debug */,
+				2489D0AA2BC7F3790053AAB1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2489D0C12BC7F3850053AAB1 /* Build configuration list for PBXNativeTarget "SDDSTheme" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2489D0C22BC7F3850053AAB1 /* Debug */,
+				2489D0C32BC7F3850053AAB1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2489D0C42BC7F3850053AAB1 /* Build configuration list for PBXNativeTarget "SDDSThemeTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2489D0C52BC7F3850053AAB1 /* Debug */,
+				2489D0C62BC7F3850053AAB1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		24CB390A2BC95BDF00B32463 /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-argument-parser.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		24CB390B2BC95BDF00B32463 /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 24CB390A2BC95BDF00B32463 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 2489D0992BC7F3790053AAB1 /* Project object */;
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "46989693916f56d1186bd59ac15124caef896560",
+        "version" : "1.3.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/xcshareddata/xcschemes/SDDSThemeBuilder.xcscheme
+++ b/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/xcshareddata/xcschemes/SDDSThemeBuilder.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2489D0A02BC7F3790053AAB1"
+               BuildableName = "SDDSThemeBuilder"
+               BlueprintName = "SDDSThemeBuilder"
+               ReferencedContainer = "container:SDDSThemeBuilder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2489D0A02BC7F3790053AAB1"
+            BuildableName = "SDDSThemeBuilder"
+            BlueprintName = "SDDSThemeBuilder"
+            ReferencedContainer = "container:SDDSThemeBuilder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "file:///Users/21967740/plasma-ios/SDDSThemeBuilder/SDDSThemeBuilder/plasma_b2c.json"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "file:///Users/21967740/plasma-ios/SDDSThemeBuilder/SDDSThemeBuilder/output.json"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2489D0A02BC7F3790053AAB1"
+            BuildableName = "SDDSThemeBuilder"
+            BlueprintName = "SDDSThemeBuilder"
+            ReferencedContainer = "container:SDDSThemeBuilder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SDDSThemeBuilder/SDDSThemeBuilder/App.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/App.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+final class App {
+    let schemeURL: URL
+    let localSchemeURL: URL
+    
+    lazy var commands: [Runnable] = {
+        [
+            DownloadSchemeCommand(schemeURL: schemeURL, outputURL: localSchemeURL),
+            DecodeSchemeCommand(schemeURL: localSchemeURL),
+            ProcessParametersCommand(),
+            PrepareCodeGenSchemeCommand(),
+            GenerateTokensCommand(),
+            BuildFrameworkCommand()
+        ]
+    }()
+    
+    init(schemeURL: URL, localSchemeURL: URL) {
+        self.schemeURL = schemeURL
+        self.localSchemeURL = localSchemeURL
+    }
+}
+
+extension App: Runnable {
+    @discardableResult func run() -> CommandResult {
+        Logger.printLine()
+        Logger.printText("Running SDDSThemeBuilder...")
+        Logger.printLine()
+        
+        commands.forEach { $0.run() }
+
+        Logger.printLine()
+        return .empty
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Commands/BuildFrameworkCommand.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Commands/BuildFrameworkCommand.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+import Foundation
+
+final class BuildFrameworkCommand: Command {
+    override init(name: String = "Build XCFramework") {
+        super.init(name: name)
+    }
+    
+    override func run() -> CommandResult {
+        super.run()
+        
+        // Сборка XCFramework
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Commands/Command.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Commands/Command.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+protocol Runnable {
+    @discardableResult func run() -> CommandResult
+}
+
+class Command: Runnable {
+    let name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    @discardableResult func run() -> CommandResult {
+        Logger.printLine()
+        Logger.printText(name)
+        
+        return .empty
+    }
+}
+
+enum CommandResult {
+    case empty
+    case success
+    case scheme(Scheme)
+    case error(Error)
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Commands/DecodeSchemeCommand.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Commands/DecodeSchemeCommand.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+final class DecodeSchemeCommand: Command {
+    let schemeURL: URL
+    
+    init(schemeURL: URL) {
+        self.schemeURL = schemeURL
+        
+        super.init(name: "Decode JSON Scheme")
+    }
+    
+    override func run() -> CommandResult {
+        super.run()
+        
+        do {
+            let data = try Data(contentsOf: schemeURL)
+            let decoder = JSONDecoder()
+            let plasmaScheme = try decoder.decode(PlasmaScheme.self, from: data)
+            
+            print(plasmaScheme)
+            
+            return .scheme(plasmaScheme)
+        } catch {
+            return .error(error)
+        }
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Commands/DownloadSchemeCommand.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Commands/DownloadSchemeCommand.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+final class DownloadSchemeCommand: Command {
+    let schemeURL: URL
+    let outputURL: URL
+    private let dispatchQueue = DispatchQueue(label: "ru.sdds.downloadSchemeCommand")
+    
+    init(schemeURL: URL,
+         outputURL: URL) {
+        
+        self.schemeURL = schemeURL
+        self.outputURL = outputURL
+        
+        super.init(name: "Download JSON Scheme")
+    }
+    
+    override func run() -> CommandResult {
+        super.run()
+        
+        return download()
+    }
+    
+    private func download() -> CommandResult {
+        switch schemeURL.scheme {
+        case "file":
+            downloadFromLocalSource()
+        case "http":
+            downloadFromRemoteSource()
+        default:
+            .error(URLError(.badURL))
+        }
+    }
+    
+    private func downloadFromLocalSource() -> CommandResult {
+        let fileManager = FileManager.default
+
+        do {
+            if fileManager.fileExists(atPath: outputURL.path()) {
+                try fileManager.removeItem(at: outputURL)
+            }
+            try fileManager.copyItem(at: schemeURL, to: outputURL)
+        } catch {
+            return .error(error)
+        }
+        
+        return .success
+    }
+    
+    private func downloadFromRemoteSource() -> CommandResult {
+        let urlRequest = URLRequest(url: schemeURL)
+        
+        var result: Result<(), Error> = .failure(URLError(.unknown))
+        let group = DispatchGroup()
+        group.enter()
+        URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+            defer {
+                group.leave()
+            }
+            if let error = error {
+                result = .failure(error)
+                return
+            }
+            
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                result = .failure(URLError(.badServerResponse))
+                return
+            }
+            
+            do {
+                try data?.write(to: self.outputURL)
+                result = .success(())
+            } catch {
+                result = .failure(error)
+            }
+            
+        }
+        group.wait()
+        
+        switch result {
+        case .success:
+            return .success
+        case .failure(let error):
+            return .error(error)
+        }
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Commands/GenerateTokensCommand.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Commands/GenerateTokensCommand.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class GenerateTokensCommand: Command {
+    override init(name: String = "Generate tokens") {
+        super.init(name: name)
+    }
+    
+    override func run() -> CommandResult {
+        super.run()
+        
+        // Кодогенерация токенов
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Commands/PrepareCodeGenSchemaCommand.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Commands/PrepareCodeGenSchemaCommand.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class PrepareCodeGenSchemeCommand: Command {
+    override init(name: String = "Prepare scheme to generate tokens") {
+        super.init(name: name)
+    }
+    
+    override func run() -> CommandResult {
+        super.run()
+        
+        // Приготовление схемы для запуска кодогенерации
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Commands/ProcessParametersCommand.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Commands/ProcessParametersCommand.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class ProcessParametersCommand: Command {
+    override init(name: String = "Process JSON Scheme") {
+        super.init(name: name)
+    }
+    
+    override func run() -> CommandResult {
+        super.run()
+        
+        // Обработка параметров кодогенерации
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Constants/Constants.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Constants/Constants.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct Constants {
+    static let outputLinesCount = 40
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Scheme/Scheme.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Scheme/Scheme.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+enum Mode: String, Codable {
+    case dark
+    case light
+}
+
+enum Category: String, Codable {
+    case text
+    case surface
+    case background
+    case outline
+}
+
+enum Subcategory: String, Codable {
+    case onDark = "on-dark"
+    case onLight = "on-light"
+    case `default`
+    case inverse
+}
+
+enum Direction: String, Codable {
+    case up
+    case down
+}
+
+enum ShadowKind: String, Codable {
+    case hard
+    case soft
+}
+
+enum ShapeKind: String, Codable {
+    case round
+}
+
+enum TypographyKind: String, Codable {
+    case display
+    case body
+    case text
+    case h1
+    case h2
+    case h3
+    case h4
+    case h5
+}
+
+enum FontFamilyKind: String, Codable {
+    case text
+    case body
+    case header
+    case display
+}
+
+enum Size: String, Codable {
+    case large = "l"
+    case medium = "m"
+    case small = "s"
+    case xs
+    case xxs
+    case xxl
+    case xl
+}
+
+enum Weight: String, Codable {
+    case normal
+    case bold
+}
+
+enum Screen: String, Codable {
+    case screenL = "screen-l"
+    case screenM = "screen-m"
+    case screenS = "screen-s"
+}
+
+enum TokenKind: String, Codable {
+    case color
+    case gradient
+    case shadow
+    case shape
+    case typography
+    case fontFamily = "font-family"
+}
+
+struct Scheme: Codable {
+    let name: String
+    let version: String
+    let color: Style
+    let gradient: Style
+    let shadow: ShadowStyle
+    let shape: ShapeStyle
+    let typography: TypographyStyle
+    let fontFamily: FontFamilyStyle
+    let tokens: [Token]
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case version
+        case color
+        case gradient
+        case shadow
+        case shape
+        case typography
+        case fontFamily = "font-family"
+        case tokens
+    }
+}
+
+struct Style: Codable {
+    let mode: [Mode]
+    let category: [Category]
+    let subcategory: [Subcategory]
+}
+
+struct ShadowStyle: Codable {
+    let direction: [Direction]
+    let kind: [ShadowKind]
+    let size: [Size]
+}
+
+struct ShapeStyle: Codable {
+    let kind: [ShapeKind]
+    let size: [Size]
+}
+
+struct TypographyStyle: Codable {
+    let screen: [Screen]
+    let kind: [TypographyKind]
+    let size: [Size]
+    let weight: [Weight]
+}
+
+struct FontFamilyStyle: Codable {
+    let kind: [FontFamilyKind]
+}
+
+struct Token: Codable {
+    let type: TokenKind
+    let name: String
+    let tags: [String]
+    let displayName: String
+    let description: String
+    let enabled: Bool
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/Utilities/Logger.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/Utilities/Logger.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+final class Logger {
+    class func printLine() {
+        print(String(Array(repeating: "-", count: Constants.outputLinesCount )))
+    }
+    
+    class func printText(_ text: String) {
+        print(String(Array(repeating: " ", count: Constants.outputLinesCount / 4 )) + text)
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/main.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/main.swift
@@ -1,0 +1,18 @@
+import Foundation
+import ArgumentParser
+
+struct ThemeBuilder: ParsableCommand {
+    @Argument var scheme: String
+    @Argument var output: String
+    
+    func run() throws {
+        guard let schemeURL = URL(string: scheme), let outputURL = URL(string: output) else {
+            return
+        }
+        
+        let app = App(schemeURL: schemeURL, localSchemeURL: outputURL)
+        app.run()
+    }
+}
+
+ThemeBuilder.main()

--- a/SDDSThemeBuilder/SDDSThemeBuilder/output.json
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/output.json
@@ -1,0 +1,103 @@
+{
+    "name" : "plasma_b2c",
+    "version" : "0.1.0",
+    "color" : {
+        "mode" : ["dark", "light"],
+        "category": ["text", "surface", "background", "outline"],
+        "subcategory" : ["on-dark", "on-light", "default", "inverse"]
+    },
+    "gradient" : {
+        "mode" : ["dark", "light"],
+        "category": ["text", "surface", "background", "outline"],
+        "subcategory" : ["on-dark", "on-light", "default", "inverse"]
+    },
+    "shadow": {
+        "direction": ["up", "down"],
+        "kind": ["hard", "soft"],
+        "size": ["l", "m", "s", "xs", "xxs"]
+    },
+    "shape": {
+        "kind": [ "round" ],
+        "size": [ "xxs", "xs", "s", "m", "l", "xl", "xxl"]
+    },
+    "typography": {
+        "screen": ["screen-l", "screen-m", "screen-s"],
+        "kind": ["display", "body", "text", "h1", "h2", "h3", "h4", "h5"],
+        "size": ["l", "m", "s", "xs", "xxs"],
+        "weight": ["normal", "bold"]
+    },
+    "font-family": {
+        "kind": [ "text", "body", "header", "display"]
+    },
+    "tokens": [{
+            "type": "color",
+            "name": "dark.text.primary",
+            "tags" : [
+                "dark",
+                "text",
+                "primary"
+            ],
+            "displayName": "textPrimary",
+            "description": "Text&Icons Default/General/textPrimary",
+            "enabled": true
+        },
+        {
+            "type": "gradient",
+            "name": "dark.surface.gradient-main",
+            "tags" : [
+                "dark",
+                "surface",
+                "gradient-main"
+            ],
+            "displayName": "surfaceGradientMain",
+            "description": "Surface Default/General/gradientMain",
+            "enabled": true
+        },
+        {
+            "type": "shadow",
+            "name": "up.hard.xs",
+            "tags" : [
+                "up",
+                "hard",
+                "xs"
+            ],
+            "displayName": "shadowUpHardXs",
+            "description": "Shadow Up Hard Xs",
+            "enabled": true
+        },
+        {
+            "type": "shape",
+            "name": "round.xss",
+            "tags": [
+                "round",
+                "xss"
+            ],
+            "displayName": "roundXss",
+            "description": "cRxxs",
+            "enabled": true
+        },
+        {
+            "type": "typography",
+            "name": "screen-s.text.s.normal",
+            "tags": [
+                "screen-s",
+                "text",
+                "s",
+                "normal"
+            ],
+            "displayName": "textS",
+            "description": "Text/Small Screen/TextS B",
+            "enabled": true
+        },
+        {
+            "type": "font-family",
+            "name": "text",
+            "tags": [
+                "text"
+            ],
+            "displayName": "fontFamilyText",
+            "description": "Font-family: SB Sans Text",
+            "enabled": true
+        }
+     ]
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder/plasma_b2c.json
+++ b/SDDSThemeBuilder/SDDSThemeBuilder/plasma_b2c.json
@@ -1,0 +1,103 @@
+{
+    "name" : "plasma_b2c",
+    "version" : "0.1.0",
+    "color" : {
+        "mode" : ["dark", "light"],
+        "category": ["text", "surface", "background", "outline"],
+        "subcategory" : ["on-dark", "on-light", "default", "inverse"]
+    },
+    "gradient" : {
+        "mode" : ["dark", "light"],
+        "category": ["text", "surface", "background", "outline"],
+        "subcategory" : ["on-dark", "on-light", "default", "inverse"]
+    },
+    "shadow": {
+        "direction": ["up", "down"],
+        "kind": ["hard", "soft"],
+        "size": ["l", "m", "s", "xs", "xxs"]
+    },
+    "shape": {
+        "kind": [ "round" ],
+        "size": [ "xxs", "xs", "s", "m", "l", "xl", "xxl"]
+    },
+    "typography": {
+        "screen": ["screen-l", "screen-m", "screen-s"],
+        "kind": ["display", "body", "text", "h1", "h2", "h3", "h4", "h5"],
+        "size": ["l", "m", "s", "xs", "xxs"],
+        "weight": ["normal", "bold"]
+    },
+    "font-family": {
+        "kind": [ "text", "body", "header", "display"]
+    },
+    "tokens": [{
+            "type": "color",
+            "name": "dark.text.primary",
+            "tags" : [
+                "dark",
+                "text",
+                "primary"
+            ],
+            "displayName": "textPrimary",
+            "description": "Text&Icons Default/General/textPrimary",
+            "enabled": true
+        },
+        {
+            "type": "gradient",
+            "name": "dark.surface.gradient-main",
+            "tags" : [
+                "dark",
+                "surface",
+                "gradient-main"
+            ],
+            "displayName": "surfaceGradientMain",
+            "description": "Surface Default/General/gradientMain",
+            "enabled": true
+        },
+        {
+            "type": "shadow",
+            "name": "up.hard.xs",
+            "tags" : [
+                "up",
+                "hard",
+                "xs"
+            ],
+            "displayName": "shadowUpHardXs",
+            "description": "Shadow Up Hard Xs",
+            "enabled": true
+        },
+        {
+            "type": "shape",
+            "name": "round.xss",
+            "tags": [
+                "round",
+                "xss"
+            ],
+            "displayName": "roundXss",
+            "description": "cRxxs",
+            "enabled": true
+        },
+        {
+            "type": "typography",
+            "name": "screen-s.text.s.normal",
+            "tags": [
+                "screen-s",
+                "text",
+                "s",
+                "normal"
+            ],
+            "displayName": "textS",
+            "description": "Text/Small Screen/TextS B",
+            "enabled": true
+        },
+        {
+            "type": "font-family",
+            "name": "text",
+            "tags": [
+                "text"
+            ],
+            "displayName": "fontFamilyText",
+            "description": "Font-family: SB Sans Text",
+            "enabled": true
+        }
+     ]
+}

--- a/SDDSThemeBuilder/SDDSThemeTests/SDDSThemeTests.swift
+++ b/SDDSThemeBuilder/SDDSThemeTests/SDDSThemeTests.swift
@@ -1,0 +1,34 @@
+//
+//  Created by Калтырин Владимир Александрович on 11.04.2024.
+//  Copyright © 2024 Sberbank. All rights reserved.
+//
+
+import XCTest
+@testable import SDDSTheme
+
+final class SDDSThemeTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
CLI утилита для генерации токенов.

В данный момента утилита загружает json схемы по URL и парсит её в Swift модель.

В дальнейшем добавится обработчик, построение модели для кодогенерации, запуск скриптов кодогенерации и другое.

Если запустить утилиту без параметров, то получим вывод в консоль:

```
USAGE: theme-builder <scheme> <output>

ARGUMENTS:
  <scheme>
  <output>

OPTIONS:
  -h, --help              Show help information.
```

`scheme` – URL схемы (в файловой системе или по http)
`output` – название папки для выходных файлов