### PR TITLE
Доработки по фидбеку на токены

### DIFF
--- a/SDDSThemeBuilder/SDDSDemo/Views/GradientView.swift
+++ b/SDDSThemeBuilder/SDDSDemo/Views/GradientView.swift
@@ -10,7 +10,7 @@ struct GradientView: View {
                 ForEach(ThemeStyle.allCases, id: \.self) { theme in
                     Section(header: header(theme: theme, token: token)) {
                         exampleView
-                            .applyGradient(token, theme: theme)
+                            .gradient(token, theme: theme)
                             .cornerRadius(16)
                     }
                 }

--- a/SDDSThemeBuilder/SDDSDemo/Views/TypographyView.swift
+++ b/SDDSThemeBuilder/SDDSDemo/Views/TypographyView.swift
@@ -9,19 +9,19 @@ struct TypographyView: View {
             Section(header: Text("Small")) {
                 ForEach(tokens.map { $0.small }, id: \.self) { token in
                     Text(placeholder)
-                        .applyTypography(token)
+                        .typography(token)
                 }
             }
             Section(header: Text("Medium")) {
                 ForEach(tokens.map { $0.medium }, id: \.self) { token in
                     Text(placeholder)
-                        .applyTypography(token)
+                        .typography(token)
                 }
             }
             Section(header: Text("Large")) {
                 ForEach(tokens.map { $0.large }, id: \.self) { token in
                     Text(placeholder)
-                        .applyTypography(token)
+                        .typography(token)
                 }
             }
         }

--- a/SDDSThemeBuilder/SDDSTheme/Extensions/View+Tokens.swift
+++ b/SDDSThemeBuilder/SDDSTheme/Extensions/View+Tokens.swift
@@ -1,19 +1,19 @@
 import SwiftUI
 
 public extension View {
-    func applyShadow(_ token: ShadowToken) -> some View {
+    func shadow(_ token: ShadowToken) -> some View {
         modifier(ShadowModifier(token: token))
     }
     
-    func applyShape(_ token: ShapeToken) -> some View {
+    func shape(_ token: ShapeToken) -> some View {
         modifier(ShapeModifier(token: token))
     }
     
-    func applyTypography(_ token: TypographyToken) -> some View {
+    func typography(_ token: TypographyToken) -> some View {
         modifier(TypographyModifier(token: token))
     }
     
-    func applyGradient(_ token: GradientToken, theme: ThemeStyle = UIScreen.themeStyle) -> some View {
+    func gradient(_ token: GradientToken, theme: ThemeStyle = UIScreen.themeStyle) -> some View {
         modifier(GradientModifier(token: token, theme: theme))
     }
 }

--- a/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.pbxproj
+++ b/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.pbxproj
@@ -21,6 +21,21 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		243C1D0D2C05CED600C17C0F /* ShadowToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D082C05CED500C17C0F /* ShadowToken+Generated.swift */; };
+		243C1D0E2C05CED600C17C0F /* GradientToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D092C05CED500C17C0F /* GradientToken+Generated.swift */; };
+		243C1D0F2C05CED600C17C0F /* ColorToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D0A2C05CED500C17C0F /* ColorToken+Generated.swift */; };
+		243C1D102C05CED600C17C0F /* ShapeToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D0B2C05CED500C17C0F /* ShapeToken+Generated.swift */; };
+		243C1D112C05CED600C17C0F /* TypographyToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D0C2C05CED500C17C0F /* TypographyToken+Generated.swift */; };
+		243C1D132C05D1D300C17C0F /* Colors.stencil in Resources */ = {isa = PBXBuildFile; fileRef = 243C1D122C05D1D300C17C0F /* Colors.stencil */; };
+		243C1D152C05D38600C17C0F /* Shapes.stencil in Resources */ = {isa = PBXBuildFile; fileRef = 243C1D142C05D38600C17C0F /* Shapes.stencil */; };
+		243C1D172C05D39E00C17C0F /* Shadows.stencil in Resources */ = {isa = PBXBuildFile; fileRef = 243C1D162C05D39E00C17C0F /* Shadows.stencil */; };
+		243C1D192C05D3B200C17C0F /* Typographies.stencil in Resources */ = {isa = PBXBuildFile; fileRef = 243C1D182C05D3B200C17C0F /* Typographies.stencil */; };
+		243C1D1B2C05D3C800C17C0F /* Gradients.stencil in Resources */ = {isa = PBXBuildFile; fileRef = 243C1D1A2C05D3C800C17C0F /* Gradients.stencil */; };
+		243C1D202C05D3F200C17C0F /* Colors+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D1C2C05D3F200C17C0F /* Colors+Generated.swift */; };
+		243C1D212C05D3F200C17C0F /* Shadows+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D1D2C05D3F200C17C0F /* Shadows+Generated.swift */; };
+		243C1D222C05D3F200C17C0F /* Gradients+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D1E2C05D3F200C17C0F /* Gradients+Generated.swift */; };
+		243C1D232C05D3F200C17C0F /* Shapes+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D1F2C05D3F200C17C0F /* Shapes+Generated.swift */; };
+		243C1D252C05D40F00C17C0F /* Typographies+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C1D242C05D40F00C17C0F /* Typographies+Generated.swift */; };
 		246D68B92BFC938700AB0020 /* TypographyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246D68B62BFC938700AB0020 /* TypographyView.swift */; };
 		246D68BA2BFC938700AB0020 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246D68B72BFC938700AB0020 /* MainView.swift */; };
 		246D68BB2BFC938700AB0020 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246D68B82BFC938700AB0020 /* GradientView.swift */; };
@@ -69,7 +84,6 @@
 		817539AC2BD16D7E00138866 /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = 817539AB2BD16D7E00138866 /* OHHTTPStubs */; };
 		817539AE2BD16D7E00138866 /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 817539AD2BD16D7E00138866 /* OHHTTPStubsSwift */; };
 		8181E3AA2BFB6A5F00D4012C /* GradientContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8181E3A92BFB6A5F00D4012C /* GradientContextBuilder.swift */; };
-		8181E3AC2BFB708900D4012C /* GradientToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8181E3AB2BFB708900D4012C /* GradientToken+Generated.swift */; };
 		8181E3AE2BFB741200D4012C /* GradientToken+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8181E3AD2BFB741200D4012C /* GradientToken+SwiftUI.swift */; };
 		8181E3B02BFB7A4200D4012C /* GradientModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8181E3AF2BFB7A4200D4012C /* GradientModifier.swift */; };
 		8181E3B22BFB7AAE00D4012C /* GradientToken+Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8181E3B12BFB7AAE00D4012C /* GradientToken+Theme.swift */; };
@@ -91,10 +105,6 @@
 		819B2ADC2BF283A600688624 /* FileExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819B2ADB2BF283A600688624 /* FileExtension.swift */; };
 		819B2ADD2BF283A600688624 /* FileExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819B2ADB2BF283A600688624 /* FileExtension.swift */; };
 		819B2AE02BF2842300688624 /* ScreenSize+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819B2ADE2BF2842300688624 /* ScreenSize+Extensions.swift */; };
-		819CFAB82BF6520600A9DFDB /* ShapeToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819CFAB42BF6520600A9DFDB /* ShapeToken+Generated.swift */; };
-		819CFAB92BF6520600A9DFDB /* TypographyToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819CFAB52BF6520600A9DFDB /* TypographyToken+Generated.swift */; };
-		819CFABA2BF6520600A9DFDB /* ColorToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819CFAB62BF6520600A9DFDB /* ColorToken+Generated.swift */; };
-		819CFABB2BF6520600A9DFDB /* ShadowToken+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819CFAB72BF6520600A9DFDB /* ShadowToken+Generated.swift */; };
 		819CFABD2BF652F700A9DFDB /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819CFABC2BF652F700A9DFDB /* Theme.swift */; };
 		819CFABF2BF6551800A9DFDB /* UIScreen+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819CFABE2BF6551800A9DFDB /* UIScreen+Extensions.swift */; };
 		81E1EDBB2BD2B9F400F86AE1 /* ContexBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E1EDBA2BD2B9F400F86AE1 /* ContexBuilder.swift */; };
@@ -214,6 +224,21 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		243C1D082C05CED500C17C0F /* ShadowToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ShadowToken+Generated.swift"; sourceTree = "<group>"; };
+		243C1D092C05CED500C17C0F /* GradientToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GradientToken+Generated.swift"; sourceTree = "<group>"; };
+		243C1D0A2C05CED500C17C0F /* ColorToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ColorToken+Generated.swift"; sourceTree = "<group>"; };
+		243C1D0B2C05CED500C17C0F /* ShapeToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ShapeToken+Generated.swift"; sourceTree = "<group>"; };
+		243C1D0C2C05CED500C17C0F /* TypographyToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TypographyToken+Generated.swift"; sourceTree = "<group>"; };
+		243C1D122C05D1D300C17C0F /* Colors.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = Colors.stencil; sourceTree = "<group>"; };
+		243C1D142C05D38600C17C0F /* Shapes.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = Shapes.stencil; sourceTree = "<group>"; };
+		243C1D162C05D39E00C17C0F /* Shadows.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = Shadows.stencil; sourceTree = "<group>"; };
+		243C1D182C05D3B200C17C0F /* Typographies.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = Typographies.stencil; sourceTree = "<group>"; };
+		243C1D1A2C05D3C800C17C0F /* Gradients.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gradients.stencil; sourceTree = "<group>"; };
+		243C1D1C2C05D3F200C17C0F /* Colors+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Colors+Generated.swift"; sourceTree = "<group>"; };
+		243C1D1D2C05D3F200C17C0F /* Shadows+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Shadows+Generated.swift"; sourceTree = "<group>"; };
+		243C1D1E2C05D3F200C17C0F /* Gradients+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Gradients+Generated.swift"; sourceTree = "<group>"; };
+		243C1D1F2C05D3F200C17C0F /* Shapes+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Shapes+Generated.swift"; sourceTree = "<group>"; };
+		243C1D242C05D40F00C17C0F /* Typographies+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Typographies+Generated.swift"; sourceTree = "<group>"; };
 		246D68B62BFC938700AB0020 /* TypographyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypographyView.swift; sourceTree = "<group>"; };
 		246D68B72BFC938700AB0020 /* MainView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		246D68B82BFC938700AB0020 /* GradientView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
@@ -259,7 +284,6 @@
 		817539A32BD1690D00138866 /* TemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateRenderer.swift; sourceTree = "<group>"; };
 		817539A52BD1699B00138866 /* RenderableMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderableMock.swift; sourceTree = "<group>"; };
 		8181E3A92BFB6A5F00D4012C /* GradientContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientContextBuilder.swift; sourceTree = "<group>"; };
-		8181E3AB2BFB708900D4012C /* GradientToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GradientToken+Generated.swift"; sourceTree = "<group>"; };
 		8181E3AD2BFB741200D4012C /* GradientToken+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GradientToken+SwiftUI.swift"; sourceTree = "<group>"; };
 		8181E3AF2BFB7A4200D4012C /* GradientModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientModifier.swift; sourceTree = "<group>"; };
 		8181E3B12BFB7AAE00D4012C /* GradientToken+Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GradientToken+Theme.swift"; sourceTree = "<group>"; };
@@ -278,10 +302,6 @@
 		819B2AD02BF280FB00688624 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		819B2ADB2BF283A600688624 /* FileExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExtension.swift; sourceTree = "<group>"; };
 		819B2ADE2BF2842300688624 /* ScreenSize+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScreenSize+Extensions.swift"; sourceTree = "<group>"; };
-		819CFAB42BF6520600A9DFDB /* ShapeToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ShapeToken+Generated.swift"; sourceTree = "<group>"; };
-		819CFAB52BF6520600A9DFDB /* TypographyToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TypographyToken+Generated.swift"; sourceTree = "<group>"; };
-		819CFAB62BF6520600A9DFDB /* ColorToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ColorToken+Generated.swift"; sourceTree = "<group>"; };
-		819CFAB72BF6520600A9DFDB /* ShadowToken+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ShadowToken+Generated.swift"; sourceTree = "<group>"; };
 		819CFABC2BF652F700A9DFDB /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		819CFABE2BF6551800A9DFDB /* UIScreen+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extensions.swift"; sourceTree = "<group>"; };
 		81E1EDB52BD2B4CD00F86AE1 /* ShapeToken.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = ShapeToken.stencil; sourceTree = "<group>"; };
@@ -514,11 +534,16 @@
 		249C3D512BD926FC007533DE /* Generated */ = {
 			isa = PBXGroup;
 			children = (
-				8181E3AB2BFB708900D4012C /* GradientToken+Generated.swift */,
-				819CFAB62BF6520600A9DFDB /* ColorToken+Generated.swift */,
-				819CFAB72BF6520600A9DFDB /* ShadowToken+Generated.swift */,
-				819CFAB42BF6520600A9DFDB /* ShapeToken+Generated.swift */,
-				819CFAB52BF6520600A9DFDB /* TypographyToken+Generated.swift */,
+				243C1D242C05D40F00C17C0F /* Typographies+Generated.swift */,
+				243C1D1C2C05D3F200C17C0F /* Colors+Generated.swift */,
+				243C1D1E2C05D3F200C17C0F /* Gradients+Generated.swift */,
+				243C1D1D2C05D3F200C17C0F /* Shadows+Generated.swift */,
+				243C1D1F2C05D3F200C17C0F /* Shapes+Generated.swift */,
+				243C1D0A2C05CED500C17C0F /* ColorToken+Generated.swift */,
+				243C1D092C05CED500C17C0F /* GradientToken+Generated.swift */,
+				243C1D082C05CED500C17C0F /* ShadowToken+Generated.swift */,
+				243C1D0B2C05CED500C17C0F /* ShapeToken+Generated.swift */,
+				243C1D0C2C05CED500C17C0F /* TypographyToken+Generated.swift */,
 			);
 			path = Generated;
 			sourceTree = "<group>";
@@ -539,6 +564,11 @@
 				81E1EDB72BD2B9B600F86AE1 /* ShadowToken.stencil */,
 				81E1EDF02BDA5E6200F86AE1 /* TypographyToken.stencil */,
 				810CB4872BF786C0002E718E /* GradientToken.stencil */,
+				243C1D122C05D1D300C17C0F /* Colors.stencil */,
+				243C1D142C05D38600C17C0F /* Shapes.stencil */,
+				243C1D162C05D39E00C17C0F /* Shadows.stencil */,
+				243C1D182C05D3B200C17C0F /* Typographies.stencil */,
+				243C1D1A2C05D3C800C17C0F /* Gradients.stencil */,
 			);
 			path = Stencil;
 			sourceTree = "<group>";
@@ -970,6 +1000,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				81E1EE622BE3B9CA00F86AE1 /* copyFonts.rb in Resources */,
+				243C1D192C05D3B200C17C0F /* Typographies.stencil in Resources */,
+				243C1D132C05D1D300C17C0F /* Colors.stencil in Resources */,
+				243C1D172C05D39E00C17C0F /* Shadows.stencil in Resources */,
+				243C1D152C05D38600C17C0F /* Shapes.stencil in Resources */,
+				243C1D1B2C05D3C800C17C0F /* Gradients.stencil in Resources */,
 				81E1EE6A2BE3C5CC00F86AE1 /* registerFonts.rb in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1035,35 +1070,40 @@
 				2489D0B42BC7F3850053AAB1 /* SDDSTheme.docc in Sources */,
 				81E1EDEF2BDA5C9800F86AE1 /* ColorToken+Theme.swift in Sources */,
 				81E1EE2A2BDA868F00F86AE1 /* ColorToken.swift in Sources */,
+				243C1D0D2C05CED600C17C0F /* ShadowToken+Generated.swift in Sources */,
 				81E1EE2B2BDA868F00F86AE1 /* ShapeToken.swift in Sources */,
 				8181E3B02BFB7A4200D4012C /* GradientModifier.swift in Sources */,
 				819B2ADC2BF283A600688624 /* FileExtension.swift in Sources */,
 				8181E3B72BFB7BAE00D4012C /* GradientKind+Extensions.swift in Sources */,
-				819CFABA2BF6520600A9DFDB /* ColorToken+Generated.swift in Sources */,
 				817539502BCE9FDA00138866 /* UIColor+Extensions.swift in Sources */,
 				819CFABF2BF6551800A9DFDB /* UIScreen+Extensions.swift in Sources */,
+				243C1D112C05CED600C17C0F /* TypographyToken+Generated.swift in Sources */,
 				819B2A8D2BF2403700688624 /* View+Conditional.swift in Sources */,
 				819B2ADA2BF2836300688624 /* Extensions.swift in Sources */,
+				243C1D0E2C05CED600C17C0F /* GradientToken+Generated.swift in Sources */,
+				243C1D0F2C05CED600C17C0F /* ColorToken+Generated.swift in Sources */,
 				81E1EDCF2BD6CA5D00F86AE1 /* View+Tokens.swift in Sources */,
 				819CFABD2BF652F700A9DFDB /* Theme.swift in Sources */,
+				243C1D102C05CED600C17C0F /* ShapeToken+Generated.swift in Sources */,
 				8181E3B52BFB7AC800D4012C /* ThemeStyle.swift in Sources */,
+				243C1D212C05D3F200C17C0F /* Shadows+Generated.swift in Sources */,
+				243C1D222C05D3F200C17C0F /* Gradients+Generated.swift in Sources */,
 				81E1EDD62BD6CE3900F86AE1 /* ShapeModifier.swift in Sources */,
 				81E1EE292BDA868F00F86AE1 /* FontFamilyToken.swift in Sources */,
 				81E1EDD42BD6CDF300F86AE1 /* ShadowModifier.swift in Sources */,
-				819CFAB92BF6520600A9DFDB /* TypographyToken+Generated.swift in Sources */,
 				819B2A862BF2377B00688624 /* TypographyToken+Extensions.swift in Sources */,
+				243C1D232C05D3F200C17C0F /* Shapes+Generated.swift in Sources */,
 				8181E3BA2BFB7F8500D4012C /* GradientView.swift in Sources */,
 				81E1EE272BDA868F00F86AE1 /* TypographyToken.swift in Sources */,
+				243C1D202C05D3F200C17C0F /* Colors+Generated.swift in Sources */,
 				81E1EE282BDA868F00F86AE1 /* ShadowToken.swift in Sources */,
 				81E1EE712BE4DD5200F86AE1 /* ThemeService.swift in Sources */,
+				243C1D252C05D40F00C17C0F /* Typographies+Generated.swift in Sources */,
 				810CB4862BF76DE9002E718E /* GradientToken.swift in Sources */,
-				819CFAB82BF6520600A9DFDB /* ShapeToken+Generated.swift in Sources */,
 				8181E3B22BFB7AAE00D4012C /* GradientToken+Theme.swift in Sources */,
 				8181E3AE2BFB741200D4012C /* GradientToken+SwiftUI.swift in Sources */,
 				819B2A8B2BF23EB600688624 /* TypographyModifier.swift in Sources */,
-				8181E3AC2BFB708900D4012C /* GradientToken+Generated.swift in Sources */,
 				819B2A8F2BF241A200688624 /* LineHeightModifier.swift in Sources */,
-				819CFABB2BF6520600A9DFDB /* ShadowToken+Generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/App.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/App.swift
@@ -36,7 +36,7 @@ public final class App {
             name: "Generate Color Tokens",
             schemeURL: schemeDirectory.url(for: .colors),
             templatesURL: templatesURL,
-            template: .color,
+            templates: [.colorToken, .colors],
             generatedOutputURL: generatedTokensURL,
             contextBuilder: ColorContextBuilder(paletteURL: paletteLocalURL)
         ).run()
@@ -44,21 +44,21 @@ public final class App {
             name: "Generate Shadow Tokens",
             schemeURL: schemeDirectory.url(for: .shadows),
             templatesURL: templatesURL,
-            template: .shadow,
+            templates: [.shadowToken, .shadows],
             generatedOutputURL: generatedTokensURL
         ).run()
         GenerateTokensCommand(
             name: "Generate Shape Tokens",
             schemeURL: schemeDirectory.url(for: .shapes),
             templatesURL: templatesURL,
-            template: .shape,
+            templates: [.shapeToken, .shapes],
             generatedOutputURL: generatedTokensURL
         ).run()
         GenerateTokensCommand(
             name: "Generate Typography Tokens",
             schemeURL: schemeDirectory.url(for: .typography),
             templatesURL: templatesURL,
-            template: .typography,
+            templates: [.typographyToken, .typographies],
             generatedOutputURL: generatedTokensURL,
             contextBuilder: TypographyContextBuilder(
                 fontFamiliesContainer: fontFamiliesContainer
@@ -68,7 +68,7 @@ public final class App {
             name: "Generate Gradient Tokens",
             schemeURL: schemeDirectory.url(for: .gradients),
             templatesURL: templatesURL,
-            template: .gradient,
+            templates: [.gradientToken, .gradients],
             generatedOutputURL: generatedTokensURL,
             contextBuilder: GradientContextBuilder(paletteURL: paletteLocalURL)
         ).run()

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Commands/GenerateTokensCommand.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Commands/GenerateTokensCommand.swift
@@ -5,7 +5,7 @@ import PathKit
 final class GenerateTokensCommand: Command, FileWriter {
     private let schemeURL: URL
     private let templatesURL: URL
-    private let template: StencilTemplate
+    private let templates: [StencilTemplate]
     private let generatedOutputURL: URL
     private let templateRender: Renderable
     private let contextBuilder: ContexBuilder
@@ -13,14 +13,14 @@ final class GenerateTokensCommand: Command, FileWriter {
     init(name: String,
          schemeURL: URL,
          templatesURL: URL,
-         template: StencilTemplate,
+         templates: [StencilTemplate],
          generatedOutputURL: URL,
          templateRender: Renderable = TemplateRenderer(),
          contextBuilder: ContexBuilder = GeneralContextBuilder()
     ) {
         self.schemeURL = schemeURL
         self.templatesURL = templatesURL
-        self.template = template
+        self.templates = templates
         self.generatedOutputURL = generatedOutputURL
         self.templateRender = templateRender
         self.contextBuilder = contextBuilder
@@ -40,15 +40,19 @@ final class GenerateTokensCommand: Command, FileWriter {
             return result
         }
         
-        result = templateRender.render(context: context, template: template, templatesURL: templatesURL)
-        guard let generatedContent = result.asGenerated else {
-            return result
+        for template in templates {
+            result = templateRender.render(context: context, template: template, templatesURL: templatesURL)
+            guard let generatedContent = result.asGenerated else {
+                return result
+            }
+            
+            result = saveFile(
+                content: generatedContent,
+                outputURL: generatedOutputURL,
+                filename: template.filename
+            )
         }
         
-        return saveFile(
-            content: generatedContent,
-            outputURL: generatedOutputURL,
-            filename: template.filename
-        )
+        return result
     }
 }

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Core/StencilTemplate.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Core/StencilTemplate.swift
@@ -1,11 +1,16 @@
 import Foundation
 
 enum StencilTemplate: String {
-    case color = "ColorToken"
-    case shape = "ShapeToken"
-    case shadow = "ShadowToken"
-    case typography = "TypographyToken"
-    case gradient = "GradientToken"
+    case colorToken = "ColorToken"
+    case shapeToken = "ShapeToken"
+    case shadowToken = "ShadowToken"
+    case typographyToken = "TypographyToken"
+    case gradientToken = "GradientToken"
+    case colors = "Colors"
+    case shapes = "Shapes"
+    case shadows = "Shadows"
+    case typographies = "Typographies"
+    case gradients = "Gradients"
     
     var withStencilExt: String {
         rawValue + ".stencil"

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ColorToken.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ColorToken.stencil
@@ -12,9 +12,3 @@ public extension ColorToken {
     }
     {%- endfor %}
 }
-
-public struct Colors {
-    {%- for key, value in json %}
-    public static let {{ key }} = ColorToken.{{ key }}
-    {%- endfor %}
-}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Colors.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Colors.stencil
@@ -1,0 +1,8 @@
+import SwiftUI
+import UIKit
+
+public struct Colors {
+    {%- for key, value in json %}
+    public static let {{ key }} = ColorToken.{{ key }}
+    {%- endfor %}
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/GradientToken.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/GradientToken.stencil
@@ -153,9 +153,3 @@ public extension GradientToken {
         {%- endfor %}
     ]
 }
-
-public struct Gradients {
-    {%- for key, value in json %}
-    public static let {{ key }} = GradientToken.{{ key }}
-    {%- endfor %}
-}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Gradients.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Gradients.stencil
@@ -1,0 +1,8 @@
+import SwiftUI
+import UIKit
+
+public struct Gradients {
+    {%- for key, value in json %}
+    public static let {{ key }} = GradientToken.{{ key }}
+    {%- endfor %}
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ShadowToken.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ShadowToken.stencil
@@ -16,9 +16,3 @@ public extension ShadowToken {
     }
     {% endfor %}
 }
-
-public struct Shadows {
-    {%- for key, value in json %}
-    public static let {{ key }} = ShadowToken.{{ key }}
-    {%- endfor %}
-}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Shadows.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Shadows.stencil
@@ -1,0 +1,8 @@
+import SwiftUI
+import UIKit
+
+public struct Shadows {
+    {%- for key, value in json %}
+    public static let {{ key }} = ShadowToken.{{ key }}
+    {%- endfor %}
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ShapeToken.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ShapeToken.stencil
@@ -8,9 +8,3 @@ public extension ShapeToken {
     }
     {% endfor %}
 }
-
-public struct Shapes {
-    {%- for key, value in json %}
-    public static let {{ key }} = ShapeToken.{{ key }}
-    {%- endfor %}
-}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Shapes.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Shapes.stencil
@@ -1,0 +1,8 @@
+import SwiftUI
+import UIKit
+
+public struct Shapes {
+    {%- for key, value in json %}
+    public static let {{ key }} = ShapeToken.{{ key }}
+    {%- endfor %}
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Typographies.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/Typographies.stencil
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct Typographies {
+    {%- for key, value in json %}
+    public static let {{ key }} = AdaptiveTypographyToken.{{ key }}
+    {%- endfor %}
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/TypographyToken.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/TypographyToken.stencil
@@ -38,9 +38,3 @@ public extension AdaptiveTypographyToken {
         {%- endfor %}
     ]
 }
-
-public struct Typographies {
-    {%- for key, value in json %}
-    public static let {{ key }} = AdaptiveTypographyToken.{{ key }}
-    {%- endfor %}
-}


### PR DESCRIPTION
- Нейминг изменен на более декларативный (`applyShadow` -> `shadow`)
- Структуры `Shapes`, `Gradients` и т.д. вынесены в отдельные файлы на уровне кодогенерация, чтобы разделить их от токенов. Эти структуры части объекта темы.

```
public struct Theme {
    public static let colors = Colors()
    public static let shapes = Shapes()
    public static let typographies = Typographies()
    public static let shadows = Shadows()
}
``` 