### PR TITLE
fix(sdds-theme-builder): added two decimals format in code generation

### DIFF
--- a/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.pbxproj
+++ b/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		819B2ADD2BF283A600688624 /* FileExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819B2ADB2BF283A600688624 /* FileExtension.swift */; };
 		819B2AE02BF2842300688624 /* ScreenSize+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819B2ADE2BF2842300688624 /* ScreenSize+Extensions.swift */; };
 		81C10A1D2C2929850055BB04 /* meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 81C10A1C2C2929850055BB04 /* meta.json */; };
+		81C10A222C292E4D0055BB04 /* Double+Stencil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C10A212C292E4D0055BB04 /* Double+Stencil.swift */; };
 		81CB0FBD2C2193DC003B1064 /* HexConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CB0FBC2C2193DC003B1064 /* HexConverter.swift */; };
 		81CB0FBE2C2193EB003B1064 /* HexConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CB0FBC2C2193DC003B1064 /* HexConverter.swift */; };
 		81CB0FC02C2194DF003B1064 /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CB0FBF2C2194DF003B1064 /* Color+Extension.swift */; };
@@ -411,6 +412,7 @@
 		819B2ADB2BF283A600688624 /* FileExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExtension.swift; sourceTree = "<group>"; };
 		819B2ADE2BF2842300688624 /* ScreenSize+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScreenSize+Extensions.swift"; sourceTree = "<group>"; };
 		81C10A1C2C2929850055BB04 /* meta.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = meta.json; sourceTree = "<group>"; };
+		81C10A212C292E4D0055BB04 /* Double+Stencil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Stencil.swift"; sourceTree = "<group>"; };
 		81CB0FBC2C2193DC003B1064 /* HexConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexConverter.swift; sourceTree = "<group>"; };
 		81CB0FBF2C2194DF003B1064 /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		81CB0FDD2C245046003B1064 /* SchemeTokenNameValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchemeTokenNameValidator.swift; sourceTree = "<group>"; };
@@ -924,6 +926,7 @@
 				81CB0FE42C245052003B1064 /* EnsureValueNode.swift */,
 				81CB0FE52C245052003B1064 /* EnsureDoubleInRangeNode.swift */,
 				81CB10012C258823003B1064 /* TemplateRendererError.swift */,
+				81C10A212C292E4D0055BB04 /* Double+Stencil.swift */,
 			);
 			path = TemplateRenderer;
 			sourceTree = "<group>";
@@ -1354,6 +1357,7 @@
 				81E1EDF62BDA7B9900F86AE1 /* ScreenSize.swift in Sources */,
 				81E1EE422BE3A5D700F86AE1 /* TypographyKind.swift in Sources */,
 				81CB0FDE2C245046003B1064 /* SchemeTokenNameValidator.swift in Sources */,
+				81C10A222C292E4D0055BB04 /* Double+Stencil.swift in Sources */,
 				81E1EDC32BD6ADC100F86AE1 /* UnpackThemeCommand.swift in Sources */,
 				81E1EE4A2BE3A61B00F86AE1 /* Screen.swift in Sources */,
 				817539822BD008A500138866 /* Renderable.swift in Sources */,

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ShapeToken.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ShapeToken.stencil
@@ -10,7 +10,7 @@ public extension ShapeToken {
     
     static var {{ key }}: Self {
         Self(
-            cornerRadius: {{ value.cornerRadius|ensure|two_decimals_format }},
+            cornerRadius: {{ value.cornerRadius|ensure }},
             kind: .{{ value.kind|ensure }}
         )
     }

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ShapeToken.stencil
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Stencil/ShapeToken.stencil
@@ -10,7 +10,7 @@ public extension ShapeToken {
     
     static var {{ key }}: Self {
         Self(
-            cornerRadius: {{ value.cornerRadius|ensure }},
+            cornerRadius: {{ value.cornerRadius|ensure|two_decimals_format }},
             kind: .{{ value.kind|ensure }}
         )
     }

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Utilities/TemplateRenderer/Double+Stencil.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Utilities/TemplateRenderer/Double+Stencil.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension Formatter {
+    static let twoDecimals: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }()
+}
+
+extension Double {
+    var twoDecimalsFormatted: String {
+        return Formatter.twoDecimals.string(for: self) ?? ""
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Utilities/TemplateRenderer/TemplateRenderer.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Utilities/TemplateRenderer/TemplateRenderer.swift
@@ -13,6 +13,7 @@ private enum Filter: String {
     case ensure = "ensure"
     case ensureFloatNonNegative = "ensure_float_non_negative"
     case ensureDoubleInRange = "ensure_double_in_range"
+    case twoDecimalsFormat = "two_decimals_format"
 }
 
 final class TemplateRenderer: Renderable {
@@ -95,6 +96,13 @@ final class TemplateRenderer: Renderable {
                  throw TemplateSyntaxError("Value is not a non-negative float")
              }
              return floatValue
+        }
+        ext.registerFilter(Filter.twoDecimalsFormat.rawValue) { (value: Any?) in
+            guard let doubleValue = value as? Double else {
+                return value
+            }
+    
+            return doubleValue.twoDecimalsFormatted
         }
     }
 }

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Utilities/TemplateRenderer/TemplateRenderer.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Utilities/TemplateRenderer/TemplateRenderer.swift
@@ -13,7 +13,6 @@ private enum Filter: String {
     case ensure = "ensure"
     case ensureFloatNonNegative = "ensure_float_non_negative"
     case ensureDoubleInRange = "ensure_double_in_range"
-    case twoDecimalsFormat = "two_decimals_format"
 }
 
 final class TemplateRenderer: Renderable {
@@ -71,7 +70,10 @@ final class TemplateRenderer: Renderable {
             guard value != nil else {
                 throw TemplateSyntaxError("Value not found in context")
             }
-            return value
+            guard let doubleValue = value as? Double else {
+                return value
+            }
+            return doubleValue.twoDecimalsFormatted
         }
         ext.registerFilter(Filter.ensureDoubleInRange.rawValue) { (value: Any?, arguments: [Any?]) in
             let range = arguments.compactMap { value in
@@ -96,13 +98,6 @@ final class TemplateRenderer: Renderable {
                  throw TemplateSyntaxError("Value is not a non-negative float")
              }
              return floatValue
-        }
-        ext.registerFilter(Filter.twoDecimalsFormat.rawValue) { (value: Any?) in
-            guard let doubleValue = value as? Double else {
-                return value
-            }
-    
-            return doubleValue.twoDecimalsFormatted
         }
     }
 }


### PR DESCRIPTION
Исправлен баг с форматированием.

Раньше генератор мог для double значений в токенах сгенерировать результат `99.99999997`, теперь будет только 2 знака после запятой.