### PR TITLE
PLASMA-7573:  add TokenMetaResolver

### DIFF
--- a/SDDSThemeBuilder/.sdds/config-info-tokens-ios.json
+++ b/SDDSThemeBuilder/.sdds/config-info-tokens-ios.json
@@ -1,0 +1,25267 @@
+{
+  "name" : "plasma_homeds_default",
+  "tokens" : [
+    {
+      "description" : "typography l header-h2-medium",
+      "displayName" : "HeaderH2 M",
+      "name" : "screen-l.header.h2.medium",
+      "reference" : "HeaderH2Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 36,
+        "size" : 32,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l header-h2",
+      "displayName" : "HeaderH2 N",
+      "name" : "screen-l.header.h2.normal",
+      "reference" : "HeaderH2Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 36,
+        "size" : 32,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l header-h3-bold",
+      "displayName" : "HeaderH3 B",
+      "name" : "screen-l.header.h3.bold",
+      "reference" : "HeaderH3Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH3Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 30,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l header-h3-medium",
+      "displayName" : "HeaderH3 M",
+      "name" : "screen-l.header.h3.medium",
+      "reference" : "HeaderH3Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH3Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 30,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l header-h3",
+      "displayName" : "HeaderH3 N",
+      "name" : "screen-l.header.h3.normal",
+      "reference" : "HeaderH3Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH3Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 30,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l header-h4-bold",
+      "displayName" : "HeaderH4 B",
+      "name" : "screen-l.header.h4.bold",
+      "reference" : "HeaderH4Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH4Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 26,
+        "size" : 20,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l header-h4-medium",
+      "displayName" : "HeaderH4 M",
+      "name" : "screen-l.header.h4.medium",
+      "reference" : "HeaderH4Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH4Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 26,
+        "size" : 20,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l header-h4",
+      "displayName" : "HeaderH4 N",
+      "name" : "screen-l.header.h4.normal",
+      "reference" : "HeaderH4Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH4Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 26,
+        "size" : 20,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l header-h5-bold",
+      "displayName" : "HeaderH5 B",
+      "name" : "screen-l.header.h5.bold",
+      "reference" : "HeaderH5Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH5Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 24,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l header-h5-medium",
+      "displayName" : "HeaderH5 M",
+      "name" : "screen-l.header.h5.medium",
+      "reference" : "HeaderH5Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH5Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 24,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "Цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfo",
+      "name" : "dark.outline.on-dark.info",
+      "reference" : "OutlineOnDarkInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfo",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "Цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfo",
+      "name" : "light.outline.on-dark.info",
+      "reference" : "OutlineOnDarkInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfo",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "typography l header-h5",
+      "displayName" : "HeaderH5 N",
+      "name" : "screen-l.header.h5.normal",
+      "reference" : "HeaderH5Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH5Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 24,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l header-h6-bold",
+      "displayName" : "HeaderH6 B",
+      "name" : "screen-l.header.h6.bold",
+      "reference" : "HeaderH6Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH6Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "Акцентный минорный цвет",
+      "displayName" : "textAccentMinorActive",
+      "name" : "dark.text.default.accent-minor-active",
+      "reference" : "TextDefaultAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF0C7920"
+    },
+    {
+      "description" : "Акцентный минорный цвет",
+      "displayName" : "textAccentMinorActive",
+      "name" : "light.text.default.accent-minor-active",
+      "reference" : "TextDefaultAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF21B03C"
+    },
+    {
+      "description" : "typography l header-h6-medium",
+      "displayName" : "HeaderH6 M",
+      "name" : "screen-l.header.h6.medium",
+      "reference" : "HeaderH6Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH6Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l header-h6",
+      "displayName" : "HeaderH6 N",
+      "name" : "screen-l.header.h6.normal",
+      "reference" : "HeaderH6Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH6Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l text-l-bold",
+      "displayName" : "TextL B",
+      "name" : "screen-l.text.l.bold",
+      "reference" : "TextLBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textLBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 32,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l text-l-medium",
+      "displayName" : "TextL M",
+      "name" : "screen-l.text.l.medium",
+      "reference" : "TextLMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textLMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 32,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "Акцентный минорный цвет",
+      "displayName" : "textAccentMinorHover",
+      "name" : "dark.text.default.accent-minor-hover",
+      "reference" : "TextDefaultAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF0F9527"
+    },
+    {
+      "description" : "Акцентный минорный цвет",
+      "displayName" : "textAccentMinorHover",
+      "name" : "light.text.default.accent-minor-hover",
+      "reference" : "TextDefaultAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF47DC62"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех",
+      "displayName" : "outlineTransparentPositiveHover",
+      "name" : "dark.outline.default.transparent-positive-hover",
+      "reference" : "OutlineDefaultTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех",
+      "displayName" : "outlineTransparentPositiveHover",
+      "name" : "light.outline.default.transparent-positive-hover",
+      "reference" : "OutlineDefaultTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0xFF108E25"
+    },
+    {
+      "description" : "Цвет информации",
+      "displayName" : "textInfo",
+      "name" : "dark.text.default.info",
+      "reference" : "TextDefaultInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfo",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "Цвет информации",
+      "displayName" : "textInfo",
+      "name" : "light.text.default.info",
+      "reference" : "TextDefaultInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfo",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Цвет информации",
+      "displayName" : "textInfoActive",
+      "name" : "dark.text.default.info-active",
+      "reference" : "TextDefaultInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoActive",
+      "type" : "color",
+      "value" : "0xFF0E8ADD"
+    },
+    {
+      "description" : "Цвет информации",
+      "displayName" : "textInfoActive",
+      "name" : "light.text.default.info-active",
+      "reference" : "TextDefaultInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoActive",
+      "type" : "color",
+      "value" : "0xFF0966A5"
+    },
+    {
+      "description" : "Цвет информации",
+      "displayName" : "textInfoHover",
+      "name" : "dark.text.default.info-hover",
+      "reference" : "TextDefaultInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoHover",
+      "type" : "color",
+      "value" : "0xFF66BCF5"
+    },
+    {
+      "description" : "Цвет информации",
+      "displayName" : "textInfoHover",
+      "name" : "light.text.default.info-hover",
+      "reference" : "TextDefaultInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoHover",
+      "type" : "color",
+      "value" : "0xFF0D96F2"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки",
+      "displayName" : "outlineTransparentPrimary",
+      "name" : "dark.outline.default.transparent-primary",
+      "reference" : "OutlineDefaultTransparentPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPrimary",
+      "type" : "color",
+      "value" : "0x1FFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки",
+      "displayName" : "outlineTransparentPrimary",
+      "name" : "light.outline.default.transparent-primary",
+      "reference" : "OutlineDefaultTransparentPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPrimary",
+      "type" : "color",
+      "value" : "0x1E080808"
+    },
+    {
+      "description" : "Минорный цвет информации",
+      "displayName" : "textInfoMinor",
+      "name" : "dark.text.default.info-minor",
+      "reference" : "TextDefaultInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0D5382"
+    },
+    {
+      "description" : "Минорный цвет информации",
+      "displayName" : "textInfoMinor",
+      "name" : "light.text.default.info-minor",
+      "reference" : "TextDefaultInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoMinor",
+      "type" : "color",
+      "value" : "0xFF52BAFF"
+    },
+    {
+      "description" : "typography l text-l",
+      "displayName" : "TextL N",
+      "name" : "screen-l.text.l.normal",
+      "reference" : "TextLNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textLNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 32,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки",
+      "displayName" : "outlineTransparentPrimaryActive",
+      "name" : "dark.outline.default.transparent-primary-active",
+      "reference" : "OutlineDefaultTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x25FFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки",
+      "displayName" : "outlineTransparentPrimaryActive",
+      "name" : "light.outline.default.transparent-primary-active",
+      "reference" : "OutlineDefaultTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x25080808"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки",
+      "displayName" : "outlineTransparentPrimaryHover",
+      "name" : "dark.outline.default.transparent-primary-hover",
+      "reference" : "OutlineDefaultTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки",
+      "displayName" : "outlineTransparentPrimaryHover",
+      "name" : "light.outline.default.transparent-primary-hover",
+      "reference" : "OutlineDefaultTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentSecondary",
+      "name" : "dark.outline.default.transparent-secondary",
+      "reference" : "OutlineDefaultTransparentSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentSecondary",
+      "type" : "color",
+      "value" : "0x47FFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentSecondary",
+      "name" : "light.outline.default.transparent-secondary",
+      "reference" : "OutlineDefaultTransparentSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentSecondary",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentSecondaryActive",
+      "name" : "dark.outline.default.transparent-secondary-active",
+      "reference" : "OutlineDefaultTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x56FFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentSecondaryActive",
+      "name" : "light.outline.default.transparent-secondary-active",
+      "reference" : "OutlineDefaultTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x56080808"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentSecondaryHover",
+      "name" : "dark.outline.default.transparent-secondary-hover",
+      "reference" : "OutlineDefaultTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentSecondaryHover",
+      "name" : "light.outline.default.transparent-secondary-hover",
+      "reference" : "OutlineDefaultTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentTertiary",
+      "name" : "dark.outline.default.transparent-tertiary",
+      "reference" : "OutlineDefaultTransparentTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentTertiary",
+      "type" : "color",
+      "value" : "0x8FFFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentTertiary",
+      "name" : "light.outline.default.transparent-tertiary",
+      "reference" : "OutlineDefaultTransparentTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentTertiary",
+      "type" : "color",
+      "value" : "0x8E080808"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentTertiaryActive",
+      "name" : "dark.outline.default.transparent-tertiary-active",
+      "reference" : "OutlineDefaultTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0xABFFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentTertiaryActive",
+      "name" : "light.outline.default.transparent-tertiary-active",
+      "reference" : "OutlineDefaultTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0xAB080808"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentTertiaryHover",
+      "name" : "dark.outline.default.transparent-tertiary-hover",
+      "reference" : "OutlineDefaultTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки",
+      "displayName" : "outlineTransparentTertiaryHover",
+      "name" : "light.outline.default.transparent-tertiary-hover",
+      "reference" : "OutlineDefaultTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentWarning",
+      "name" : "dark.outline.default.transparent-warning",
+      "reference" : "OutlineDefaultTransparentWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentWarning",
+      "type" : "color",
+      "value" : "0x47FF6F23"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentWarning",
+      "name" : "light.outline.default.transparent-warning",
+      "reference" : "OutlineDefaultTransparentWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentWarning",
+      "type" : "color",
+      "value" : "0x33E85602"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentWarningActive",
+      "name" : "dark.outline.default.transparent-warning-active",
+      "reference" : "OutlineDefaultTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x56FF7024"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentWarningActive",
+      "name" : "light.outline.default.transparent-warning-active",
+      "reference" : "OutlineDefaultTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x3DE85702"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentWarningHover",
+      "name" : "dark.outline.default.transparent-warning-hover",
+      "reference" : "OutlineDefaultTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentWarningHover",
+      "name" : "light.outline.default.transparent-warning-hover",
+      "reference" : "OutlineDefaultTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentWarningHover",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Цвет обводки предупреждение",
+      "displayName" : "outlineWarning",
+      "name" : "dark.outline.default.warning",
+      "reference" : "OutlineDefaultWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarning",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Цвет обводки предупреждение",
+      "displayName" : "outlineWarning",
+      "name" : "light.outline.default.warning",
+      "reference" : "OutlineDefaultWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarning",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Цвет обводки предупреждение",
+      "displayName" : "outlineWarningActive",
+      "name" : "dark.outline.default.warning-active",
+      "reference" : "OutlineDefaultWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningActive",
+      "type" : "color",
+      "value" : "0xFFFF5D05"
+    },
+    {
+      "description" : "Цвет обводки предупреждение",
+      "displayName" : "outlineWarningActive",
+      "name" : "light.outline.default.warning-active",
+      "reference" : "OutlineDefaultWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningActive",
+      "type" : "color",
+      "value" : "0xFFC04802"
+    },
+    {
+      "description" : "Цвет обводки предупреждение",
+      "displayName" : "outlineWarningHover",
+      "name" : "dark.outline.default.warning-hover",
+      "reference" : "OutlineDefaultWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF8442"
+    },
+    {
+      "description" : "Цвет обводки предупреждение",
+      "displayName" : "outlineWarningHover",
+      "name" : "light.outline.default.warning-hover",
+      "reference" : "OutlineDefaultWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningHover",
+      "type" : "color",
+      "value" : "0xFFFD6B17"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение",
+      "displayName" : "outlineWarningMinor",
+      "name" : "dark.outline.default.warning-minor",
+      "reference" : "OutlineDefaultWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningMinor",
+      "type" : "color",
+      "value" : "0xFF85380C"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение",
+      "displayName" : "outlineWarningMinor",
+      "name" : "light.outline.default.warning-minor",
+      "reference" : "OutlineDefaultWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFD9C68"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение",
+      "displayName" : "outlineWarningMinorActive",
+      "name" : "dark.outline.default.warning-minor-active",
+      "reference" : "OutlineDefaultWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFF9F440F"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение",
+      "displayName" : "outlineWarningMinorActive",
+      "name" : "light.outline.default.warning-minor-active",
+      "reference" : "OutlineDefaultWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFC8240"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение",
+      "displayName" : "outlineWarningMinorHover",
+      "name" : "dark.outline.default.warning-minor-hover",
+      "reference" : "OutlineDefaultWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFBB4F11"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение",
+      "displayName" : "outlineWarningMinorHover",
+      "name" : "light.outline.default.warning-minor-hover",
+      "reference" : "OutlineDefaultWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFDB790"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineAccent",
+      "name" : "dark.outline.inverse.accent",
+      "reference" : "OutlineInverseAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccent",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineAccent",
+      "name" : "light.outline.inverse.accent",
+      "reference" : "OutlineInverseAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccent",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineAccentActive",
+      "name" : "dark.outline.inverse.accent-active",
+      "reference" : "OutlineInverseAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentActive",
+      "type" : "color",
+      "value" : "0xFF0D731E"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineAccentActive",
+      "name" : "light.outline.inverse.accent-active",
+      "reference" : "OutlineInverseAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentActive",
+      "type" : "color",
+      "value" : "0xFF1D9032"
+    },
+    {
+      "description" : "Минорный цвет информации",
+      "displayName" : "textInfoMinorActive",
+      "name" : "dark.text.default.info-minor-active",
+      "reference" : "TextDefaultInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF10659E"
+    },
+    {
+      "description" : "Минорный цвет информации",
+      "displayName" : "textInfoMinorActive",
+      "name" : "light.text.default.info-minor-active",
+      "reference" : "TextDefaultInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF29A9FF"
+    },
+    {
+      "description" : "typography l text-m-bold",
+      "displayName" : "TextM B",
+      "name" : "screen-l.text.m.bold",
+      "reference" : "TextMBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textMBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 26,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineAccentHover",
+      "name" : "dark.outline.inverse.accent-hover",
+      "reference" : "OutlineInverseAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentHover",
+      "type" : "color",
+      "value" : "0xFF13AA2C"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineAccentHover",
+      "name" : "light.outline.inverse.accent-hover",
+      "reference" : "OutlineInverseAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentHover",
+      "type" : "color",
+      "value" : "0xFF2BD44A"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineAccentMinor",
+      "name" : "dark.outline.inverse.accent-minor",
+      "reference" : "OutlineInverseAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineAccentMinor",
+      "name" : "light.outline.inverse.accent-minor",
+      "reference" : "OutlineInverseAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineAccentMinorActive",
+      "name" : "dark.outline.inverse.accent-minor-active",
+      "reference" : "OutlineInverseAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF23B83E"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineAccentMinorActive",
+      "name" : "light.outline.inverse.accent-minor-active",
+      "reference" : "OutlineInverseAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF0D8222"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineAccentMinorHover",
+      "name" : "dark.outline.inverse.accent-minor-hover",
+      "reference" : "OutlineInverseAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF3EDA5B"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineAccentMinorHover",
+      "name" : "light.outline.inverse.accent-minor-hover",
+      "reference" : "OutlineInverseAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF11A72C"
+    },
+    {
+      "description" : "Инвертированная бесцветная обводка",
+      "displayName" : "inverseOutlineClear",
+      "name" : "dark.outline.inverse.clear",
+      "reference" : "OutlineInverseClear",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Инвертированная бесцветная обводка",
+      "displayName" : "inverseOutlineClear",
+      "name" : "light.outline.inverse.clear",
+      "reference" : "OutlineInverseClear",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Инвертированная бесцветная обводка",
+      "displayName" : "inverseOutlineClearActive",
+      "name" : "dark.outline.inverse.clear-active",
+      "reference" : "OutlineInverseClearActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированная бесцветная обводка",
+      "displayName" : "inverseOutlineClearActive",
+      "name" : "light.outline.inverse.clear-active",
+      "reference" : "OutlineInverseClearActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированная бесцветная обводка",
+      "displayName" : "inverseOutlineClearHover",
+      "name" : "dark.outline.inverse.clear-hover",
+      "reference" : "OutlineInverseClearHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированная бесцветная обводка",
+      "displayName" : "inverseOutlineClearHover",
+      "name" : "light.outline.inverse.clear-hover",
+      "reference" : "OutlineInverseClearHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineInfo",
+      "name" : "dark.outline.inverse.info",
+      "reference" : "OutlineInverseInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfo",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineInfo",
+      "name" : "light.outline.inverse.info",
+      "reference" : "OutlineInverseInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfo",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "Инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoActive",
+      "name" : "dark.outline.inverse.info-active",
+      "reference" : "OutlineInverseInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoActive",
+      "type" : "color",
+      "value" : "0xFF096CAE"
+    },
+    {
+      "description" : "Инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoActive",
+      "name" : "light.outline.inverse.info-active",
+      "reference" : "OutlineInverseInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoActive",
+      "type" : "color",
+      "value" : "0xFF0D84D3"
+    },
+    {
+      "description" : "Инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoHover",
+      "name" : "dark.outline.inverse.info-hover",
+      "reference" : "OutlineInverseInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoHover",
+      "type" : "color",
+      "value" : "0xFF34A7F4"
+    },
+    {
+      "description" : "Инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoHover",
+      "name" : "light.outline.inverse.info-hover",
+      "reference" : "OutlineInverseInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoHover",
+      "type" : "color",
+      "value" : "0xFF3FABF3"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoMinor",
+      "name" : "dark.outline.inverse.info-minor",
+      "reference" : "OutlineInverseInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoMinor",
+      "type" : "color",
+      "value" : "0xFF52BAFF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoMinor",
+      "name" : "light.outline.inverse.info-minor",
+      "reference" : "OutlineInverseInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0D5382"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoMinorActive",
+      "name" : "dark.outline.inverse.info-minor-active",
+      "reference" : "OutlineInverseInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF33ADFF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoMinorActive",
+      "name" : "light.outline.inverse.info-minor-active",
+      "reference" : "OutlineInverseInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF116BA7"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoMinorHover",
+      "name" : "dark.outline.inverse.info-minor-hover",
+      "reference" : "OutlineInverseInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFFA3DAFF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки информация",
+      "displayName" : "inverseOutlineInfoMinorHover",
+      "name" : "light.outline.inverse.info-minor-hover",
+      "reference" : "OutlineInverseInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF1483CC"
+    },
+    {
+      "description" : "Инвертированный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegative",
+      "name" : "dark.outline.inverse.negative",
+      "reference" : "OutlineInverseNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegative",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Инвертированный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegative",
+      "name" : "light.outline.inverse.negative",
+      "reference" : "OutlineInverseNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegative",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Инвертированный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeActive",
+      "name" : "dark.outline.inverse.negative-active",
+      "reference" : "OutlineInverseNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeActive",
+      "type" : "color",
+      "value" : "0xFFE40C22"
+    },
+    {
+      "description" : "Инвертированный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeActive",
+      "name" : "light.outline.inverse.negative-active",
+      "reference" : "OutlineInverseNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF142C"
+    },
+    {
+      "description" : "Инвертированный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeHover",
+      "name" : "dark.outline.inverse.negative-hover",
+      "reference" : "OutlineInverseNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF5384B"
+    },
+    {
+      "description" : "Инвертированный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeHover",
+      "name" : "light.outline.inverse.negative-hover",
+      "reference" : "OutlineInverseNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF6675"
+    },
+    {
+      "description" : "Основной фон на темном фоне",
+      "displayName" : "darkBackgroundPrimary",
+      "name" : "dark.background.dark.primary",
+      "reference" : "BackgroundDarkPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.backgroundDarkPrimary",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Основной фон на темном фоне",
+      "displayName" : "darkBackgroundPrimary",
+      "name" : "light.background.dark.primary",
+      "reference" : "BackgroundDarkPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.backgroundDarkPrimary",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Основной фон",
+      "displayName" : "backgroundPrimary",
+      "name" : "dark.background.default.primary",
+      "reference" : "BackgroundDefaultPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.backgroundDefaultPrimary",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Основной фон",
+      "displayName" : "backgroundPrimary",
+      "name" : "light.background.default.primary",
+      "reference" : "BackgroundDefaultPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.backgroundDefaultPrimary",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Инвертированный основной фон",
+      "displayName" : "inverseBackgroundPrimary",
+      "name" : "dark.background.inverse.primary",
+      "reference" : "BackgroundInversePrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.backgroundInversePrimary",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Инвертированный основной фон",
+      "displayName" : "inverseBackgroundPrimary",
+      "name" : "light.background.inverse.primary",
+      "reference" : "BackgroundInversePrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.backgroundInversePrimary",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Основной фон на светлом фоне",
+      "displayName" : "lightBackgroundPrimary",
+      "name" : "dark.background.light.primary",
+      "reference" : "BackgroundLightPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.backgroundLightPrimary",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Основной фон на светлом фоне",
+      "displayName" : "lightBackgroundPrimary",
+      "name" : "light.background.light.primary",
+      "reference" : "BackgroundLightPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.backgroundLightPrimary",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Желтый цвет для данных",
+      "displayName" : "dataYellow",
+      "name" : "dark.data.default.yellow",
+      "reference" : "DataDefaultYellow",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataDefaultYellow",
+      "type" : "color",
+      "value" : "0xFFF3A912"
+    },
+    {
+      "description" : "Желтый цвет для данных",
+      "displayName" : "dataYellow",
+      "name" : "light.data.default.yellow",
+      "reference" : "DataDefaultYellow",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataDefaultYellow",
+      "type" : "color",
+      "value" : "0xFFF3A912"
+    },
+    {
+      "description" : "Минорный желтый цвет для данных",
+      "displayName" : "dataYellowMinor",
+      "name" : "dark.data.default.yellow-minor",
+      "reference" : "DataDefaultYellowMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataDefaultYellowMinor",
+      "type" : "color",
+      "value" : "0xFFA16B00"
+    },
+    {
+      "description" : "Минорный желтый цвет для данных",
+      "displayName" : "dataYellowMinor",
+      "name" : "light.data.default.yellow-minor",
+      "reference" : "DataDefaultYellowMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataDefaultYellowMinor",
+      "type" : "color",
+      "value" : "0xFFFFD37A"
+    },
+    {
+      "description" : "Прозрачный желтый цвет для данных",
+      "displayName" : "dataYellowTransparent",
+      "name" : "dark.data.default.yellow-transparent",
+      "reference" : "DataDefaultYellowTransparent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataDefaultYellowTransparent",
+      "type" : "color",
+      "value" : "0x8EF3A911"
+    },
+    {
+      "description" : "Прозрачный желтый цвет для данных",
+      "displayName" : "dataYellowTransparent",
+      "name" : "light.data.default.yellow-transparent",
+      "reference" : "DataDefaultYellowTransparent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataDefaultYellowTransparent",
+      "type" : "color",
+      "value" : "0x8EF3A911"
+    },
+    {
+      "description" : "Инвертированный желтый цвет для данных",
+      "displayName" : "inverseDataYellow",
+      "name" : "dark.data.inverse.yellow",
+      "reference" : "DataInverseYellow",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataInverseYellow",
+      "type" : "color",
+      "value" : "0xFFF3A912"
+    },
+    {
+      "description" : "Инвертированный желтый цвет для данных",
+      "displayName" : "inverseDataYellow",
+      "name" : "light.data.inverse.yellow",
+      "reference" : "DataInverseYellow",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataInverseYellow",
+      "type" : "color",
+      "value" : "0xFFF3A912"
+    },
+    {
+      "description" : "Инвертированный минорный желтый цвет для данных",
+      "displayName" : "inverseDataYellowMinor",
+      "name" : "dark.data.inverse.yellow-minor",
+      "reference" : "DataInverseYellowMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataInverseYellowMinor",
+      "type" : "color",
+      "value" : "0xFFFFD37A"
+    },
+    {
+      "description" : "Инвертированный минорный желтый цвет для данных",
+      "displayName" : "inverseDataYellowMinor",
+      "name" : "light.data.inverse.yellow-minor",
+      "reference" : "DataInverseYellowMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataInverseYellowMinor",
+      "type" : "color",
+      "value" : "0xFFA16B00"
+    },
+    {
+      "description" : "Инвертированный прозрачный желтый цвет для данных",
+      "displayName" : "inverseDataYellowTransparent",
+      "name" : "dark.data.inverse.yellow-transparent",
+      "reference" : "DataInverseYellowTransparent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataInverseYellowTransparent",
+      "type" : "color",
+      "value" : "0x8EF3A911"
+    },
+    {
+      "description" : "Инвертированный прозрачный желтый цвет для данных",
+      "displayName" : "inverseDataYellowTransparent",
+      "name" : "light.data.inverse.yellow-transparent",
+      "reference" : "DataInverseYellowTransparent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataInverseYellowTransparent",
+      "type" : "color",
+      "value" : "0x8EF3A911"
+    },
+    {
+      "description" : "Желтый цвет для данных на темном фоне",
+      "displayName" : "onDarkDataYellow",
+      "name" : "dark.data.on-dark.yellow",
+      "reference" : "DataOnDarkYellow",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnDarkYellow",
+      "type" : "color",
+      "value" : "0xFFF3A912"
+    },
+    {
+      "description" : "Желтый цвет для данных на темном фоне",
+      "displayName" : "onDarkDataYellow",
+      "name" : "light.data.on-dark.yellow",
+      "reference" : "DataOnDarkYellow",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnDarkYellow",
+      "type" : "color",
+      "value" : "0xFFF3A912"
+    },
+    {
+      "description" : "Минорный желтый цвет для данных на темном фоне",
+      "displayName" : "onDarkDataYellowMinor",
+      "name" : "dark.data.on-dark.yellow-minor",
+      "reference" : "DataOnDarkYellowMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnDarkYellowMinor",
+      "type" : "color",
+      "value" : "0xFFA16B00"
+    },
+    {
+      "description" : "Минорный желтый цвет для данных на темном фоне",
+      "displayName" : "onDarkDataYellowMinor",
+      "name" : "light.data.on-dark.yellow-minor",
+      "reference" : "DataOnDarkYellowMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnDarkYellowMinor",
+      "type" : "color",
+      "value" : "0xFFA16B00"
+    },
+    {
+      "description" : "Прозрачный желтый цвет для данных на темном фоне",
+      "displayName" : "onDarkDataYellowTransparent",
+      "name" : "dark.data.on-dark.yellow-transparent",
+      "reference" : "DataOnDarkYellowTransparent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnDarkYellowTransparent",
+      "type" : "color",
+      "value" : "0x8EF3A911"
+    },
+    {
+      "description" : "Прозрачный желтый цвет для данных на темном фоне",
+      "displayName" : "onDarkDataYellowTransparent",
+      "name" : "light.data.on-dark.yellow-transparent",
+      "reference" : "DataOnDarkYellowTransparent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnDarkYellowTransparent",
+      "type" : "color",
+      "value" : "0x8EF3A911"
+    },
+    {
+      "description" : "Желтый цвет для данных на светлом фоне",
+      "displayName" : "onLightDataYellow",
+      "name" : "dark.data.on-light.yellow",
+      "reference" : "DataOnLightYellow",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnLightYellow",
+      "type" : "color",
+      "value" : "0xFFF3A912"
+    },
+    {
+      "description" : "Желтый цвет для данных на светлом фоне",
+      "displayName" : "onLightDataYellow",
+      "name" : "light.data.on-light.yellow",
+      "reference" : "DataOnLightYellow",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnLightYellow",
+      "type" : "color",
+      "value" : "0xFFF3A912"
+    },
+    {
+      "description" : "Минорный желтый цвет для данных на светлом фоне",
+      "displayName" : "onLightDataYellowMinor",
+      "name" : "dark.data.on-light.yellow-minor",
+      "reference" : "DataOnLightYellowMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnLightYellowMinor",
+      "type" : "color",
+      "value" : "0xFFFFD37A"
+    },
+    {
+      "description" : "Минорный желтый цвет для данных на светлом фоне",
+      "displayName" : "onLightDataYellowMinor",
+      "name" : "light.data.on-light.yellow-minor",
+      "reference" : "DataOnLightYellowMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnLightYellowMinor",
+      "type" : "color",
+      "value" : "0xFFFFD37A"
+    },
+    {
+      "description" : "Прозрачный желтый цвет для данных на светлом фоне",
+      "displayName" : "onLightDataYellowTransparent",
+      "name" : "dark.data.on-light.yellow-transparent",
+      "reference" : "DataOnLightYellowTransparent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnLightYellowTransparent",
+      "type" : "color",
+      "value" : "0x8EF3A911"
+    },
+    {
+      "description" : "Прозрачный желтый цвет для данных на светлом фоне",
+      "displayName" : "onLightDataYellowTransparent",
+      "name" : "light.data.on-light.yellow-transparent",
+      "reference" : "DataOnLightYellowTransparent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.dataOnLightYellowTransparent",
+      "type" : "color",
+      "value" : "0x8EF3A911"
+    },
+    {
+      "description" : "Акцентный цвет обводки",
+      "displayName" : "outlineAccent",
+      "name" : "dark.outline.default.accent",
+      "reference" : "OutlineDefaultAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccent",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Акцентный цвет обводки",
+      "displayName" : "outlineAccent",
+      "name" : "light.outline.default.accent",
+      "reference" : "OutlineDefaultAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccent",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Акцентный цвет обводки",
+      "displayName" : "outlineAccentActive",
+      "name" : "dark.outline.default.accent-active",
+      "reference" : "OutlineDefaultAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentActive",
+      "type" : "color",
+      "value" : "0xFF1F9835"
+    },
+    {
+      "description" : "Акцентный цвет обводки",
+      "displayName" : "outlineAccentActive",
+      "name" : "light.outline.default.accent-active",
+      "reference" : "OutlineDefaultAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentActive",
+      "type" : "color",
+      "value" : "0xFF0C6A1B"
+    },
+    {
+      "description" : "Акцентный цвет обводки",
+      "displayName" : "outlineAccentHover",
+      "name" : "dark.outline.default.accent-hover",
+      "reference" : "OutlineDefaultAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentHover",
+      "type" : "color",
+      "value" : "0xFF2ACB47"
+    },
+    {
+      "description" : "Акцентный цвет обводки",
+      "displayName" : "outlineAccentHover",
+      "name" : "light.outline.default.accent-hover",
+      "reference" : "OutlineDefaultAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentHover",
+      "type" : "color",
+      "value" : "0xFF14B32E"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "outlineAccentMinor",
+      "name" : "dark.outline.default.accent-minor",
+      "reference" : "OutlineDefaultAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "outlineAccentMinor",
+      "name" : "light.outline.default.accent-minor",
+      "reference" : "OutlineDefaultAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "outlineAccentMinorActive",
+      "name" : "dark.outline.default.accent-minor-active",
+      "reference" : "OutlineDefaultAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF0C7920"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "outlineAccentMinorActive",
+      "name" : "light.outline.default.accent-minor-active",
+      "reference" : "OutlineDefaultAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF21B03C"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "outlineAccentMinorHover",
+      "name" : "dark.outline.default.accent-minor-hover",
+      "reference" : "OutlineDefaultAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF0F9527"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки",
+      "displayName" : "outlineAccentMinorHover",
+      "name" : "light.outline.default.accent-minor-hover",
+      "reference" : "OutlineDefaultAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF47DC62"
+    },
+    {
+      "description" : "Бесцветная обводка",
+      "displayName" : "outlineClear",
+      "name" : "dark.outline.default.clear",
+      "reference" : "OutlineDefaultClear",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка",
+      "displayName" : "outlineClear",
+      "name" : "light.outline.default.clear",
+      "reference" : "OutlineDefaultClear",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка",
+      "displayName" : "outlineClearActive",
+      "name" : "dark.outline.default.clear-active",
+      "reference" : "OutlineDefaultClearActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка",
+      "displayName" : "outlineClearActive",
+      "name" : "light.outline.default.clear-active",
+      "reference" : "OutlineDefaultClearActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка",
+      "displayName" : "outlineClearHover",
+      "name" : "dark.outline.default.clear-hover",
+      "reference" : "OutlineDefaultClearHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка",
+      "displayName" : "outlineClearHover",
+      "name" : "light.outline.default.clear-hover",
+      "reference" : "OutlineDefaultClearHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Цвет обводки информация",
+      "displayName" : "outlineInfo",
+      "name" : "dark.outline.default.info",
+      "reference" : "OutlineDefaultInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfo",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "Цвет обводки информация",
+      "displayName" : "outlineInfo",
+      "name" : "light.outline.default.info",
+      "reference" : "OutlineDefaultInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfo",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Цвет обводки информация",
+      "displayName" : "outlineInfoActive",
+      "name" : "dark.outline.default.info-active",
+      "reference" : "OutlineDefaultInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoActive",
+      "type" : "color",
+      "value" : "0xFF0E8ADD"
+    },
+    {
+      "description" : "Цвет обводки информация",
+      "displayName" : "outlineInfoActive",
+      "name" : "light.outline.default.info-active",
+      "reference" : "OutlineDefaultInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoActive",
+      "type" : "color",
+      "value" : "0xFF0966A5"
+    },
+    {
+      "description" : "Цвет обводки информация",
+      "displayName" : "outlineInfoHover",
+      "name" : "dark.outline.default.info-hover",
+      "reference" : "OutlineDefaultInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoHover",
+      "type" : "color",
+      "value" : "0xFF66BCF5"
+    },
+    {
+      "description" : "Цвет обводки информация",
+      "displayName" : "outlineInfoHover",
+      "name" : "light.outline.default.info-hover",
+      "reference" : "OutlineDefaultInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoHover",
+      "type" : "color",
+      "value" : "0xFF0D96F2"
+    },
+    {
+      "description" : "Минорный цвет обводки информация",
+      "displayName" : "outlineInfoMinor",
+      "name" : "dark.outline.default.info-minor",
+      "reference" : "OutlineDefaultInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0D5382"
+    },
+    {
+      "description" : "Минорный цвет обводки информация",
+      "displayName" : "outlineInfoMinor",
+      "name" : "light.outline.default.info-minor",
+      "reference" : "OutlineDefaultInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoMinor",
+      "type" : "color",
+      "value" : "0xFF52BAFF"
+    },
+    {
+      "description" : "Минорный цвет обводки информация",
+      "displayName" : "outlineInfoMinorActive",
+      "name" : "dark.outline.default.info-minor-active",
+      "reference" : "OutlineDefaultInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF10659E"
+    },
+    {
+      "description" : "Минорный цвет обводки информация",
+      "displayName" : "outlineInfoMinorActive",
+      "name" : "light.outline.default.info-minor-active",
+      "reference" : "OutlineDefaultInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF29A9FF"
+    },
+    {
+      "description" : "Минорный цвет обводки информация",
+      "displayName" : "outlineInfoMinorHover",
+      "name" : "dark.outline.default.info-minor-hover",
+      "reference" : "OutlineDefaultInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF1277BA"
+    },
+    {
+      "description" : "Минорный цвет обводки информация",
+      "displayName" : "outlineInfoMinorHover",
+      "name" : "light.outline.default.info-minor-hover",
+      "reference" : "OutlineDefaultInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF7ACAFF"
+    },
+    {
+      "description" : "Цвет обводки ошибка",
+      "displayName" : "outlineNegative",
+      "name" : "dark.outline.default.negative",
+      "reference" : "OutlineDefaultNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegative",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Цвет обводки ошибка",
+      "displayName" : "outlineNegative",
+      "name" : "light.outline.default.negative",
+      "reference" : "OutlineDefaultNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegative",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Цвет обводки ошибка",
+      "displayName" : "outlineNegativeActive",
+      "name" : "dark.outline.default.negative-active",
+      "reference" : "OutlineDefaultNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF1F35"
+    },
+    {
+      "description" : "Цвет обводки ошибка",
+      "displayName" : "outlineNegativeActive",
+      "name" : "light.outline.default.negative-active",
+      "reference" : "OutlineDefaultNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeActive",
+      "type" : "color",
+      "value" : "0xFFDA0B20"
+    },
+    {
+      "description" : "Цвет обводки ошибка",
+      "displayName" : "outlineNegativeHover",
+      "name" : "dark.outline.default.negative-hover",
+      "reference" : "OutlineDefaultNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF5C6C"
+    },
+    {
+      "description" : "Цвет обводки ошибка",
+      "displayName" : "outlineNegativeHover",
+      "name" : "light.outline.default.negative-hover",
+      "reference" : "OutlineDefaultNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF54254"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка",
+      "displayName" : "outlineNegativeMinor",
+      "name" : "dark.outline.default.negative-minor",
+      "reference" : "OutlineDefaultNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF9C1422"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка",
+      "displayName" : "outlineNegativeMinor",
+      "name" : "light.outline.default.negative-minor",
+      "reference" : "OutlineDefaultNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFF8F9A"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка",
+      "displayName" : "outlineNegativeMinorActive",
+      "name" : "dark.outline.default.negative-minor-active",
+      "reference" : "OutlineDefaultNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF83111C"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка",
+      "displayName" : "outlineNegativeMinorActive",
+      "name" : "light.outline.default.negative-minor-active",
+      "reference" : "OutlineDefaultNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFF6675"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка",
+      "displayName" : "outlineNegativeMinorHover",
+      "name" : "dark.outline.default.negative-minor-hover",
+      "reference" : "OutlineDefaultNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFB91828"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка",
+      "displayName" : "outlineNegativeMinorHover",
+      "name" : "light.outline.default.negative-minor-hover",
+      "reference" : "OutlineDefaultNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFB8BF"
+    },
+    {
+      "description" : "Цвет обводки успех",
+      "displayName" : "outlinePositive",
+      "name" : "dark.outline.default.positive",
+      "reference" : "OutlineDefaultPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositive",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Цвет обводки успех",
+      "displayName" : "outlinePositive",
+      "name" : "light.outline.default.positive",
+      "reference" : "OutlineDefaultPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositive",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Цвет обводки успех",
+      "displayName" : "outlinePositiveActive",
+      "name" : "dark.outline.default.positive-active",
+      "reference" : "OutlineDefaultPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveActive",
+      "type" : "color",
+      "value" : "0xFF1F9835"
+    },
+    {
+      "description" : "Цвет обводки успех",
+      "displayName" : "outlinePositiveActive",
+      "name" : "light.outline.default.positive-active",
+      "reference" : "OutlineDefaultPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveActive",
+      "type" : "color",
+      "value" : "0xFF0C6A1B"
+    },
+    {
+      "description" : "Цвет обводки успех",
+      "displayName" : "outlinePositiveHover",
+      "name" : "dark.outline.default.positive-hover",
+      "reference" : "OutlineDefaultPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveHover",
+      "type" : "color",
+      "value" : "0xFF2ACB47"
+    },
+    {
+      "description" : "Цвет обводки успех",
+      "displayName" : "outlinePositiveHover",
+      "name" : "light.outline.default.positive-hover",
+      "reference" : "OutlineDefaultPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveHover",
+      "type" : "color",
+      "value" : "0xFF14B32E"
+    },
+    {
+      "description" : "Минорный цвет обводки успех",
+      "displayName" : "outlinePositiveMinor",
+      "name" : "dark.outline.default.positive-minor",
+      "reference" : "OutlineDefaultPositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Минорный цвет обводки успех",
+      "displayName" : "outlinePositiveMinor",
+      "name" : "light.outline.default.positive-minor",
+      "reference" : "OutlineDefaultPositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Минорный цвет обводки успех",
+      "displayName" : "outlinePositiveMinorActive",
+      "name" : "dark.outline.default.positive-minor-active",
+      "reference" : "OutlineDefaultPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF0C7920"
+    },
+    {
+      "description" : "Минорный цвет обводки успех",
+      "displayName" : "outlinePositiveMinorActive",
+      "name" : "light.outline.default.positive-minor-active",
+      "reference" : "OutlineDefaultPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF21B03C"
+    },
+    {
+      "description" : "Минорный цвет обводки успех",
+      "displayName" : "outlinePositiveMinorHover",
+      "name" : "dark.outline.default.positive-minor-hover",
+      "reference" : "OutlineDefaultPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF0F9527"
+    },
+    {
+      "description" : "Минорный цвет обводки успех",
+      "displayName" : "outlinePositiveMinorHover",
+      "name" : "light.outline.default.positive-minor-hover",
+      "reference" : "OutlineDefaultPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF47DC62"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "outlineSolidDefault",
+      "name" : "dark.outline.default.solid-default",
+      "reference" : "OutlineDefaultSolidDefault",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidDefault",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "outlineSolidDefault",
+      "name" : "light.outline.default.solid-default",
+      "reference" : "OutlineDefaultSolidDefault",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidDefault",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "outlineSolidDefaultActive",
+      "name" : "dark.outline.default.solid-default-active",
+      "reference" : "OutlineDefaultSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFE0E0E0"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "outlineSolidDefaultActive",
+      "name" : "light.outline.default.solid-default-active",
+      "reference" : "OutlineDefaultSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFF303030"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "outlineSolidDefaultHover",
+      "name" : "dark.outline.default.solid-default-hover",
+      "reference" : "OutlineDefaultSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFC7C7C7"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "outlineSolidDefaultHover",
+      "name" : "light.outline.default.solid-default-hover",
+      "reference" : "OutlineDefaultSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFF595959"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки",
+      "displayName" : "outlineSolidPrimary",
+      "name" : "dark.outline.default.solid-primary",
+      "reference" : "OutlineDefaultSolidPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidPrimary",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки",
+      "displayName" : "outlineSolidPrimary",
+      "name" : "light.outline.default.solid-primary",
+      "reference" : "OutlineDefaultSolidPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidPrimary",
+      "type" : "color",
+      "value" : "0xFFDDDDDD"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки",
+      "displayName" : "outlineSolidPrimaryActive",
+      "name" : "dark.outline.default.solid-primary-active",
+      "reference" : "OutlineDefaultSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFADADAD"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки",
+      "displayName" : "outlineSolidPrimaryActive",
+      "name" : "light.outline.default.solid-primary-active",
+      "reference" : "OutlineDefaultSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFB3B3B3"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки",
+      "displayName" : "outlineSolidPrimaryHover",
+      "name" : "dark.outline.default.solid-primary-hover",
+      "reference" : "OutlineDefaultSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки",
+      "displayName" : "outlineSolidPrimaryHover",
+      "name" : "light.outline.default.solid-primary-hover",
+      "reference" : "OutlineDefaultSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidSecondary",
+      "name" : "dark.outline.default.solid-secondary",
+      "reference" : "OutlineDefaultSolidSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF4E4E4E"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidSecondary",
+      "name" : "light.outline.default.solid-secondary",
+      "reference" : "OutlineDefaultSolidSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF949494"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidSecondaryActive",
+      "name" : "dark.outline.default.solid-secondary-active",
+      "reference" : "OutlineDefaultSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF8C8C8C"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidSecondaryActive",
+      "name" : "light.outline.default.solid-secondary-active",
+      "reference" : "OutlineDefaultSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF757575"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidSecondaryHover",
+      "name" : "dark.outline.default.solid-secondary-hover",
+      "reference" : "OutlineDefaultSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidSecondaryHover",
+      "name" : "light.outline.default.solid-secondary-hover",
+      "reference" : "OutlineDefaultSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidTertiary",
+      "name" : "dark.outline.default.solid-tertiary",
+      "reference" : "OutlineDefaultSolidTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF858585"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidTertiary",
+      "name" : "light.outline.default.solid-tertiary",
+      "reference" : "OutlineDefaultSolidTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF707070"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidTertiaryActive",
+      "name" : "dark.outline.default.solid-tertiary-active",
+      "reference" : "OutlineDefaultSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF616161"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidTertiaryActive",
+      "name" : "light.outline.default.solid-tertiary-active",
+      "reference" : "OutlineDefaultSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF595959"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidTertiaryHover",
+      "name" : "dark.outline.default.solid-tertiary-hover",
+      "reference" : "OutlineDefaultSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки",
+      "displayName" : "outlineSolidTertiaryHover",
+      "name" : "light.outline.default.solid-tertiary-hover",
+      "reference" : "OutlineDefaultSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки",
+      "displayName" : "outlineTransparentAccent",
+      "name" : "dark.outline.default.transparent-accent",
+      "reference" : "OutlineDefaultTransparentAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentAccent",
+      "type" : "color",
+      "value" : "0x4723B23D"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки",
+      "displayName" : "outlineTransparentAccent",
+      "name" : "light.outline.default.transparent-accent",
+      "reference" : "OutlineDefaultTransparentAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentAccent",
+      "type" : "color",
+      "value" : "0x330F8E25"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки",
+      "displayName" : "outlineTransparentAccentActive",
+      "name" : "dark.outline.default.transparent-accent-active",
+      "reference" : "OutlineDefaultTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x5624B23E"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки",
+      "displayName" : "outlineTransparentAccentActive",
+      "name" : "light.outline.default.transparent-accent-active",
+      "reference" : "OutlineDefaultTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x3D108E25"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки",
+      "displayName" : "outlineTransparentAccentHover",
+      "name" : "dark.outline.default.transparent-accent-hover",
+      "reference" : "OutlineDefaultTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentAccentHover",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки",
+      "displayName" : "outlineTransparentAccentHover",
+      "name" : "light.outline.default.transparent-accent-hover",
+      "reference" : "OutlineDefaultTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentAccentHover",
+      "type" : "color",
+      "value" : "0xFF108E25"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация",
+      "displayName" : "outlineTransparentInfo",
+      "name" : "dark.outline.default.transparent-info",
+      "reference" : "OutlineDefaultTransparentInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentInfo",
+      "type" : "color",
+      "value" : "0x47189AF0"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация",
+      "displayName" : "outlineTransparentInfo",
+      "name" : "light.outline.default.transparent-info",
+      "reference" : "OutlineDefaultTransparentInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentInfo",
+      "type" : "color",
+      "value" : "0x330A7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация",
+      "displayName" : "outlineTransparentInfoActive",
+      "name" : "dark.outline.default.transparent-info-active",
+      "reference" : "OutlineDefaultTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x56199AF0"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация",
+      "displayName" : "outlineTransparentInfoActive",
+      "name" : "light.outline.default.transparent-info-active",
+      "reference" : "OutlineDefaultTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x3D0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация",
+      "displayName" : "outlineTransparentInfoHover",
+      "name" : "dark.outline.default.transparent-info-hover",
+      "reference" : "OutlineDefaultTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentInfoHover",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация",
+      "displayName" : "outlineTransparentInfoHover",
+      "name" : "light.outline.default.transparent-info-hover",
+      "reference" : "OutlineDefaultTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentInfoHover",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentNegative",
+      "name" : "dark.outline.default.transparent-negative",
+      "reference" : "OutlineDefaultTransparentNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentNegative",
+      "type" : "color",
+      "value" : "0x47FF3C51"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentNegative",
+      "name" : "light.outline.default.transparent-negative",
+      "reference" : "OutlineDefaultTransparentNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentNegative",
+      "type" : "color",
+      "value" : "0x1FFF293E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentNegativeActive",
+      "name" : "dark.outline.default.transparent-negative-active",
+      "reference" : "OutlineDefaultTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x56FF3D51"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentNegativeActive",
+      "name" : "light.outline.default.transparent-negative-active",
+      "reference" : "OutlineDefaultTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x25FF293E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentNegativeHover",
+      "name" : "dark.outline.default.transparent-negative-hover",
+      "reference" : "OutlineDefaultTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение",
+      "displayName" : "outlineTransparentNegativeHover",
+      "name" : "light.outline.default.transparent-negative-hover",
+      "reference" : "OutlineDefaultTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех",
+      "displayName" : "outlineTransparentPositive",
+      "name" : "dark.outline.default.transparent-positive",
+      "reference" : "OutlineDefaultTransparentPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPositive",
+      "type" : "color",
+      "value" : "0x4723B23D"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех",
+      "displayName" : "outlineTransparentPositive",
+      "name" : "light.outline.default.transparent-positive",
+      "reference" : "OutlineDefaultTransparentPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPositive",
+      "type" : "color",
+      "value" : "0x330F8E25"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех",
+      "displayName" : "outlineTransparentPositiveActive",
+      "name" : "dark.outline.default.transparent-positive-active",
+      "reference" : "OutlineDefaultTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x5624B23E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех",
+      "displayName" : "outlineTransparentPositiveActive",
+      "name" : "light.outline.default.transparent-positive-active",
+      "reference" : "OutlineDefaultTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineDefaultTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x3D108E25"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeMinor",
+      "name" : "dark.outline.inverse.negative-minor",
+      "reference" : "OutlineInverseNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFF8F9A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeMinor",
+      "name" : "light.outline.inverse.negative-minor",
+      "reference" : "OutlineInverseNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF9C1422"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeMinorActive",
+      "name" : "dark.outline.inverse.negative-minor-active",
+      "reference" : "OutlineInverseNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFF707E"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeMinorActive",
+      "name" : "light.outline.inverse.negative-minor-active",
+      "reference" : "OutlineInverseNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF7A101A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeMinorHover",
+      "name" : "dark.outline.inverse.negative-minor-hover",
+      "reference" : "OutlineInverseNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFADB6"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки ошибка",
+      "displayName" : "inverseOutlineNegativeMinorHover",
+      "name" : "light.outline.inverse.negative-minor-hover",
+      "reference" : "OutlineInverseNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFC2192A"
+    },
+    {
+      "description" : "Инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlinePositive",
+      "name" : "dark.outline.inverse.positive",
+      "reference" : "OutlineInversePositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositive",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlinePositive",
+      "name" : "light.outline.inverse.positive",
+      "reference" : "OutlineInversePositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositive",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveActive",
+      "name" : "dark.outline.inverse.positive-active",
+      "reference" : "OutlineInversePositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveActive",
+      "type" : "color",
+      "value" : "0xFF0D731E"
+    },
+    {
+      "description" : "Инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveActive",
+      "name" : "light.outline.inverse.positive-active",
+      "reference" : "OutlineInversePositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveActive",
+      "type" : "color",
+      "value" : "0xFF1D9032"
+    },
+    {
+      "description" : "Инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveHover",
+      "name" : "dark.outline.inverse.positive-hover",
+      "reference" : "OutlineInversePositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveHover",
+      "type" : "color",
+      "value" : "0xFF13AA2C"
+    },
+    {
+      "description" : "Инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveHover",
+      "name" : "light.outline.inverse.positive-hover",
+      "reference" : "OutlineInversePositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveHover",
+      "type" : "color",
+      "value" : "0xFF2BD44A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveMinor",
+      "name" : "dark.outline.inverse.positive-minor",
+      "reference" : "OutlineInversePositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveMinor",
+      "name" : "light.outline.inverse.positive-minor",
+      "reference" : "OutlineInversePositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveMinorActive",
+      "name" : "dark.outline.inverse.positive-minor-active",
+      "reference" : "OutlineInversePositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF23B83E"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveMinorActive",
+      "name" : "light.outline.inverse.positive-minor-active",
+      "reference" : "OutlineInversePositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF0D8222"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveMinorHover",
+      "name" : "dark.outline.inverse.positive-minor-hover",
+      "reference" : "OutlineInversePositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF3EDA5B"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки успех",
+      "displayName" : "inverseOutlinePositiveMinorHover",
+      "name" : "light.outline.inverse.positive-minor-hover",
+      "reference" : "OutlineInversePositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInversePositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF11A72C"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseOutlineSolidDefault",
+      "name" : "dark.outline.inverse.solid-default",
+      "reference" : "OutlineInverseSolidDefault",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidDefault",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseOutlineSolidDefault",
+      "name" : "light.outline.inverse.solid-default",
+      "reference" : "OutlineInverseSolidDefault",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidDefault",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseOutlineSolidDefaultActive",
+      "name" : "dark.outline.inverse.solid-default-active",
+      "reference" : "OutlineInverseSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFC7C7C7"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseOutlineSolidDefaultActive",
+      "name" : "light.outline.inverse.solid-default-active",
+      "reference" : "OutlineInverseSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFC7C7C7"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseOutlineSolidDefaultHover",
+      "name" : "dark.outline.inverse.solid-default-hover",
+      "reference" : "OutlineInverseSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseOutlineSolidDefaultHover",
+      "name" : "light.outline.inverse.solid-default-hover",
+      "reference" : "OutlineInverseSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidPrimary",
+      "name" : "dark.outline.inverse.solid-primary",
+      "reference" : "OutlineInverseSolidPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidPrimary",
+      "type" : "color",
+      "value" : "0xFFDDDDDD"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidPrimary",
+      "name" : "light.outline.inverse.solid-primary",
+      "reference" : "OutlineInverseSolidPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidPrimary",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidPrimaryActive",
+      "name" : "dark.outline.inverse.solid-primary-active",
+      "reference" : "OutlineInverseSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFC4C4C4"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidPrimaryActive",
+      "name" : "light.outline.inverse.solid-primary-active",
+      "reference" : "OutlineInverseSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFF4F4F4F"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidPrimaryHover",
+      "name" : "dark.outline.inverse.solid-primary-hover",
+      "reference" : "OutlineInverseSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFABABAB"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidPrimaryHover",
+      "name" : "light.outline.inverse.solid-primary-hover",
+      "reference" : "OutlineInverseSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF787878"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidSecondary",
+      "name" : "dark.outline.inverse.solid-secondary",
+      "reference" : "OutlineInverseSolidSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF949494"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidSecondary",
+      "name" : "light.outline.inverse.solid-secondary",
+      "reference" : "OutlineInverseSolidSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidSecondaryActive",
+      "name" : "dark.outline.inverse.solid-secondary-active",
+      "reference" : "OutlineInverseSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF575757"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidSecondaryActive",
+      "name" : "light.outline.inverse.solid-secondary-active",
+      "reference" : "OutlineInverseSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF5E5E5E"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidSecondaryHover",
+      "name" : "dark.outline.inverse.solid-secondary-hover",
+      "reference" : "OutlineInverseSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidSecondaryHover",
+      "name" : "light.outline.inverse.solid-secondary-hover",
+      "reference" : "OutlineInverseSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF878787"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidTertiary",
+      "name" : "dark.outline.inverse.solid-tertiary",
+      "reference" : "OutlineInverseSolidTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF707070"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidTertiary",
+      "name" : "light.outline.inverse.solid-tertiary",
+      "reference" : "OutlineInverseSolidTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF707070"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidTertiaryActive",
+      "name" : "dark.outline.inverse.solid-tertiary-active",
+      "reference" : "OutlineInverseSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF737373"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidTertiaryActive",
+      "name" : "light.outline.inverse.solid-tertiary-active",
+      "reference" : "OutlineInverseSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF595959"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidTertiaryHover",
+      "name" : "dark.outline.inverse.solid-tertiary-hover",
+      "reference" : "OutlineInverseSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный цвет обводки",
+      "displayName" : "inverseOutlineSolidTertiaryHover",
+      "name" : "light.outline.inverse.solid-tertiary-hover",
+      "reference" : "OutlineInverseSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineTransparentAccent",
+      "name" : "dark.outline.inverse.transparent-accent",
+      "reference" : "OutlineInverseTransparentAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentAccent",
+      "type" : "color",
+      "value" : "0x330F8E25"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineTransparentAccent",
+      "name" : "light.outline.inverse.transparent-accent",
+      "reference" : "OutlineInverseTransparentAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentAccent",
+      "type" : "color",
+      "value" : "0x471A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineTransparentAccentActive",
+      "name" : "dark.outline.inverse.transparent-accent-active",
+      "reference" : "OutlineInverseTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x3D108E25"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineTransparentAccentActive",
+      "name" : "light.outline.inverse.transparent-accent-active",
+      "reference" : "OutlineInverseTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x561A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineTransparentAccentHover",
+      "name" : "dark.outline.inverse.transparent-accent-hover",
+      "reference" : "OutlineInverseTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentAccentHover",
+      "type" : "color",
+      "value" : "0xFF108E25"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный цвет обводки",
+      "displayName" : "inverseOutlineTransparentAccentHover",
+      "name" : "light.outline.inverse.transparent-accent-hover",
+      "reference" : "OutlineInverseTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentAccentHover",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineTransparentInfo",
+      "name" : "dark.outline.inverse.transparent-info",
+      "reference" : "OutlineInverseTransparentInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentInfo",
+      "type" : "color",
+      "value" : "0x330A7ECB"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineTransparentInfo",
+      "name" : "light.outline.inverse.transparent-info",
+      "reference" : "OutlineInverseTransparentInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentInfo",
+      "type" : "color",
+      "value" : "0x47118CDF"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineTransparentInfoActive",
+      "name" : "dark.outline.inverse.transparent-info-active",
+      "reference" : "OutlineInverseTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x3D0B7ECB"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineTransparentInfoActive",
+      "name" : "light.outline.inverse.transparent-info-active",
+      "reference" : "OutlineInverseTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x56118CDF"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineTransparentInfoHover",
+      "name" : "dark.outline.inverse.transparent-info-hover",
+      "reference" : "OutlineInverseTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentInfoHover",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки информация",
+      "displayName" : "inverseOutlineTransparentInfoHover",
+      "name" : "light.outline.inverse.transparent-info-hover",
+      "reference" : "OutlineInverseTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentInfoHover",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "typography l text-m-medium",
+      "displayName" : "TextM M",
+      "name" : "screen-l.text.m.medium",
+      "reference" : "TextMMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textMMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 26,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentNegative",
+      "name" : "dark.outline.inverse.transparent-negative",
+      "reference" : "OutlineInverseTransparentNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentNegative",
+      "type" : "color",
+      "value" : "0x33F31B30"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentNegative",
+      "name" : "light.outline.inverse.transparent-negative",
+      "reference" : "OutlineInverseTransparentNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentNegative",
+      "type" : "color",
+      "value" : "0x47FF293E"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentNegativeActive",
+      "name" : "dark.outline.inverse.transparent-negative-active",
+      "reference" : "OutlineInverseTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x3DF31B31"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentNegativeActive",
+      "name" : "light.outline.inverse.transparent-negative-active",
+      "reference" : "OutlineInverseTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x56FF293E"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentNegativeHover",
+      "name" : "dark.outline.inverse.transparent-negative-hover",
+      "reference" : "OutlineInverseTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentNegativeHover",
+      "name" : "light.outline.inverse.transparent-negative-hover",
+      "reference" : "OutlineInverseTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlineTransparentPositive",
+      "name" : "dark.outline.inverse.transparent-positive",
+      "reference" : "OutlineInverseTransparentPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPositive",
+      "type" : "color",
+      "value" : "0x330F8E25"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlineTransparentPositive",
+      "name" : "light.outline.inverse.transparent-positive",
+      "reference" : "OutlineInverseTransparentPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPositive",
+      "type" : "color",
+      "value" : "0x471A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlineTransparentPositiveActive",
+      "name" : "dark.outline.inverse.transparent-positive-active",
+      "reference" : "OutlineInverseTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x3D108E25"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlineTransparentPositiveActive",
+      "name" : "light.outline.inverse.transparent-positive-active",
+      "reference" : "OutlineInverseTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x561A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlineTransparentPositiveHover",
+      "name" : "dark.outline.inverse.transparent-positive-hover",
+      "reference" : "OutlineInverseTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0xFF108E25"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки успех",
+      "displayName" : "inverseOutlineTransparentPositiveHover",
+      "name" : "light.outline.inverse.transparent-positive-hover",
+      "reference" : "OutlineInverseTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentPrimary",
+      "name" : "dark.outline.inverse.transparent-primary",
+      "reference" : "OutlineInverseTransparentPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPrimary",
+      "type" : "color",
+      "value" : "0x1E080808"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentPrimary",
+      "name" : "light.outline.inverse.transparent-primary",
+      "reference" : "OutlineInverseTransparentPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPrimary",
+      "type" : "color",
+      "value" : "0x1FF9F9F9"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentPrimaryActive",
+      "name" : "dark.outline.inverse.transparent-primary-active",
+      "reference" : "OutlineInverseTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x25080808"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentPrimaryActive",
+      "name" : "light.outline.inverse.transparent-primary-active",
+      "reference" : "OutlineInverseTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x25FAFAFA"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentPrimaryHover",
+      "name" : "dark.outline.inverse.transparent-primary-hover",
+      "reference" : "OutlineInverseTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentPrimaryHover",
+      "name" : "light.outline.inverse.transparent-primary-hover",
+      "reference" : "OutlineInverseTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentSecondary",
+      "name" : "dark.outline.inverse.transparent-secondary",
+      "reference" : "OutlineInverseTransparentSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentSecondary",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentSecondary",
+      "name" : "light.outline.inverse.transparent-secondary",
+      "reference" : "OutlineInverseTransparentSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentSecondary",
+      "type" : "color",
+      "value" : "0x47F9F9F9"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentSecondaryActive",
+      "name" : "dark.outline.inverse.transparent-secondary-active",
+      "reference" : "OutlineInverseTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x56080808"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentSecondaryActive",
+      "name" : "light.outline.inverse.transparent-secondary-active",
+      "reference" : "OutlineInverseTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x56FAFAFA"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentSecondaryHover",
+      "name" : "dark.outline.inverse.transparent-secondary-hover",
+      "reference" : "OutlineInverseTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentSecondaryHover",
+      "name" : "light.outline.inverse.transparent-secondary-hover",
+      "reference" : "OutlineInverseTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentTertiary",
+      "name" : "dark.outline.inverse.transparent-tertiary",
+      "reference" : "OutlineInverseTransparentTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentTertiary",
+      "type" : "color",
+      "value" : "0x8E080808"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentTertiary",
+      "name" : "light.outline.inverse.transparent-tertiary",
+      "reference" : "OutlineInverseTransparentTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentTertiary",
+      "type" : "color",
+      "value" : "0x8FF9F9F9"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentTertiaryActive",
+      "name" : "dark.outline.inverse.transparent-tertiary-active",
+      "reference" : "OutlineInverseTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0xAB080808"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentTertiaryActive",
+      "name" : "light.outline.inverse.transparent-tertiary-active",
+      "reference" : "OutlineInverseTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0xABFAFAFA"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentTertiaryHover",
+      "name" : "dark.outline.inverse.transparent-tertiary-hover",
+      "reference" : "OutlineInverseTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный цвет обводки",
+      "displayName" : "inverseOutlineTransparentTertiaryHover",
+      "name" : "light.outline.inverse.transparent-tertiary-hover",
+      "reference" : "OutlineInverseTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentWarning",
+      "name" : "dark.outline.inverse.transparent-warning",
+      "reference" : "OutlineInverseTransparentWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentWarning",
+      "type" : "color",
+      "value" : "0x33E85602"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentWarning",
+      "name" : "light.outline.inverse.transparent-warning",
+      "reference" : "OutlineInverseTransparentWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentWarning",
+      "type" : "color",
+      "value" : "0x47FA5F05"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentWarningActive",
+      "name" : "dark.outline.inverse.transparent-warning-active",
+      "reference" : "OutlineInverseTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x3DE85702"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentWarningActive",
+      "name" : "light.outline.inverse.transparent-warning-active",
+      "reference" : "OutlineInverseTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x56FA5F05"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentWarningHover",
+      "name" : "dark.outline.inverse.transparent-warning-hover",
+      "reference" : "OutlineInverseTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentWarningHover",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineTransparentWarningHover",
+      "name" : "light.outline.inverse.transparent-warning-hover",
+      "reference" : "OutlineInverseTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseTransparentWarningHover",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarning",
+      "name" : "dark.outline.inverse.warning",
+      "reference" : "OutlineInverseWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarning",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarning",
+      "name" : "light.outline.inverse.warning",
+      "reference" : "OutlineInverseWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarning",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningActive",
+      "name" : "dark.outline.inverse.warning-active",
+      "reference" : "OutlineInverseWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningActive",
+      "type" : "color",
+      "value" : "0xFFCA4B02"
+    },
+    {
+      "description" : "Инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningActive",
+      "name" : "light.outline.inverse.warning-active",
+      "reference" : "OutlineInverseWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningActive",
+      "type" : "color",
+      "value" : "0xFFFA5700"
+    },
+    {
+      "description" : "Инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningHover",
+      "name" : "dark.outline.inverse.warning-hover",
+      "reference" : "OutlineInverseWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningHover",
+      "type" : "color",
+      "value" : "0xFFFD650D"
+    },
+    {
+      "description" : "Инвертированный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningHover",
+      "name" : "light.outline.inverse.warning-hover",
+      "reference" : "OutlineInverseWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF8B4D"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningMinor",
+      "name" : "dark.outline.inverse.warning-minor",
+      "reference" : "OutlineInverseWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFD9C68"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningMinor",
+      "name" : "light.outline.inverse.warning-minor",
+      "reference" : "OutlineInverseWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningMinor",
+      "type" : "color",
+      "value" : "0xFF85380C"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningMinorActive",
+      "name" : "dark.outline.inverse.warning-minor-active",
+      "reference" : "OutlineInverseWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFC884A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningMinorActive",
+      "name" : "light.outline.inverse.warning-minor-active",
+      "reference" : "OutlineInverseWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFA84710"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningMinorHover",
+      "name" : "dark.outline.inverse.warning-minor-hover",
+      "reference" : "OutlineInverseWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFDB086"
+    },
+    {
+      "description" : "Инвертированный минорный цвет обводки предупреждение",
+      "displayName" : "inverseOutlineWarningMinorHover",
+      "name" : "light.outline.inverse.warning-minor-hover",
+      "reference" : "OutlineInverseWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineInverseWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFCD5713"
+    },
+    {
+      "description" : "Акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccent",
+      "name" : "dark.outline.on-dark.accent",
+      "reference" : "OutlineOnDarkAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccent",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccent",
+      "name" : "light.outline.on-dark.accent",
+      "reference" : "OutlineOnDarkAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccent",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentActive",
+      "name" : "dark.outline.on-dark.accent-active",
+      "reference" : "OutlineOnDarkAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentActive",
+      "type" : "color",
+      "value" : "0xFF1F9835"
+    },
+    {
+      "description" : "Акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentActive",
+      "name" : "light.outline.on-dark.accent-active",
+      "reference" : "OutlineOnDarkAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentActive",
+      "type" : "color",
+      "value" : "0xFF1D9032"
+    },
+    {
+      "description" : "Акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentHover",
+      "name" : "dark.outline.on-dark.accent-hover",
+      "reference" : "OutlineOnDarkAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentHover",
+      "type" : "color",
+      "value" : "0xFF2ACB47"
+    },
+    {
+      "description" : "Акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentHover",
+      "name" : "light.outline.on-dark.accent-hover",
+      "reference" : "OutlineOnDarkAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentHover",
+      "type" : "color",
+      "value" : "0xFF2BD44A"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentMinor",
+      "name" : "dark.outline.on-dark.accent-minor",
+      "reference" : "OutlineOnDarkAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentMinor",
+      "name" : "light.outline.on-dark.accent-minor",
+      "reference" : "OutlineOnDarkAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentMinorActive",
+      "name" : "dark.outline.on-dark.accent-minor-active",
+      "reference" : "OutlineOnDarkAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF0C7920"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentMinorActive",
+      "name" : "light.outline.on-dark.accent-minor-active",
+      "reference" : "OutlineOnDarkAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF0D8222"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentMinorHover",
+      "name" : "dark.outline.on-dark.accent-minor-hover",
+      "reference" : "OutlineOnDarkAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF0F9527"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineAccentMinorHover",
+      "name" : "light.outline.on-dark.accent-minor-hover",
+      "reference" : "OutlineOnDarkAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF11A72C"
+    },
+    {
+      "description" : "Бесцветная обводка на темном фоне",
+      "displayName" : "onDarkOutlineClear",
+      "name" : "dark.outline.on-dark.clear",
+      "reference" : "OutlineOnDarkClear",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на темном фоне",
+      "displayName" : "onDarkOutlineClear",
+      "name" : "light.outline.on-dark.clear",
+      "reference" : "OutlineOnDarkClear",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на темном фоне",
+      "displayName" : "onDarkOutlineClearActive",
+      "name" : "dark.outline.on-dark.clear-active",
+      "reference" : "OutlineOnDarkClearActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на темном фоне",
+      "displayName" : "onDarkOutlineClearActive",
+      "name" : "light.outline.on-dark.clear-active",
+      "reference" : "OutlineOnDarkClearActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на темном фоне",
+      "displayName" : "onDarkOutlineClearHover",
+      "name" : "dark.outline.on-dark.clear-hover",
+      "reference" : "OutlineOnDarkClearHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на темном фоне",
+      "displayName" : "onDarkOutlineClearHover",
+      "name" : "light.outline.on-dark.clear-hover",
+      "reference" : "OutlineOnDarkClearHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoActive",
+      "name" : "dark.outline.on-dark.info-active",
+      "reference" : "OutlineOnDarkInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoActive",
+      "type" : "color",
+      "value" : "0xFF0E8ADD"
+    },
+    {
+      "description" : "Цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoActive",
+      "name" : "light.outline.on-dark.info-active",
+      "reference" : "OutlineOnDarkInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoActive",
+      "type" : "color",
+      "value" : "0xFF0D84D3"
+    },
+    {
+      "description" : "Цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoHover",
+      "name" : "dark.outline.on-dark.info-hover",
+      "reference" : "OutlineOnDarkInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoHover",
+      "type" : "color",
+      "value" : "0xFF66BCF5"
+    },
+    {
+      "description" : "Цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoHover",
+      "name" : "light.outline.on-dark.info-hover",
+      "reference" : "OutlineOnDarkInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoHover",
+      "type" : "color",
+      "value" : "0xFF3FABF3"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoMinor",
+      "name" : "dark.outline.on-dark.info-minor",
+      "reference" : "OutlineOnDarkInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0D5382"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoMinor",
+      "name" : "light.outline.on-dark.info-minor",
+      "reference" : "OutlineOnDarkInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0D5382"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoMinorActive",
+      "name" : "dark.outline.on-dark.info-minor-active",
+      "reference" : "OutlineOnDarkInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF10659E"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoMinorActive",
+      "name" : "light.outline.on-dark.info-minor-active",
+      "reference" : "OutlineOnDarkInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF116BA7"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoMinorHover",
+      "name" : "dark.outline.on-dark.info-minor-hover",
+      "reference" : "OutlineOnDarkInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF1277BA"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineInfoMinorHover",
+      "name" : "light.outline.on-dark.info-minor-hover",
+      "reference" : "OutlineOnDarkInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF1483CC"
+    },
+    {
+      "description" : "Цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegative",
+      "name" : "dark.outline.on-dark.negative",
+      "reference" : "OutlineOnDarkNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegative",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegative",
+      "name" : "light.outline.on-dark.negative",
+      "reference" : "OutlineOnDarkNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegative",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeActive",
+      "name" : "dark.outline.on-dark.negative-active",
+      "reference" : "OutlineOnDarkNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF1F35"
+    },
+    {
+      "description" : "Цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeActive",
+      "name" : "light.outline.on-dark.negative-active",
+      "reference" : "OutlineOnDarkNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF142C"
+    },
+    {
+      "description" : "Цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeHover",
+      "name" : "dark.outline.on-dark.negative-hover",
+      "reference" : "OutlineOnDarkNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF5C6C"
+    },
+    {
+      "description" : "Цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeHover",
+      "name" : "light.outline.on-dark.negative-hover",
+      "reference" : "OutlineOnDarkNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF6675"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeMinor",
+      "name" : "dark.outline.on-dark.negative-minor",
+      "reference" : "OutlineOnDarkNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF9C1422"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeMinor",
+      "name" : "light.outline.on-dark.negative-minor",
+      "reference" : "OutlineOnDarkNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF9C1422"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeMinorActive",
+      "name" : "dark.outline.on-dark.negative-minor-active",
+      "reference" : "OutlineOnDarkNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF83111C"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeMinorActive",
+      "name" : "light.outline.on-dark.negative-minor-active",
+      "reference" : "OutlineOnDarkNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF7A101A"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeMinorHover",
+      "name" : "dark.outline.on-dark.negative-minor-hover",
+      "reference" : "OutlineOnDarkNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFB91828"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на темном фоне",
+      "displayName" : "onDarkOutlineNegativeMinorHover",
+      "name" : "light.outline.on-dark.negative-minor-hover",
+      "reference" : "OutlineOnDarkNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFC2192A"
+    },
+    {
+      "description" : "Цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositive",
+      "name" : "dark.outline.on-dark.positive",
+      "reference" : "OutlineOnDarkPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositive",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositive",
+      "name" : "light.outline.on-dark.positive",
+      "reference" : "OutlineOnDarkPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositive",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveActive",
+      "name" : "dark.outline.on-dark.positive-active",
+      "reference" : "OutlineOnDarkPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveActive",
+      "type" : "color",
+      "value" : "0xFF1F9835"
+    },
+    {
+      "description" : "Цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveActive",
+      "name" : "light.outline.on-dark.positive-active",
+      "reference" : "OutlineOnDarkPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveActive",
+      "type" : "color",
+      "value" : "0xFF1D9032"
+    },
+    {
+      "description" : "Цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveHover",
+      "name" : "dark.outline.on-dark.positive-hover",
+      "reference" : "OutlineOnDarkPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveHover",
+      "type" : "color",
+      "value" : "0xFF2ACB47"
+    },
+    {
+      "description" : "Цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveHover",
+      "name" : "light.outline.on-dark.positive-hover",
+      "reference" : "OutlineOnDarkPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveHover",
+      "type" : "color",
+      "value" : "0xFF2BD44A"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveMinor",
+      "name" : "dark.outline.on-dark.positive-minor",
+      "reference" : "OutlineOnDarkPositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveMinor",
+      "name" : "light.outline.on-dark.positive-minor",
+      "reference" : "OutlineOnDarkPositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveMinorActive",
+      "name" : "dark.outline.on-dark.positive-minor-active",
+      "reference" : "OutlineOnDarkPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF0C7920"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveMinorActive",
+      "name" : "light.outline.on-dark.positive-minor-active",
+      "reference" : "OutlineOnDarkPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF0D8222"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveMinorHover",
+      "name" : "dark.outline.on-dark.positive-minor-hover",
+      "reference" : "OutlineOnDarkPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF0F9527"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlinePositiveMinorHover",
+      "name" : "light.outline.on-dark.positive-minor-hover",
+      "reference" : "OutlineOnDarkPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF11A72C"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkOutlineSolidDefault",
+      "name" : "dark.outline.on-dark.solid-default",
+      "reference" : "OutlineOnDarkSolidDefault",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidDefault",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkOutlineSolidDefault",
+      "name" : "light.outline.on-dark.solid-default",
+      "reference" : "OutlineOnDarkSolidDefault",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidDefault",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkOutlineSolidDefaultActive",
+      "name" : "dark.outline.on-dark.solid-default-active",
+      "reference" : "OutlineOnDarkSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFE0E0E0"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkOutlineSolidDefaultActive",
+      "name" : "light.outline.on-dark.solid-default-active",
+      "reference" : "OutlineOnDarkSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFC7C7C7"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkOutlineSolidDefaultHover",
+      "name" : "dark.outline.on-dark.solid-default-hover",
+      "reference" : "OutlineOnDarkSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFC7C7C7"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkOutlineSolidDefaultHover",
+      "name" : "light.outline.on-dark.solid-default-hover",
+      "reference" : "OutlineOnDarkSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidPrimary",
+      "name" : "dark.outline.on-dark.solid-primary",
+      "reference" : "OutlineOnDarkSolidPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidPrimary",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidPrimary",
+      "name" : "light.outline.on-dark.solid-primary",
+      "reference" : "OutlineOnDarkSolidPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidPrimary",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidPrimaryActive",
+      "name" : "dark.outline.on-dark.solid-primary-active",
+      "reference" : "OutlineOnDarkSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFADADAD"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidPrimaryActive",
+      "name" : "light.outline.on-dark.solid-primary-active",
+      "reference" : "OutlineOnDarkSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFF4F4F4F"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidPrimaryHover",
+      "name" : "dark.outline.on-dark.solid-primary-hover",
+      "reference" : "OutlineOnDarkSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidPrimaryHover",
+      "name" : "light.outline.on-dark.solid-primary-hover",
+      "reference" : "OutlineOnDarkSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF787878"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidSecondary",
+      "name" : "dark.outline.on-dark.solid-secondary",
+      "reference" : "OutlineOnDarkSolidSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidSecondary",
+      "name" : "light.outline.on-dark.solid-secondary",
+      "reference" : "OutlineOnDarkSolidSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidSecondaryActive",
+      "name" : "dark.outline.on-dark.solid-secondary-active",
+      "reference" : "OutlineOnDarkSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFFA1A1A1"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidSecondaryActive",
+      "name" : "light.outline.on-dark.solid-secondary-active",
+      "reference" : "OutlineOnDarkSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF5E5E5E"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidSecondaryHover",
+      "name" : "dark.outline.on-dark.solid-secondary-hover",
+      "reference" : "OutlineOnDarkSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidSecondaryHover",
+      "name" : "light.outline.on-dark.solid-secondary-hover",
+      "reference" : "OutlineOnDarkSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF878787"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidTertiary",
+      "name" : "dark.outline.on-dark.solid-tertiary",
+      "reference" : "OutlineOnDarkSolidTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF707070"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidTertiary",
+      "name" : "light.outline.on-dark.solid-tertiary",
+      "reference" : "OutlineOnDarkSolidTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF707070"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidTertiaryActive",
+      "name" : "dark.outline.on-dark.solid-tertiary-active",
+      "reference" : "OutlineOnDarkSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF737373"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidTertiaryActive",
+      "name" : "light.outline.on-dark.solid-tertiary-active",
+      "reference" : "OutlineOnDarkSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF595959"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidTertiaryHover",
+      "name" : "dark.outline.on-dark.solid-tertiary-hover",
+      "reference" : "OutlineOnDarkSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineSolidTertiaryHover",
+      "name" : "light.outline.on-dark.solid-tertiary-hover",
+      "reference" : "OutlineOnDarkSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentAccent",
+      "name" : "dark.outline.on-dark.transparent-accent",
+      "reference" : "OutlineOnDarkTransparentAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentAccent",
+      "type" : "color",
+      "value" : "0x4723B23D"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentAccent",
+      "name" : "light.outline.on-dark.transparent-accent",
+      "reference" : "OutlineOnDarkTransparentAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentAccent",
+      "type" : "color",
+      "value" : "0x471A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentAccentActive",
+      "name" : "dark.outline.on-dark.transparent-accent-active",
+      "reference" : "OutlineOnDarkTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x5624B23E"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentAccentActive",
+      "name" : "light.outline.on-dark.transparent-accent-active",
+      "reference" : "OutlineOnDarkTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x561A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentAccentHover",
+      "name" : "dark.outline.on-dark.transparent-accent-hover",
+      "reference" : "OutlineOnDarkTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentAccentHover",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentAccentHover",
+      "name" : "light.outline.on-dark.transparent-accent-hover",
+      "reference" : "OutlineOnDarkTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentAccentHover",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineTransparentInfo",
+      "name" : "dark.outline.on-dark.transparent-info",
+      "reference" : "OutlineOnDarkTransparentInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentInfo",
+      "type" : "color",
+      "value" : "0x47189AF0"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineTransparentInfo",
+      "name" : "light.outline.on-dark.transparent-info",
+      "reference" : "OutlineOnDarkTransparentInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentInfo",
+      "type" : "color",
+      "value" : "0x47118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineTransparentInfoActive",
+      "name" : "dark.outline.on-dark.transparent-info-active",
+      "reference" : "OutlineOnDarkTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x56199AF0"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineTransparentInfoActive",
+      "name" : "light.outline.on-dark.transparent-info-active",
+      "reference" : "OutlineOnDarkTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x56118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineTransparentInfoHover",
+      "name" : "dark.outline.on-dark.transparent-info-hover",
+      "reference" : "OutlineOnDarkTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentInfoHover",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на темном фоне",
+      "displayName" : "onDarkOutlineTransparentInfoHover",
+      "name" : "light.outline.on-dark.transparent-info-hover",
+      "reference" : "OutlineOnDarkTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentInfoHover",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentNegative",
+      "name" : "dark.outline.on-dark.transparent-negative",
+      "reference" : "OutlineOnDarkTransparentNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentNegative",
+      "type" : "color",
+      "value" : "0x47FF3C51"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentNegative",
+      "name" : "light.outline.on-dark.transparent-negative",
+      "reference" : "OutlineOnDarkTransparentNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentNegative",
+      "type" : "color",
+      "value" : "0x47FF293E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentNegativeActive",
+      "name" : "dark.outline.on-dark.transparent-negative-active",
+      "reference" : "OutlineOnDarkTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x56FF3D51"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentNegativeActive",
+      "name" : "light.outline.on-dark.transparent-negative-active",
+      "reference" : "OutlineOnDarkTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x56FF293E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentNegativeHover",
+      "name" : "dark.outline.on-dark.transparent-negative-hover",
+      "reference" : "OutlineOnDarkTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentNegativeHover",
+      "name" : "light.outline.on-dark.transparent-negative-hover",
+      "reference" : "OutlineOnDarkTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPositive",
+      "name" : "dark.outline.on-dark.transparent-positive",
+      "reference" : "OutlineOnDarkTransparentPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPositive",
+      "type" : "color",
+      "value" : "0x4723B23D"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPositive",
+      "name" : "light.outline.on-dark.transparent-positive",
+      "reference" : "OutlineOnDarkTransparentPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPositive",
+      "type" : "color",
+      "value" : "0x471A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPositiveActive",
+      "name" : "dark.outline.on-dark.transparent-positive-active",
+      "reference" : "OutlineOnDarkTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x5624B23E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPositiveActive",
+      "name" : "light.outline.on-dark.transparent-positive-active",
+      "reference" : "OutlineOnDarkTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x561A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPositiveHover",
+      "name" : "dark.outline.on-dark.transparent-positive-hover",
+      "reference" : "OutlineOnDarkTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPositiveHover",
+      "name" : "light.outline.on-dark.transparent-positive-hover",
+      "reference" : "OutlineOnDarkTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPrimary",
+      "name" : "dark.outline.on-dark.transparent-primary",
+      "reference" : "OutlineOnDarkTransparentPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPrimary",
+      "type" : "color",
+      "value" : "0x1FFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPrimary",
+      "name" : "light.outline.on-dark.transparent-primary",
+      "reference" : "OutlineOnDarkTransparentPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPrimary",
+      "type" : "color",
+      "value" : "0x1FF9F9F9"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPrimaryActive",
+      "name" : "dark.outline.on-dark.transparent-primary-active",
+      "reference" : "OutlineOnDarkTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x25FFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPrimaryActive",
+      "name" : "light.outline.on-dark.transparent-primary-active",
+      "reference" : "OutlineOnDarkTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x25FAFAFA"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPrimaryHover",
+      "name" : "dark.outline.on-dark.transparent-primary-hover",
+      "reference" : "OutlineOnDarkTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentPrimaryHover",
+      "name" : "light.outline.on-dark.transparent-primary-hover",
+      "reference" : "OutlineOnDarkTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentSecondary",
+      "name" : "dark.outline.on-dark.transparent-secondary",
+      "reference" : "OutlineOnDarkTransparentSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentSecondary",
+      "type" : "color",
+      "value" : "0x47F9F9F9"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentSecondary",
+      "name" : "light.outline.on-dark.transparent-secondary",
+      "reference" : "OutlineOnDarkTransparentSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentSecondary",
+      "type" : "color",
+      "value" : "0x47FFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentSecondaryActive",
+      "name" : "dark.outline.on-dark.transparent-secondary-active",
+      "reference" : "OutlineOnDarkTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x56FAFAFA"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentSecondaryActive",
+      "name" : "light.outline.on-dark.transparent-secondary-active",
+      "reference" : "OutlineOnDarkTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x56FFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentSecondaryHover",
+      "name" : "dark.outline.on-dark.transparent-secondary-hover",
+      "reference" : "OutlineOnDarkTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentSecondaryHover",
+      "name" : "light.outline.on-dark.transparent-secondary-hover",
+      "reference" : "OutlineOnDarkTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentTertiary",
+      "name" : "dark.outline.on-dark.transparent-tertiary",
+      "reference" : "OutlineOnDarkTransparentTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentTertiary",
+      "type" : "color",
+      "value" : "0x8FF9F9F9"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentTertiary",
+      "name" : "light.outline.on-dark.transparent-tertiary",
+      "reference" : "OutlineOnDarkTransparentTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentTertiary",
+      "type" : "color",
+      "value" : "0x8FFFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentTertiaryActive",
+      "name" : "dark.outline.on-dark.transparent-tertiary-active",
+      "reference" : "OutlineOnDarkTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0xABFAFAFA"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentTertiaryActive",
+      "name" : "light.outline.on-dark.transparent-tertiary-active",
+      "reference" : "OutlineOnDarkTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0xABFFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentTertiaryHover",
+      "name" : "dark.outline.on-dark.transparent-tertiary-hover",
+      "reference" : "OutlineOnDarkTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на темном фоне",
+      "displayName" : "onDarkOutlineTransparentTertiaryHover",
+      "name" : "light.outline.on-dark.transparent-tertiary-hover",
+      "reference" : "OutlineOnDarkTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentWarning",
+      "name" : "dark.outline.on-dark.transparent-warning",
+      "reference" : "OutlineOnDarkTransparentWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentWarning",
+      "type" : "color",
+      "value" : "0x47FF6F23"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentWarning",
+      "name" : "light.outline.on-dark.transparent-warning",
+      "reference" : "OutlineOnDarkTransparentWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentWarning",
+      "type" : "color",
+      "value" : "0x47FA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentWarningActive",
+      "name" : "dark.outline.on-dark.transparent-warning-active",
+      "reference" : "OutlineOnDarkTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x56FF7024"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentWarningActive",
+      "name" : "light.outline.on-dark.transparent-warning-active",
+      "reference" : "OutlineOnDarkTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x56FA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentWarningHover",
+      "name" : "dark.outline.on-dark.transparent-warning-hover",
+      "reference" : "OutlineOnDarkTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineTransparentWarningHover",
+      "name" : "light.outline.on-dark.transparent-warning-hover",
+      "reference" : "OutlineOnDarkTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkTransparentWarningHover",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarning",
+      "name" : "dark.outline.on-dark.warning",
+      "reference" : "OutlineOnDarkWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarning",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarning",
+      "name" : "light.outline.on-dark.warning",
+      "reference" : "OutlineOnDarkWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarning",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningActive",
+      "name" : "dark.outline.on-dark.warning-active",
+      "reference" : "OutlineOnDarkWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningActive",
+      "type" : "color",
+      "value" : "0xFFFF5D05"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningActive",
+      "name" : "light.outline.on-dark.warning-active",
+      "reference" : "OutlineOnDarkWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningActive",
+      "type" : "color",
+      "value" : "0xFFFA5700"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningHover",
+      "name" : "dark.outline.on-dark.warning-hover",
+      "reference" : "OutlineOnDarkWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF8442"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningHover",
+      "name" : "light.outline.on-dark.warning-hover",
+      "reference" : "OutlineOnDarkWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF8B4D"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningMinor",
+      "name" : "dark.outline.on-dark.warning-minor",
+      "reference" : "OutlineOnDarkWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningMinor",
+      "type" : "color",
+      "value" : "0xFF85380C"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningMinor",
+      "name" : "light.outline.on-dark.warning-minor",
+      "reference" : "OutlineOnDarkWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningMinor",
+      "type" : "color",
+      "value" : "0xFF85380C"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningMinorActive",
+      "name" : "dark.outline.on-dark.warning-minor-active",
+      "reference" : "OutlineOnDarkWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFF9F440F"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningMinorActive",
+      "name" : "light.outline.on-dark.warning-minor-active",
+      "reference" : "OutlineOnDarkWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFA84710"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningMinorHover",
+      "name" : "dark.outline.on-dark.warning-minor-hover",
+      "reference" : "OutlineOnDarkWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFBB4F11"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на темном фоне",
+      "displayName" : "onDarkOutlineWarningMinorHover",
+      "name" : "light.outline.on-dark.warning-minor-hover",
+      "reference" : "OutlineOnDarkWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnDarkWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFCD5713"
+    },
+    {
+      "description" : "Акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccent",
+      "name" : "dark.outline.on-light.accent",
+      "reference" : "OutlineOnLightAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccent",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccent",
+      "name" : "light.outline.on-light.accent",
+      "reference" : "OutlineOnLightAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccent",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentActive",
+      "name" : "dark.outline.on-light.accent-active",
+      "reference" : "OutlineOnLightAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentActive",
+      "type" : "color",
+      "value" : "0xFF0D731E"
+    },
+    {
+      "description" : "Акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentActive",
+      "name" : "light.outline.on-light.accent-active",
+      "reference" : "OutlineOnLightAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentActive",
+      "type" : "color",
+      "value" : "0xFF0C6A1B"
+    },
+    {
+      "description" : "Акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentHover",
+      "name" : "dark.outline.on-light.accent-hover",
+      "reference" : "OutlineOnLightAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentHover",
+      "type" : "color",
+      "value" : "0xFF13AA2C"
+    },
+    {
+      "description" : "Акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentHover",
+      "name" : "light.outline.on-light.accent-hover",
+      "reference" : "OutlineOnLightAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentHover",
+      "type" : "color",
+      "value" : "0xFF14B32E"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentMinor",
+      "name" : "dark.outline.on-light.accent-minor",
+      "reference" : "OutlineOnLightAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentMinor",
+      "name" : "light.outline.on-light.accent-minor",
+      "reference" : "OutlineOnLightAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentMinorActive",
+      "name" : "dark.outline.on-light.accent-minor-active",
+      "reference" : "OutlineOnLightAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF23B83E"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentMinorActive",
+      "name" : "light.outline.on-light.accent-minor-active",
+      "reference" : "OutlineOnLightAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF21B03C"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentMinorHover",
+      "name" : "dark.outline.on-light.accent-minor-hover",
+      "reference" : "OutlineOnLightAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF3EDA5B"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineAccentMinorHover",
+      "name" : "light.outline.on-light.accent-minor-hover",
+      "reference" : "OutlineOnLightAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF47DC62"
+    },
+    {
+      "description" : "Бесцветная обводка на светлом фоне",
+      "displayName" : "onLightOutlineClear",
+      "name" : "dark.outline.on-light.clear",
+      "reference" : "OutlineOnLightClear",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на светлом фоне",
+      "displayName" : "onLightOutlineClear",
+      "name" : "light.outline.on-light.clear",
+      "reference" : "OutlineOnLightClear",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на светлом фоне",
+      "displayName" : "onLightOutlineClearActive",
+      "name" : "dark.outline.on-light.clear-active",
+      "reference" : "OutlineOnLightClearActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на светлом фоне",
+      "displayName" : "onLightOutlineClearActive",
+      "name" : "light.outline.on-light.clear-active",
+      "reference" : "OutlineOnLightClearActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на светлом фоне",
+      "displayName" : "onLightOutlineClearHover",
+      "name" : "dark.outline.on-light.clear-hover",
+      "reference" : "OutlineOnLightClearHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Бесцветная обводка на светлом фоне",
+      "displayName" : "onLightOutlineClearHover",
+      "name" : "light.outline.on-light.clear-hover",
+      "reference" : "OutlineOnLightClearHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfo",
+      "name" : "dark.outline.on-light.info",
+      "reference" : "OutlineOnLightInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfo",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfo",
+      "name" : "light.outline.on-light.info",
+      "reference" : "OutlineOnLightInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfo",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoActive",
+      "name" : "dark.outline.on-light.info-active",
+      "reference" : "OutlineOnLightInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoActive",
+      "type" : "color",
+      "value" : "0xFF096CAE"
+    },
+    {
+      "description" : "Цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoActive",
+      "name" : "light.outline.on-light.info-active",
+      "reference" : "OutlineOnLightInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoActive",
+      "type" : "color",
+      "value" : "0xFF0966A5"
+    },
+    {
+      "description" : "Цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoHover",
+      "name" : "dark.outline.on-light.info-hover",
+      "reference" : "OutlineOnLightInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoHover",
+      "type" : "color",
+      "value" : "0xFF34A7F4"
+    },
+    {
+      "description" : "Цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoHover",
+      "name" : "light.outline.on-light.info-hover",
+      "reference" : "OutlineOnLightInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoHover",
+      "type" : "color",
+      "value" : "0xFF0D96F2"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoMinor",
+      "name" : "dark.outline.on-light.info-minor",
+      "reference" : "OutlineOnLightInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoMinor",
+      "type" : "color",
+      "value" : "0xFF52BAFF"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoMinor",
+      "name" : "light.outline.on-light.info-minor",
+      "reference" : "OutlineOnLightInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoMinor",
+      "type" : "color",
+      "value" : "0xFF52BAFF"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoMinorActive",
+      "name" : "dark.outline.on-light.info-minor-active",
+      "reference" : "OutlineOnLightInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF33ADFF"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoMinorActive",
+      "name" : "light.outline.on-light.info-minor-active",
+      "reference" : "OutlineOnLightInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF29A9FF"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoMinorHover",
+      "name" : "dark.outline.on-light.info-minor-hover",
+      "reference" : "OutlineOnLightInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFFA3DAFF"
+    },
+    {
+      "description" : "Минорный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineInfoMinorHover",
+      "name" : "light.outline.on-light.info-minor-hover",
+      "reference" : "OutlineOnLightInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF7ACAFF"
+    },
+    {
+      "description" : "Цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegative",
+      "name" : "dark.outline.on-light.negative",
+      "reference" : "OutlineOnLightNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegative",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegative",
+      "name" : "light.outline.on-light.negative",
+      "reference" : "OutlineOnLightNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegative",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeActive",
+      "name" : "dark.outline.on-light.negative-active",
+      "reference" : "OutlineOnLightNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeActive",
+      "type" : "color",
+      "value" : "0xFFE40C22"
+    },
+    {
+      "description" : "Цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeActive",
+      "name" : "light.outline.on-light.negative-active",
+      "reference" : "OutlineOnLightNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeActive",
+      "type" : "color",
+      "value" : "0xFFDA0B20"
+    },
+    {
+      "description" : "Цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeHover",
+      "name" : "dark.outline.on-light.negative-hover",
+      "reference" : "OutlineOnLightNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF5384B"
+    },
+    {
+      "description" : "Цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeHover",
+      "name" : "light.outline.on-light.negative-hover",
+      "reference" : "OutlineOnLightNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF54254"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeMinor",
+      "name" : "dark.outline.on-light.negative-minor",
+      "reference" : "OutlineOnLightNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFF8F9A"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeMinor",
+      "name" : "light.outline.on-light.negative-minor",
+      "reference" : "OutlineOnLightNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFF8F9A"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeMinorActive",
+      "name" : "dark.outline.on-light.negative-minor-active",
+      "reference" : "OutlineOnLightNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFF707E"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeMinorActive",
+      "name" : "light.outline.on-light.negative-minor-active",
+      "reference" : "OutlineOnLightNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFF6675"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeMinorHover",
+      "name" : "dark.outline.on-light.negative-minor-hover",
+      "reference" : "OutlineOnLightNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFADB6"
+    },
+    {
+      "description" : "Минорный цвет обводки ошибка на светлом фоне",
+      "displayName" : "onLightOutlineNegativeMinorHover",
+      "name" : "light.outline.on-light.negative-minor-hover",
+      "reference" : "OutlineOnLightNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFB8BF"
+    },
+    {
+      "description" : "Цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositive",
+      "name" : "dark.outline.on-light.positive",
+      "reference" : "OutlineOnLightPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositive",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositive",
+      "name" : "light.outline.on-light.positive",
+      "reference" : "OutlineOnLightPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositive",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveActive",
+      "name" : "dark.outline.on-light.positive-active",
+      "reference" : "OutlineOnLightPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveActive",
+      "type" : "color",
+      "value" : "0xFF0D731E"
+    },
+    {
+      "description" : "Цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveActive",
+      "name" : "light.outline.on-light.positive-active",
+      "reference" : "OutlineOnLightPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveActive",
+      "type" : "color",
+      "value" : "0xFF0C6A1B"
+    },
+    {
+      "description" : "Цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveHover",
+      "name" : "dark.outline.on-light.positive-hover",
+      "reference" : "OutlineOnLightPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveHover",
+      "type" : "color",
+      "value" : "0xFF13AA2C"
+    },
+    {
+      "description" : "Цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveHover",
+      "name" : "light.outline.on-light.positive-hover",
+      "reference" : "OutlineOnLightPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveHover",
+      "type" : "color",
+      "value" : "0xFF14B32E"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveMinor",
+      "name" : "dark.outline.on-light.positive-minor",
+      "reference" : "OutlineOnLightPositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveMinor",
+      "name" : "light.outline.on-light.positive-minor",
+      "reference" : "OutlineOnLightPositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveMinorActive",
+      "name" : "dark.outline.on-light.positive-minor-active",
+      "reference" : "OutlineOnLightPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF23B83E"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveMinorActive",
+      "name" : "light.outline.on-light.positive-minor-active",
+      "reference" : "OutlineOnLightPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF21B03C"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveMinorHover",
+      "name" : "dark.outline.on-light.positive-minor-hover",
+      "reference" : "OutlineOnLightPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF3EDA5B"
+    },
+    {
+      "description" : "Минорный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlinePositiveMinorHover",
+      "name" : "light.outline.on-light.positive-minor-hover",
+      "reference" : "OutlineOnLightPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF47DC62"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightOutlineSolidDefault",
+      "name" : "dark.outline.on-light.solid-default",
+      "reference" : "OutlineOnLightSolidDefault",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidDefault",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightOutlineSolidDefault",
+      "name" : "light.outline.on-light.solid-default",
+      "reference" : "OutlineOnLightSolidDefault",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidDefault",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightOutlineSolidDefaultActive",
+      "name" : "dark.outline.on-light.solid-default-active",
+      "reference" : "OutlineOnLightSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFC7C7C7"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightOutlineSolidDefaultActive",
+      "name" : "light.outline.on-light.solid-default-active",
+      "reference" : "OutlineOnLightSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFF303030"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightOutlineSolidDefaultHover",
+      "name" : "dark.outline.on-light.solid-default-hover",
+      "reference" : "OutlineOnLightSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightOutlineSolidDefaultHover",
+      "name" : "light.outline.on-light.solid-default-hover",
+      "reference" : "OutlineOnLightSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFF595959"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidPrimary",
+      "name" : "dark.outline.on-light.solid-primary",
+      "reference" : "OutlineOnLightSolidPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidPrimary",
+      "type" : "color",
+      "value" : "0xFFDDDDDD"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidPrimary",
+      "name" : "light.outline.on-light.solid-primary",
+      "reference" : "OutlineOnLightSolidPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidPrimary",
+      "type" : "color",
+      "value" : "0xFFDDDDDD"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidPrimaryActive",
+      "name" : "dark.outline.on-light.solid-primary-active",
+      "reference" : "OutlineOnLightSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFC4C4C4"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidPrimaryActive",
+      "name" : "light.outline.on-light.solid-primary-active",
+      "reference" : "OutlineOnLightSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFB3B3B3"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidPrimaryHover",
+      "name" : "dark.outline.on-light.solid-primary-hover",
+      "reference" : "OutlineOnLightSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFABABAB"
+    },
+    {
+      "description" : "Основной непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidPrimaryHover",
+      "name" : "light.outline.on-light.solid-primary-hover",
+      "reference" : "OutlineOnLightSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidSecondary",
+      "name" : "dark.outline.on-light.solid-secondary",
+      "reference" : "OutlineOnLightSolidSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidSecondary",
+      "type" : "color",
+      "value" : "0xFFB3B3B3"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidSecondary",
+      "name" : "light.outline.on-light.solid-secondary",
+      "reference" : "OutlineOnLightSolidSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF949494"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidSecondaryActive",
+      "name" : "dark.outline.on-light.solid-secondary-active",
+      "reference" : "OutlineOnLightSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF3D3D3D"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidSecondaryActive",
+      "name" : "light.outline.on-light.solid-secondary-active",
+      "reference" : "OutlineOnLightSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF757575"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidSecondaryHover",
+      "name" : "dark.outline.on-light.solid-secondary-hover",
+      "reference" : "OutlineOnLightSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Вторичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidSecondaryHover",
+      "name" : "light.outline.on-light.solid-secondary-hover",
+      "reference" : "OutlineOnLightSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidTertiary",
+      "name" : "dark.outline.on-light.solid-tertiary",
+      "reference" : "OutlineOnLightSolidTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF707070"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidTertiary",
+      "name" : "light.outline.on-light.solid-tertiary",
+      "reference" : "OutlineOnLightSolidTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF707070"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidTertiaryActive",
+      "name" : "dark.outline.on-light.solid-tertiary-active",
+      "reference" : "OutlineOnLightSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF737373"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidTertiaryActive",
+      "name" : "light.outline.on-light.solid-tertiary-active",
+      "reference" : "OutlineOnLightSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF595959"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidTertiaryHover",
+      "name" : "dark.outline.on-light.solid-tertiary-hover",
+      "reference" : "OutlineOnLightSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный непрозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineSolidTertiaryHover",
+      "name" : "light.outline.on-light.solid-tertiary-hover",
+      "reference" : "OutlineOnLightSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentAccent",
+      "name" : "dark.outline.on-light.transparent-accent",
+      "reference" : "OutlineOnLightTransparentAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentAccent",
+      "type" : "color",
+      "value" : "0x330F8E25"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentAccent",
+      "name" : "light.outline.on-light.transparent-accent",
+      "reference" : "OutlineOnLightTransparentAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentAccent",
+      "type" : "color",
+      "value" : "0x330F8E25"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentAccentActive",
+      "name" : "dark.outline.on-light.transparent-accent-active",
+      "reference" : "OutlineOnLightTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x3D108E25"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentAccentActive",
+      "name" : "light.outline.on-light.transparent-accent-active",
+      "reference" : "OutlineOnLightTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x3D108E25"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentAccentHover",
+      "name" : "dark.outline.on-light.transparent-accent-hover",
+      "reference" : "OutlineOnLightTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentAccentHover",
+      "type" : "color",
+      "value" : "0xFF108E25"
+    },
+    {
+      "description" : "Прозрачный акцентный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentAccentHover",
+      "name" : "light.outline.on-light.transparent-accent-hover",
+      "reference" : "OutlineOnLightTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentAccentHover",
+      "type" : "color",
+      "value" : "0xFF108E25"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineTransparentInfo",
+      "name" : "dark.outline.on-light.transparent-info",
+      "reference" : "OutlineOnLightTransparentInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentInfo",
+      "type" : "color",
+      "value" : "0x330A7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineTransparentInfo",
+      "name" : "light.outline.on-light.transparent-info",
+      "reference" : "OutlineOnLightTransparentInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentInfo",
+      "type" : "color",
+      "value" : "0x330A7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineTransparentInfoActive",
+      "name" : "dark.outline.on-light.transparent-info-active",
+      "reference" : "OutlineOnLightTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x3D0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineTransparentInfoActive",
+      "name" : "light.outline.on-light.transparent-info-active",
+      "reference" : "OutlineOnLightTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x3D0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineTransparentInfoHover",
+      "name" : "dark.outline.on-light.transparent-info-hover",
+      "reference" : "OutlineOnLightTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentInfoHover",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет обводки информация на светлом фоне",
+      "displayName" : "onLightOutlineTransparentInfoHover",
+      "name" : "light.outline.on-light.transparent-info-hover",
+      "reference" : "OutlineOnLightTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentInfoHover",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentNegative",
+      "name" : "dark.outline.on-light.transparent-negative",
+      "reference" : "OutlineOnLightTransparentNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentNegative",
+      "type" : "color",
+      "value" : "0x33F31B30"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentNegative",
+      "name" : "light.outline.on-light.transparent-negative",
+      "reference" : "OutlineOnLightTransparentNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentNegative",
+      "type" : "color",
+      "value" : "0x33FF293E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentNegativeActive",
+      "name" : "dark.outline.on-light.transparent-negative-active",
+      "reference" : "OutlineOnLightTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x3DF31B31"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentNegativeActive",
+      "name" : "light.outline.on-light.transparent-negative-active",
+      "reference" : "OutlineOnLightTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x3DFF293E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentNegativeHover",
+      "name" : "dark.outline.on-light.transparent-negative-hover",
+      "reference" : "OutlineOnLightTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentNegativeHover",
+      "name" : "light.outline.on-light.transparent-negative-hover",
+      "reference" : "OutlineOnLightTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPositive",
+      "name" : "dark.outline.on-light.transparent-positive",
+      "reference" : "OutlineOnLightTransparentPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPositive",
+      "type" : "color",
+      "value" : "0x330F8E25"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPositive",
+      "name" : "light.outline.on-light.transparent-positive",
+      "reference" : "OutlineOnLightTransparentPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPositive",
+      "type" : "color",
+      "value" : "0x330F8E25"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPositiveActive",
+      "name" : "dark.outline.on-light.transparent-positive-active",
+      "reference" : "OutlineOnLightTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x3D108E25"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPositiveActive",
+      "name" : "light.outline.on-light.transparent-positive-active",
+      "reference" : "OutlineOnLightTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x3D108E25"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPositiveHover",
+      "name" : "dark.outline.on-light.transparent-positive-hover",
+      "reference" : "OutlineOnLightTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0xFF108E25"
+    },
+    {
+      "description" : "Прозрачный цвет обводки успех на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPositiveHover",
+      "name" : "light.outline.on-light.transparent-positive-hover",
+      "reference" : "OutlineOnLightTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0xFF108E25"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPrimary",
+      "name" : "dark.outline.on-light.transparent-primary",
+      "reference" : "OutlineOnLightTransparentPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPrimary",
+      "type" : "color",
+      "value" : "0x1E080808"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPrimary",
+      "name" : "light.outline.on-light.transparent-primary",
+      "reference" : "OutlineOnLightTransparentPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPrimary",
+      "type" : "color",
+      "value" : "0x1E080808"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPrimaryActive",
+      "name" : "dark.outline.on-light.transparent-primary-active",
+      "reference" : "OutlineOnLightTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x25080808"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPrimaryActive",
+      "name" : "light.outline.on-light.transparent-primary-active",
+      "reference" : "OutlineOnLightTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x25080808"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPrimaryHover",
+      "name" : "dark.outline.on-light.transparent-primary-hover",
+      "reference" : "OutlineOnLightTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Основной прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentPrimaryHover",
+      "name" : "light.outline.on-light.transparent-primary-hover",
+      "reference" : "OutlineOnLightTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentSecondary",
+      "name" : "dark.outline.on-light.transparent-secondary",
+      "reference" : "OutlineOnLightTransparentSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentSecondary",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentSecondary",
+      "name" : "light.outline.on-light.transparent-secondary",
+      "reference" : "OutlineOnLightTransparentSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentSecondary",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentSecondaryActive",
+      "name" : "dark.outline.on-light.transparent-secondary-active",
+      "reference" : "OutlineOnLightTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x56080808"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentSecondaryActive",
+      "name" : "light.outline.on-light.transparent-secondary-active",
+      "reference" : "OutlineOnLightTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x56080808"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentSecondaryHover",
+      "name" : "dark.outline.on-light.transparent-secondary-hover",
+      "reference" : "OutlineOnLightTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Вторичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentSecondaryHover",
+      "name" : "light.outline.on-light.transparent-secondary-hover",
+      "reference" : "OutlineOnLightTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentTertiary",
+      "name" : "dark.outline.on-light.transparent-tertiary",
+      "reference" : "OutlineOnLightTransparentTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentTertiary",
+      "type" : "color",
+      "value" : "0x8E080808"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentTertiary",
+      "name" : "light.outline.on-light.transparent-tertiary",
+      "reference" : "OutlineOnLightTransparentTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentTertiary",
+      "type" : "color",
+      "value" : "0x8E080808"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentTertiaryActive",
+      "name" : "dark.outline.on-light.transparent-tertiary-active",
+      "reference" : "OutlineOnLightTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0xAB080808"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentTertiaryActive",
+      "name" : "light.outline.on-light.transparent-tertiary-active",
+      "reference" : "OutlineOnLightTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0xAB080808"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentTertiaryHover",
+      "name" : "dark.outline.on-light.transparent-tertiary-hover",
+      "reference" : "OutlineOnLightTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Третичный прозрачный цвет обводки на светлом фоне",
+      "displayName" : "onLightOutlineTransparentTertiaryHover",
+      "name" : "light.outline.on-light.transparent-tertiary-hover",
+      "reference" : "OutlineOnLightTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentWarning",
+      "name" : "dark.outline.on-light.transparent-warning",
+      "reference" : "OutlineOnLightTransparentWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentWarning",
+      "type" : "color",
+      "value" : "0x33E85602"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentWarning",
+      "name" : "light.outline.on-light.transparent-warning",
+      "reference" : "OutlineOnLightTransparentWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentWarning",
+      "type" : "color",
+      "value" : "0x33E85602"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentWarningActive",
+      "name" : "dark.outline.on-light.transparent-warning-active",
+      "reference" : "OutlineOnLightTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x3DE85702"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentWarningActive",
+      "name" : "light.outline.on-light.transparent-warning-active",
+      "reference" : "OutlineOnLightTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x3DE85702"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentWarningHover",
+      "name" : "dark.outline.on-light.transparent-warning-hover",
+      "reference" : "OutlineOnLightTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentWarningHover",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Прозрачный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineTransparentWarningHover",
+      "name" : "light.outline.on-light.transparent-warning-hover",
+      "reference" : "OutlineOnLightTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightTransparentWarningHover",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Минорный цвет информации",
+      "displayName" : "textInfoMinorHover",
+      "name" : "dark.text.default.info-minor-hover",
+      "reference" : "TextDefaultInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF1277BA"
+    },
+    {
+      "description" : "Минорный цвет информации",
+      "displayName" : "textInfoMinorHover",
+      "name" : "light.text.default.info-minor-hover",
+      "reference" : "TextDefaultInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF7ACAFF"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarning",
+      "name" : "dark.outline.on-light.warning",
+      "reference" : "OutlineOnLightWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarning",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarning",
+      "name" : "light.outline.on-light.warning",
+      "reference" : "OutlineOnLightWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarning",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningActive",
+      "name" : "dark.outline.on-light.warning-active",
+      "reference" : "OutlineOnLightWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningActive",
+      "type" : "color",
+      "value" : "0xFFCA4B02"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningActive",
+      "name" : "light.outline.on-light.warning-active",
+      "reference" : "OutlineOnLightWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningActive",
+      "type" : "color",
+      "value" : "0xFFC04802"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningHover",
+      "name" : "dark.outline.on-light.warning-hover",
+      "reference" : "OutlineOnLightWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningHover",
+      "type" : "color",
+      "value" : "0xFFFD650D"
+    },
+    {
+      "description" : "Цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningHover",
+      "name" : "light.outline.on-light.warning-hover",
+      "reference" : "OutlineOnLightWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningHover",
+      "type" : "color",
+      "value" : "0xFFFD6B17"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningMinor",
+      "name" : "dark.outline.on-light.warning-minor",
+      "reference" : "OutlineOnLightWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFD9C68"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningMinor",
+      "name" : "light.outline.on-light.warning-minor",
+      "reference" : "OutlineOnLightWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFD9C68"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningMinorActive",
+      "name" : "dark.outline.on-light.warning-minor-active",
+      "reference" : "OutlineOnLightWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFC884A"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningMinorActive",
+      "name" : "light.outline.on-light.warning-minor-active",
+      "reference" : "OutlineOnLightWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFC8240"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningMinorHover",
+      "name" : "dark.outline.on-light.warning-minor-hover",
+      "reference" : "OutlineOnLightWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFDB086"
+    },
+    {
+      "description" : "Минорный цвет обводки предупреждение на светлом фоне",
+      "displayName" : "onLightOutlineWarningMinorHover",
+      "name" : "light.outline.on-light.warning-minor-hover",
+      "reference" : "OutlineOnLightWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.outlineOnLightWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFDB790"
+    },
+    {
+      "description" : "Цвет фона паранжи размытый",
+      "displayName" : "overlayBlur",
+      "name" : "dark.overlay.default.blur",
+      "reference" : "OverlayDefaultBlur",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayDefaultBlur",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Цвет фона паранжи размытый",
+      "displayName" : "overlayBlur",
+      "name" : "light.overlay.default.blur",
+      "reference" : "OverlayDefaultBlur",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayDefaultBlur",
+      "type" : "color",
+      "value" : "0x47F9F9F9"
+    },
+    {
+      "description" : "Цвет фона паранжи темный",
+      "displayName" : "overlayHard",
+      "name" : "dark.overlay.default.hard",
+      "reference" : "OverlayDefaultHard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayDefaultHard",
+      "type" : "color",
+      "value" : "0xF4080808"
+    },
+    {
+      "description" : "Цвет фона паранжи темный",
+      "displayName" : "overlayHard",
+      "name" : "light.overlay.default.hard",
+      "reference" : "OverlayDefaultHard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayDefaultHard",
+      "type" : "color",
+      "value" : "0xF4F9F9F9"
+    },
+    {
+      "description" : "Цвет фона паранжи светлый",
+      "displayName" : "overlaySoft",
+      "name" : "dark.overlay.default.soft",
+      "reference" : "OverlayDefaultSoft",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayDefaultSoft",
+      "type" : "color",
+      "value" : "0x8E080808"
+    },
+    {
+      "description" : "Цвет фона паранжи светлый",
+      "displayName" : "overlaySoft",
+      "name" : "light.overlay.default.soft",
+      "reference" : "OverlayDefaultSoft",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayDefaultSoft",
+      "type" : "color",
+      "value" : "0x8EF9F9F9"
+    },
+    {
+      "description" : "Инвертированный цвет фона паранжи размытый",
+      "displayName" : "inverseOverlayBlur",
+      "name" : "dark.overlay.inverse.blur",
+      "reference" : "OverlayInverseBlur",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayInverseBlur",
+      "type" : "color",
+      "value" : "0x47F9F9F9"
+    },
+    {
+      "description" : "Инвертированный цвет фона паранжи размытый",
+      "displayName" : "inverseOverlayBlur",
+      "name" : "light.overlay.inverse.blur",
+      "reference" : "OverlayInverseBlur",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayInverseBlur",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Инвертированный цвет фона паранжи темный",
+      "displayName" : "inverseOverlayHard",
+      "name" : "dark.overlay.inverse.hard",
+      "reference" : "OverlayInverseHard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayInverseHard",
+      "type" : "color",
+      "value" : "0xF4F9F9F9"
+    },
+    {
+      "description" : "Инвертированный цвет фона паранжи темный",
+      "displayName" : "inverseOverlayHard",
+      "name" : "light.overlay.inverse.hard",
+      "reference" : "OverlayInverseHard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayInverseHard",
+      "type" : "color",
+      "value" : "0xF4080808"
+    },
+    {
+      "description" : "Инвертированный цвет фона паранжи светлый",
+      "displayName" : "inverseOverlaySoft",
+      "name" : "dark.overlay.inverse.soft",
+      "reference" : "OverlayInverseSoft",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayInverseSoft",
+      "type" : "color",
+      "value" : "0x8EF9F9F9"
+    },
+    {
+      "description" : "Инвертированный цвет фона паранжи светлый",
+      "displayName" : "inverseOverlaySoft",
+      "name" : "light.overlay.inverse.soft",
+      "reference" : "OverlayInverseSoft",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayInverseSoft",
+      "type" : "color",
+      "value" : "0x8E080808"
+    },
+    {
+      "description" : "Цвет фона паранжи размытый на темном фоне",
+      "displayName" : "onDarkOverlayBlur",
+      "name" : "dark.overlay.on-dark.blur",
+      "reference" : "OverlayOnDarkBlur",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnDarkBlur",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Цвет фона паранжи размытый на темном фоне",
+      "displayName" : "onDarkOverlayBlur",
+      "name" : "light.overlay.on-dark.blur",
+      "reference" : "OverlayOnDarkBlur",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnDarkBlur",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Цвет фона паранжи темный на темном фоне",
+      "displayName" : "onDarkOverlayHard",
+      "name" : "dark.overlay.on-dark.hard",
+      "reference" : "OverlayOnDarkHard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnDarkHard",
+      "type" : "color",
+      "value" : "0xF4080808"
+    },
+    {
+      "description" : "Цвет фона паранжи темный на темном фоне",
+      "displayName" : "onDarkOverlayHard",
+      "name" : "light.overlay.on-dark.hard",
+      "reference" : "OverlayOnDarkHard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnDarkHard",
+      "type" : "color",
+      "value" : "0xF4080808"
+    },
+    {
+      "description" : "Цвет фона паранжи светлый на темном фоне",
+      "displayName" : "onDarkOverlaySoft",
+      "name" : "dark.overlay.on-dark.soft",
+      "reference" : "OverlayOnDarkSoft",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnDarkSoft",
+      "type" : "color",
+      "value" : "0x8E080808"
+    },
+    {
+      "description" : "Цвет фона паранжи светлый на темном фоне",
+      "displayName" : "onDarkOverlaySoft",
+      "name" : "light.overlay.on-dark.soft",
+      "reference" : "OverlayOnDarkSoft",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnDarkSoft",
+      "type" : "color",
+      "value" : "0x8E080808"
+    },
+    {
+      "description" : "Цвет фона паранжи размытый на светлом фоне",
+      "displayName" : "onLightOverlayBlur",
+      "name" : "dark.overlay.on-light.blur",
+      "reference" : "OverlayOnLightBlur",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnLightBlur",
+      "type" : "color",
+      "value" : "0x47F9F9F9"
+    },
+    {
+      "description" : "Цвет фона паранжи размытый на светлом фоне",
+      "displayName" : "onLightOverlayBlur",
+      "name" : "light.overlay.on-light.blur",
+      "reference" : "OverlayOnLightBlur",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnLightBlur",
+      "type" : "color",
+      "value" : "0x47F9F9F9"
+    },
+    {
+      "description" : "Цвет фона паранжи темный на светлом фоне",
+      "displayName" : "onLightOverlayHard",
+      "name" : "dark.overlay.on-light.hard",
+      "reference" : "OverlayOnLightHard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnLightHard",
+      "type" : "color",
+      "value" : "0xF4F9F9F9"
+    },
+    {
+      "description" : "Цвет фона паранжи темный на светлом фоне",
+      "displayName" : "onLightOverlayHard",
+      "name" : "light.overlay.on-light.hard",
+      "reference" : "OverlayOnLightHard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnLightHard",
+      "type" : "color",
+      "value" : "0xF4F9F9F9"
+    },
+    {
+      "description" : "Цвет фона паранжи светлый на светлом фоне",
+      "displayName" : "onLightOverlaySoft",
+      "name" : "dark.overlay.on-light.soft",
+      "reference" : "OverlayOnLightSoft",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnLightSoft",
+      "type" : "color",
+      "value" : "0x8EF9F9F9"
+    },
+    {
+      "description" : "Цвет фона паранжи светлый на светлом фоне",
+      "displayName" : "onLightOverlaySoft",
+      "name" : "light.overlay.on-light.soft",
+      "reference" : "OverlayOnLightSoft",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.overlayOnLightSoft",
+      "type" : "color",
+      "value" : "0x8EF9F9F9"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола",
+      "displayName" : "surfaceAccent",
+      "name" : "dark.surface.default.accent",
+      "reference" : "SurfaceDefaultAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccent",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола",
+      "displayName" : "surfaceAccent",
+      "name" : "light.surface.default.accent",
+      "reference" : "SurfaceDefaultAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccent",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола",
+      "displayName" : "surfaceAccentActive",
+      "name" : "dark.surface.default.accent-active",
+      "reference" : "SurfaceDefaultAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentActive",
+      "type" : "color",
+      "value" : "0xFF18952F"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола",
+      "displayName" : "surfaceAccentActive",
+      "name" : "light.surface.default.accent-active",
+      "reference" : "SurfaceDefaultAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentActive",
+      "type" : "color",
+      "value" : "0xFF178C2C"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола",
+      "displayName" : "surfaceAccentHover",
+      "name" : "dark.surface.default.accent-hover",
+      "reference" : "SurfaceDefaultAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentHover",
+      "type" : "color",
+      "value" : "0xFF1DAF37"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола",
+      "displayName" : "surfaceAccentHover",
+      "name" : "light.surface.default.accent-hover",
+      "reference" : "SurfaceDefaultAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentHover",
+      "type" : "color",
+      "value" : "0xFF1EB83A"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceAccentMinor",
+      "name" : "dark.surface.default.accent-minor",
+      "reference" : "SurfaceDefaultAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentMinor",
+      "type" : "color",
+      "value" : "0xFF0A2B10"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceAccentMinor",
+      "name" : "light.surface.default.accent-minor",
+      "reference" : "SurfaceDefaultAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentMinor",
+      "type" : "color",
+      "value" : "0xFF9EFAAF"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceAccentMinorActive",
+      "name" : "dark.surface.default.accent-minor-active",
+      "reference" : "SurfaceDefaultAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF08210C"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceAccentMinorActive",
+      "name" : "light.surface.default.accent-minor-active",
+      "reference" : "SurfaceDefaultAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF8BF99F"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceAccentMinorHover",
+      "name" : "dark.surface.default.accent-minor-hover",
+      "reference" : "SurfaceDefaultAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF0E3A16"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceAccentMinorHover",
+      "name" : "light.surface.default.accent-minor-hover",
+      "reference" : "SurfaceDefaultAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFFB1FBBF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки",
+      "displayName" : "surfaceClear",
+      "name" : "dark.surface.default.clear",
+      "reference" : "SurfaceDefaultClear",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки",
+      "displayName" : "surfaceClear",
+      "name" : "light.surface.default.clear",
+      "reference" : "SurfaceDefaultClear",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки",
+      "displayName" : "surfaceClearActive",
+      "name" : "dark.surface.default.clear-active",
+      "reference" : "SurfaceDefaultClearActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки",
+      "displayName" : "surfaceClearActive",
+      "name" : "light.surface.default.clear-active",
+      "reference" : "SurfaceDefaultClearActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки",
+      "displayName" : "surfaceClearHover",
+      "name" : "dark.surface.default.clear-hover",
+      "reference" : "SurfaceDefaultClearHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки",
+      "displayName" : "surfaceClearHover",
+      "name" : "light.surface.default.clear-hover",
+      "reference" : "SurfaceDefaultClearHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfo",
+      "name" : "dark.surface.default.info",
+      "reference" : "SurfaceDefaultInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfo",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfo",
+      "name" : "light.surface.default.info",
+      "reference" : "SurfaceDefaultInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfo",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoActive",
+      "name" : "dark.surface.default.info-active",
+      "reference" : "SurfaceDefaultInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoActive",
+      "type" : "color",
+      "value" : "0xFF1086D5"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoActive",
+      "name" : "light.surface.default.info-active",
+      "reference" : "SurfaceDefaultInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoActive",
+      "type" : "color",
+      "value" : "0xFF0F81CC"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoHover",
+      "name" : "dark.surface.default.info-hover",
+      "reference" : "SurfaceDefaultInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoHover",
+      "type" : "color",
+      "value" : "0xFF1798EE"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoHover",
+      "name" : "light.surface.default.info-hover",
+      "reference" : "SurfaceDefaultInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoHover",
+      "type" : "color",
+      "value" : "0xFF1798EE"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoMinor",
+      "name" : "dark.surface.default.info-minor",
+      "reference" : "SurfaceDefaultInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0C283B"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoMinor",
+      "name" : "light.surface.default.info-minor",
+      "reference" : "SurfaceDefaultInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoMinor",
+      "type" : "color",
+      "value" : "0xFFCFECFF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoMinorActive",
+      "name" : "dark.surface.default.info-minor-active",
+      "reference" : "SurfaceDefaultInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF0A2333"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoMinorActive",
+      "name" : "light.surface.default.info-minor-active",
+      "reference" : "SurfaceDefaultInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFFC7E9FF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoMinorHover",
+      "name" : "dark.surface.default.info-minor-hover",
+      "reference" : "SurfaceDefaultInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF10344C"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceInfoMinorHover",
+      "name" : "light.surface.default.info-minor-hover",
+      "reference" : "SurfaceDefaultInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFFE5F5FF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegative",
+      "name" : "dark.surface.default.negative",
+      "reference" : "SurfaceDefaultNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegative",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegative",
+      "name" : "light.surface.default.negative",
+      "reference" : "SurfaceDefaultNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegative",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeActive",
+      "name" : "dark.surface.default.negative-active",
+      "reference" : "SurfaceDefaultNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF1F35"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeActive",
+      "name" : "light.surface.default.negative-active",
+      "reference" : "SurfaceDefaultNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF142C"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeHover",
+      "name" : "dark.surface.default.negative-hover",
+      "reference" : "SurfaceDefaultNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF475A"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeHover",
+      "name" : "light.surface.default.negative-hover",
+      "reference" : "SurfaceDefaultNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF5263"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeMinor",
+      "name" : "dark.surface.default.negative-minor",
+      "reference" : "SurfaceDefaultNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF4A0D13"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeMinor",
+      "name" : "light.surface.default.negative-minor",
+      "reference" : "SurfaceDefaultNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFFE0E3"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeMinorActive",
+      "name" : "dark.surface.default.negative-minor-active",
+      "reference" : "SurfaceDefaultNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF410B11"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeMinorActive",
+      "name" : "light.surface.default.negative-minor-active",
+      "reference" : "SurfaceDefaultNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFFD6DA"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeMinorHover",
+      "name" : "dark.surface.default.negative-minor-hover",
+      "reference" : "SurfaceDefaultNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFF5B1018"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "surfaceNegativeMinorHover",
+      "name" : "light.surface.default.negative-minor-hover",
+      "reference" : "SurfaceDefaultNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFF5F6"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositive",
+      "name" : "dark.surface.default.positive",
+      "reference" : "SurfaceDefaultPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositive",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositive",
+      "name" : "light.surface.default.positive",
+      "reference" : "SurfaceDefaultPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositive",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveActive",
+      "name" : "dark.surface.default.positive-active",
+      "reference" : "SurfaceDefaultPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveActive",
+      "type" : "color",
+      "value" : "0xFF18952F"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveActive",
+      "name" : "light.surface.default.positive-active",
+      "reference" : "SurfaceDefaultPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveActive",
+      "type" : "color",
+      "value" : "0xFF178C2C"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveHover",
+      "name" : "dark.surface.default.positive-hover",
+      "reference" : "SurfaceDefaultPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveHover",
+      "type" : "color",
+      "value" : "0xFF1DAF37"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveHover",
+      "name" : "light.surface.default.positive-hover",
+      "reference" : "SurfaceDefaultPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveHover",
+      "type" : "color",
+      "value" : "0xFF1EB83A"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveMinor",
+      "name" : "dark.surface.default.positive-minor",
+      "reference" : "SurfaceDefaultPositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF0A2B10"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveMinor",
+      "name" : "light.surface.default.positive-minor",
+      "reference" : "SurfaceDefaultPositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF9EFAAF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveMinorActive",
+      "name" : "dark.surface.default.positive-minor-active",
+      "reference" : "SurfaceDefaultPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF08210C"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveMinorActive",
+      "name" : "light.surface.default.positive-minor-active",
+      "reference" : "SurfaceDefaultPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF8BF99F"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveMinorHover",
+      "name" : "dark.surface.default.positive-minor-hover",
+      "reference" : "SurfaceDefaultPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF0E3A16"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех",
+      "displayName" : "surfacePositiveMinorHover",
+      "name" : "light.surface.default.positive-minor-hover",
+      "reference" : "SurfaceDefaultPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFFB1FBBF"
+    },
+    {
+      "description" : "Основной фон для карточек",
+      "displayName" : "surfaceSolidCard",
+      "name" : "dark.surface.default.solid-card",
+      "reference" : "SurfaceDefaultSolidCard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidCard",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Основной фон для карточек",
+      "displayName" : "surfaceSolidCard",
+      "name" : "light.surface.default.solid-card",
+      "reference" : "SurfaceDefaultSolidCard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidCard",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек",
+      "displayName" : "surfaceSolidCardActive",
+      "name" : "dark.surface.default.solid-card-active",
+      "reference" : "SurfaceDefaultSolidCardActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidCardActive",
+      "type" : "color",
+      "value" : "0xFF121212"
+    },
+    {
+      "description" : "Основной фон для карточек",
+      "displayName" : "surfaceSolidCardActive",
+      "name" : "light.surface.default.solid-card-active",
+      "reference" : "SurfaceDefaultSolidCardActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidCardActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек",
+      "displayName" : "surfaceSolidCardBrightness",
+      "name" : "dark.surface.default.solid-card-brightness",
+      "reference" : "SurfaceDefaultSolidCardBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidCardBrightness",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной фон для карточек",
+      "displayName" : "surfaceSolidCardBrightness",
+      "name" : "light.surface.default.solid-card-brightness",
+      "reference" : "SurfaceDefaultSolidCardBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidCardBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек",
+      "displayName" : "surfaceSolidCardHover",
+      "name" : "dark.surface.default.solid-card-hover",
+      "reference" : "SurfaceDefaultSolidCardHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidCardHover",
+      "type" : "color",
+      "value" : "0xFF1C1C1C"
+    },
+    {
+      "description" : "Основной фон для карточек",
+      "displayName" : "surfaceSolidCardHover",
+      "name" : "light.surface.default.solid-card-hover",
+      "reference" : "SurfaceDefaultSolidCardHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidCardHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "surfaceSolidDefault",
+      "name" : "dark.surface.default.solid-default",
+      "reference" : "SurfaceDefaultSolidDefault",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidDefault",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "surfaceSolidDefault",
+      "name" : "light.surface.default.solid-default",
+      "reference" : "SurfaceDefaultSolidDefault",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidDefault",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "surfaceSolidDefaultActive",
+      "name" : "dark.surface.default.solid-default-active",
+      "reference" : "SurfaceDefaultSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFF5F5F5"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "surfaceSolidDefaultActive",
+      "name" : "light.surface.default.solid-default-active",
+      "reference" : "SurfaceDefaultSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFF030303"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "surfaceSolidDefaultHover",
+      "name" : "dark.surface.default.solid-default-hover",
+      "reference" : "SurfaceDefaultSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "surfaceSolidDefaultHover",
+      "name" : "light.surface.default.solid-default-hover",
+      "reference" : "SurfaceDefaultSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidPrimary",
+      "name" : "dark.surface.default.solid-primary",
+      "reference" : "SurfaceDefaultSolidPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidPrimary",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidPrimary",
+      "name" : "light.surface.default.solid-primary",
+      "reference" : "SurfaceDefaultSolidPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidPrimary",
+      "type" : "color",
+      "value" : "0xFFF5F5F5"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidPrimaryActive",
+      "name" : "dark.surface.default.solid-primary-active",
+      "reference" : "SurfaceDefaultSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFF121212"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidPrimaryActive",
+      "name" : "light.surface.default.solid-primary-active",
+      "reference" : "SurfaceDefaultSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFF0F0F0"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidPrimaryBrightness",
+      "name" : "dark.surface.default.solid-primary-brightness",
+      "reference" : "SurfaceDefaultSolidPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidPrimaryBrightness",
+      "name" : "light.surface.default.solid-primary-brightness",
+      "reference" : "SurfaceDefaultSolidPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidPrimaryHover",
+      "name" : "dark.surface.default.solid-primary-hover",
+      "reference" : "SurfaceDefaultSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF1C1C1C"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidPrimaryHover",
+      "name" : "light.surface.default.solid-primary-hover",
+      "reference" : "SurfaceDefaultSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidSecondary",
+      "name" : "dark.surface.default.solid-secondary",
+      "reference" : "SurfaceDefaultSolidSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidSecondary",
+      "name" : "light.surface.default.solid-secondary",
+      "reference" : "SurfaceDefaultSolidSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidSecondary",
+      "type" : "color",
+      "value" : "0xFFECECEC"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidSecondaryActive",
+      "name" : "dark.surface.default.solid-secondary-active",
+      "reference" : "SurfaceDefaultSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF212121"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidSecondaryActive",
+      "name" : "light.surface.default.solid-secondary-active",
+      "reference" : "SurfaceDefaultSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFFE8E8E8"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidSecondaryHover",
+      "name" : "dark.surface.default.solid-secondary-hover",
+      "reference" : "SurfaceDefaultSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF303030"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidSecondaryHover",
+      "name" : "light.surface.default.solid-secondary-hover",
+      "reference" : "SurfaceDefaultSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFF7F7F7"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidTertiary",
+      "name" : "dark.surface.default.solid-tertiary",
+      "reference" : "SurfaceDefaultSolidTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidTertiary",
+      "name" : "light.surface.default.solid-tertiary",
+      "reference" : "SurfaceDefaultSolidTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidTertiary",
+      "type" : "color",
+      "value" : "0xFFDDDDDD"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidTertiaryActive",
+      "name" : "dark.surface.default.solid-tertiary-active",
+      "reference" : "SurfaceDefaultSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF303030"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidTertiaryActive",
+      "name" : "light.surface.default.solid-tertiary-active",
+      "reference" : "SurfaceDefaultSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFFD4D4D4"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidTertiaryHover",
+      "name" : "dark.surface.default.solid-tertiary-hover",
+      "reference" : "SurfaceDefaultSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF404040"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "surfaceSolidTertiaryHover",
+      "name" : "light.surface.default.solid-tertiary-hover",
+      "reference" : "SurfaceDefaultSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFEDEDED"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentAccent",
+      "name" : "dark.surface.default.transparent-accent",
+      "reference" : "SurfaceDefaultTransparentAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentAccent",
+      "type" : "color",
+      "value" : "0x33199E31"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentAccent",
+      "name" : "light.surface.default.transparent-accent",
+      "reference" : "SurfaceDefaultTransparentAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentAccent",
+      "type" : "color",
+      "value" : "0x1F108E26"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentAccentActive",
+      "name" : "dark.surface.default.transparent-accent-active",
+      "reference" : "SurfaceDefaultTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x241A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentAccentActive",
+      "name" : "light.surface.default.transparent-accent-active",
+      "reference" : "SurfaceDefaultTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x29108E25"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentAccentHover",
+      "name" : "dark.surface.default.transparent-accent-hover",
+      "reference" : "SurfaceDefaultTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentAccentHover",
+      "type" : "color",
+      "value" : "0x521A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentAccentHover",
+      "name" : "light.surface.default.transparent-accent-hover",
+      "reference" : "SurfaceDefaultTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentAccentHover",
+      "type" : "color",
+      "value" : "0x0A108E25"
+    },
+    {
+      "description" : "Прозрачный фон для карточек",
+      "displayName" : "surfaceTransparentCard",
+      "name" : "dark.surface.default.transparent-card",
+      "reference" : "SurfaceDefaultTransparentCard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentCard",
+      "type" : "color",
+      "value" : "0x0FFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек",
+      "displayName" : "surfaceTransparentCard",
+      "name" : "light.surface.default.transparent-card",
+      "reference" : "SurfaceDefaultTransparentCard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentCard",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек",
+      "displayName" : "surfaceTransparentCardActive",
+      "name" : "dark.surface.default.transparent-card-active",
+      "reference" : "SurfaceDefaultTransparentCardActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentCardActive",
+      "type" : "color",
+      "value" : "0x0AFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек",
+      "displayName" : "surfaceTransparentCardActive",
+      "name" : "light.surface.default.transparent-card-active",
+      "reference" : "SurfaceDefaultTransparentCardActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentCardActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек",
+      "displayName" : "surfaceTransparentCardBrightness",
+      "name" : "dark.surface.default.transparent-card-brightness",
+      "reference" : "SurfaceDefaultTransparentCardBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentCardBrightness",
+      "type" : "color",
+      "value" : "0x0FFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек",
+      "displayName" : "surfaceTransparentCardBrightness",
+      "name" : "light.surface.default.transparent-card-brightness",
+      "reference" : "SurfaceDefaultTransparentCardBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentCardBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек",
+      "displayName" : "surfaceTransparentCardHover",
+      "name" : "dark.surface.default.transparent-card-hover",
+      "reference" : "SurfaceDefaultTransparentCardHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentCardHover",
+      "type" : "color",
+      "value" : "0x1FFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек",
+      "displayName" : "surfaceTransparentCardHover",
+      "name" : "light.surface.default.transparent-card-hover",
+      "reference" : "SurfaceDefaultTransparentCardHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentCardHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentDeep",
+      "name" : "dark.surface.default.transparent-deep",
+      "reference" : "SurfaceDefaultTransparentDeep",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentDeep",
+      "type" : "color",
+      "value" : "0xA3FFFFFF"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentDeep",
+      "name" : "light.surface.default.transparent-deep",
+      "reference" : "SurfaceDefaultTransparentDeep",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentDeep",
+      "type" : "color",
+      "value" : "0xA3080808"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentDeepActive",
+      "name" : "dark.surface.default.transparent-deep-active",
+      "reference" : "SurfaceDefaultTransparentDeepActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentDeepActive",
+      "type" : "color",
+      "value" : "0x94FFFFFF"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentDeepActive",
+      "name" : "light.surface.default.transparent-deep-active",
+      "reference" : "SurfaceDefaultTransparentDeepActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentDeepActive",
+      "type" : "color",
+      "value" : "0xAD080808"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentDeepHover",
+      "name" : "dark.surface.default.transparent-deep-hover",
+      "reference" : "SurfaceDefaultTransparentDeepHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentDeepHover",
+      "type" : "color",
+      "value" : "0xC2FFFFFF"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentDeepHover",
+      "name" : "light.surface.default.transparent-deep-hover",
+      "reference" : "SurfaceDefaultTransparentDeepHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentDeepHover",
+      "type" : "color",
+      "value" : "0x8F080808"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceTransparentInfo",
+      "name" : "dark.surface.default.transparent-info",
+      "reference" : "SurfaceDefaultTransparentInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentInfo",
+      "type" : "color",
+      "value" : "0x33118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceTransparentInfo",
+      "name" : "light.surface.default.transparent-info",
+      "reference" : "SurfaceDefaultTransparentInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentInfo",
+      "type" : "color",
+      "value" : "0x1F0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceTransparentInfoActive",
+      "name" : "dark.surface.default.transparent-info-active",
+      "reference" : "SurfaceDefaultTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x24118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceTransparentInfoActive",
+      "name" : "light.surface.default.transparent-info-active",
+      "reference" : "SurfaceDefaultTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x290B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceTransparentInfoHover",
+      "name" : "dark.surface.default.transparent-info-hover",
+      "reference" : "SurfaceDefaultTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentInfoHover",
+      "type" : "color",
+      "value" : "0x52118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация",
+      "displayName" : "surfaceTransparentInfoHover",
+      "name" : "light.surface.default.transparent-info-hover",
+      "reference" : "SurfaceDefaultTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentInfoHover",
+      "type" : "color",
+      "value" : "0x0A0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentNegative",
+      "name" : "dark.surface.default.transparent-negative",
+      "reference" : "SurfaceDefaultTransparentNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentNegative",
+      "type" : "color",
+      "value" : "0x33FF293D"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentNegative",
+      "name" : "light.surface.default.transparent-negative",
+      "reference" : "SurfaceDefaultTransparentNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentNegative",
+      "type" : "color",
+      "value" : "0x1FF31B31"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentNegativeActive",
+      "name" : "dark.surface.default.transparent-negative-active",
+      "reference" : "SurfaceDefaultTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x24FF293E"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentNegativeActive",
+      "name" : "light.surface.default.transparent-negative-active",
+      "reference" : "SurfaceDefaultTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x29F31B31"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentNegativeHover",
+      "name" : "dark.surface.default.transparent-negative-hover",
+      "reference" : "SurfaceDefaultTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0x52FF293E"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentNegativeHover",
+      "name" : "light.surface.default.transparent-negative-hover",
+      "reference" : "SurfaceDefaultTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0x0AF31B31"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех",
+      "displayName" : "surfaceTransparentPositive",
+      "name" : "dark.surface.default.transparent-positive",
+      "reference" : "SurfaceDefaultTransparentPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPositive",
+      "type" : "color",
+      "value" : "0x33199E31"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех",
+      "displayName" : "surfaceTransparentPositive",
+      "name" : "light.surface.default.transparent-positive",
+      "reference" : "SurfaceDefaultTransparentPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPositive",
+      "type" : "color",
+      "value" : "0x1F108E26"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех",
+      "displayName" : "surfaceTransparentPositiveActive",
+      "name" : "dark.surface.default.transparent-positive-active",
+      "reference" : "SurfaceDefaultTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x241A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех",
+      "displayName" : "surfaceTransparentPositiveActive",
+      "name" : "light.surface.default.transparent-positive-active",
+      "reference" : "SurfaceDefaultTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x29108E25"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех",
+      "displayName" : "surfaceTransparentPositiveHover",
+      "name" : "dark.surface.default.transparent-positive-hover",
+      "reference" : "SurfaceDefaultTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0x521A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех",
+      "displayName" : "surfaceTransparentPositiveHover",
+      "name" : "light.surface.default.transparent-positive-hover",
+      "reference" : "SurfaceDefaultTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0x0A108E25"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentPrimary",
+      "name" : "dark.surface.default.transparent-primary",
+      "reference" : "SurfaceDefaultTransparentPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPrimary",
+      "type" : "color",
+      "value" : "0x0FFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentPrimary",
+      "name" : "light.surface.default.transparent-primary",
+      "reference" : "SurfaceDefaultTransparentPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPrimary",
+      "type" : "color",
+      "value" : "0x08080808"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentPrimaryActive",
+      "name" : "dark.surface.default.transparent-primary-active",
+      "reference" : "SurfaceDefaultTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x0AFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentPrimaryActive",
+      "name" : "light.surface.default.transparent-primary-active",
+      "reference" : "SurfaceDefaultTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x0D080808"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentPrimaryHover",
+      "name" : "dark.surface.default.transparent-primary-hover",
+      "reference" : "SurfaceDefaultTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0x1FFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentPrimaryHover",
+      "name" : "light.surface.default.transparent-primary-hover",
+      "reference" : "SurfaceDefaultTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0x03080808"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentSecondary",
+      "name" : "dark.surface.default.transparent-secondary",
+      "reference" : "SurfaceDefaultTransparentSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentSecondary",
+      "type" : "color",
+      "value" : "0x1FFFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentSecondary",
+      "name" : "light.surface.default.transparent-secondary",
+      "reference" : "SurfaceDefaultTransparentSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentSecondary",
+      "type" : "color",
+      "value" : "0x0F080808"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentSecondaryActive",
+      "name" : "dark.surface.default.transparent-secondary-active",
+      "reference" : "SurfaceDefaultTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x0FFFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentSecondaryActive",
+      "name" : "light.surface.default.transparent-secondary-active",
+      "reference" : "SurfaceDefaultTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x1A080808"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentSecondaryHover",
+      "name" : "dark.surface.default.transparent-secondary-hover",
+      "reference" : "SurfaceDefaultTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0x3DFFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentSecondaryHover",
+      "name" : "light.surface.default.transparent-secondary-hover",
+      "reference" : "SurfaceDefaultTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0x05080808"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentTertiary",
+      "name" : "dark.surface.default.transparent-tertiary",
+      "reference" : "SurfaceDefaultTransparentTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentTertiary",
+      "type" : "color",
+      "value" : "0x33FFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentTertiary",
+      "name" : "light.surface.default.transparent-tertiary",
+      "reference" : "SurfaceDefaultTransparentTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentTertiary",
+      "type" : "color",
+      "value" : "0x1F080808"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentTertiaryActive",
+      "name" : "dark.surface.default.transparent-tertiary-active",
+      "reference" : "SurfaceDefaultTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0x24FFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentTertiaryActive",
+      "name" : "light.surface.default.transparent-tertiary-active",
+      "reference" : "SurfaceDefaultTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0x29080808"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentTertiaryHover",
+      "name" : "dark.surface.default.transparent-tertiary-hover",
+      "reference" : "SurfaceDefaultTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0x52FFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола",
+      "displayName" : "surfaceTransparentTertiaryHover",
+      "name" : "light.surface.default.transparent-tertiary-hover",
+      "reference" : "SurfaceDefaultTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0x0A080808"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentWarning",
+      "name" : "dark.surface.default.transparent-warning",
+      "reference" : "SurfaceDefaultTransparentWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentWarning",
+      "type" : "color",
+      "value" : "0x33FA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentWarning",
+      "name" : "light.surface.default.transparent-warning",
+      "reference" : "SurfaceDefaultTransparentWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentWarning",
+      "type" : "color",
+      "value" : "0x1FE85702"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentWarningActive",
+      "name" : "dark.surface.default.transparent-warning-active",
+      "reference" : "SurfaceDefaultTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x24FA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentWarningActive",
+      "name" : "light.surface.default.transparent-warning-active",
+      "reference" : "SurfaceDefaultTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x29E85702"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentWarningHover",
+      "name" : "dark.surface.default.transparent-warning-hover",
+      "reference" : "SurfaceDefaultTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentWarningHover",
+      "type" : "color",
+      "value" : "0x52FA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceTransparentWarningHover",
+      "name" : "light.surface.default.transparent-warning-hover",
+      "reference" : "SurfaceDefaultTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultTransparentWarningHover",
+      "type" : "color",
+      "value" : "0x0AE85702"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarning",
+      "name" : "dark.surface.default.warning",
+      "reference" : "SurfaceDefaultWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarning",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarning",
+      "name" : "light.surface.default.warning",
+      "reference" : "SurfaceDefaultWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarning",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningActive",
+      "name" : "dark.surface.default.warning-active",
+      "reference" : "SurfaceDefaultWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningActive",
+      "type" : "color",
+      "value" : "0xFFF05B05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningActive",
+      "name" : "light.surface.default.warning-active",
+      "reference" : "SurfaceDefaultWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningActive",
+      "type" : "color",
+      "value" : "0xFFE65705"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningHover",
+      "name" : "dark.surface.default.warning-hover",
+      "reference" : "SurfaceDefaultWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningHover",
+      "type" : "color",
+      "value" : "0xFFFB7223"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningHover",
+      "name" : "light.surface.default.warning-hover",
+      "reference" : "SurfaceDefaultWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningHover",
+      "type" : "color",
+      "value" : "0xFFFB782D"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningMinor",
+      "name" : "dark.surface.default.warning-minor",
+      "reference" : "SurfaceDefaultWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningMinor",
+      "type" : "color",
+      "value" : "0xFF3D1D0A"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningMinor",
+      "name" : "light.surface.default.warning-minor",
+      "reference" : "SurfaceDefaultWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFEE2D2"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningMinorActive",
+      "name" : "dark.surface.default.warning-minor-active",
+      "reference" : "SurfaceDefaultWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFF351909"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningMinorActive",
+      "name" : "light.surface.default.warning-minor-active",
+      "reference" : "SurfaceDefaultWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFEDCC8"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningMinorHover",
+      "name" : "dark.surface.default.warning-minor-hover",
+      "reference" : "SurfaceDefaultWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFF4F250D"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "surfaceWarningMinorHover",
+      "name" : "light.surface.default.warning-minor-hover",
+      "reference" : "SurfaceDefaultWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceDefaultWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFEEFE6"
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccent",
+      "name" : "dark.surface.inverse.accent",
+      "reference" : "SurfaceInverseAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccent",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccent",
+      "name" : "light.surface.inverse.accent",
+      "reference" : "SurfaceInverseAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccent",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentActive",
+      "name" : "dark.surface.inverse.accent-active",
+      "reference" : "SurfaceInverseAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentActive",
+      "type" : "color",
+      "value" : "0xFF18952F"
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentActive",
+      "name" : "light.surface.inverse.accent-active",
+      "reference" : "SurfaceInverseAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentActive",
+      "type" : "color",
+      "value" : "0xFF178C2C"
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentHover",
+      "name" : "dark.surface.inverse.accent-hover",
+      "reference" : "SurfaceInverseAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentHover",
+      "type" : "color",
+      "value" : "0xFF1DAF37"
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentHover",
+      "name" : "light.surface.inverse.accent-hover",
+      "reference" : "SurfaceInverseAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentHover",
+      "type" : "color",
+      "value" : "0xFF1EB83A"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentMinor",
+      "name" : "dark.surface.inverse.accent-minor",
+      "reference" : "SurfaceInverseAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentMinor",
+      "type" : "color",
+      "value" : "0xFF9EFAAF"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentMinor",
+      "name" : "light.surface.inverse.accent-minor",
+      "reference" : "SurfaceInverseAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentMinor",
+      "type" : "color",
+      "value" : "0xFF0A2B10"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentMinorActive",
+      "name" : "dark.surface.inverse.accent-minor-active",
+      "reference" : "SurfaceInverseAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF94F9A7"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentMinorActive",
+      "name" : "light.surface.inverse.accent-minor-active",
+      "reference" : "SurfaceInverseAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF061909"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentMinorHover",
+      "name" : "dark.surface.inverse.accent-minor-hover",
+      "reference" : "SurfaceInverseAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFFB1FBBF"
+    },
+    {
+      "description" : "Инвертированный акцентный минорный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceAccentMinorHover",
+      "name" : "light.surface.inverse.accent-minor-hover",
+      "reference" : "SurfaceInverseAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF0E3A16"
+    },
+    {
+      "description" : "Инвертированный фон поверхности/контрола без заливки",
+      "displayName" : "inverseSurfaceClear",
+      "name" : "dark.surface.inverse.clear",
+      "reference" : "SurfaceInverseClear",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Инвертированный фон поверхности/контрола без заливки",
+      "displayName" : "inverseSurfaceClear",
+      "name" : "light.surface.inverse.clear",
+      "reference" : "SurfaceInverseClear",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Инвертированный фон поверхности/контрола без заливки",
+      "displayName" : "inverseSurfaceClearActive",
+      "name" : "dark.surface.inverse.clear-active",
+      "reference" : "SurfaceInverseClearActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный фон поверхности/контрола без заливки",
+      "displayName" : "inverseSurfaceClearActive",
+      "name" : "light.surface.inverse.clear-active",
+      "reference" : "SurfaceInverseClearActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный фон поверхности/контрола без заливки",
+      "displayName" : "inverseSurfaceClearHover",
+      "name" : "dark.surface.inverse.clear-hover",
+      "reference" : "SurfaceInverseClearHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный фон поверхности/контрола без заливки",
+      "displayName" : "inverseSurfaceClearHover",
+      "name" : "light.surface.inverse.clear-hover",
+      "reference" : "SurfaceInverseClearHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfo",
+      "name" : "dark.surface.inverse.info",
+      "reference" : "SurfaceInverseInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfo",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfo",
+      "name" : "light.surface.inverse.info",
+      "reference" : "SurfaceInverseInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfo",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoActive",
+      "name" : "dark.surface.inverse.info-active",
+      "reference" : "SurfaceInverseInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoActive",
+      "type" : "color",
+      "value" : "0xFF1086D5"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoActive",
+      "name" : "light.surface.inverse.info-active",
+      "reference" : "SurfaceInverseInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoActive",
+      "type" : "color",
+      "value" : "0xFF0F81CC"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoHover",
+      "name" : "dark.surface.inverse.info-hover",
+      "reference" : "SurfaceInverseInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoHover",
+      "type" : "color",
+      "value" : "0xFF1798EE"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoHover",
+      "name" : "light.surface.inverse.info-hover",
+      "reference" : "SurfaceInverseInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoHover",
+      "type" : "color",
+      "value" : "0xFF1798EE"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoMinor",
+      "name" : "dark.surface.inverse.info-minor",
+      "reference" : "SurfaceInverseInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoMinor",
+      "type" : "color",
+      "value" : "0xFFCFECFF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoMinor",
+      "name" : "light.surface.inverse.info-minor",
+      "reference" : "SurfaceInverseInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0C283B"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoMinorActive",
+      "name" : "dark.surface.inverse.info-minor-active",
+      "reference" : "SurfaceInverseInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFFC7E9FF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoMinorActive",
+      "name" : "light.surface.inverse.info-minor-active",
+      "reference" : "SurfaceInverseInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF091D2A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoMinorHover",
+      "name" : "dark.surface.inverse.info-minor-hover",
+      "reference" : "SurfaceInverseInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFFDBF1FF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceInfoMinorHover",
+      "name" : "light.surface.inverse.info-minor-hover",
+      "reference" : "SurfaceInverseInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF10344C"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegative",
+      "name" : "dark.surface.inverse.negative",
+      "reference" : "SurfaceInverseNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegative",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegative",
+      "name" : "light.surface.inverse.negative",
+      "reference" : "SurfaceInverseNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegative",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeActive",
+      "name" : "dark.surface.inverse.negative-active",
+      "reference" : "SurfaceInverseNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF1F35"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeActive",
+      "name" : "light.surface.inverse.negative-active",
+      "reference" : "SurfaceInverseNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF142C"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeHover",
+      "name" : "dark.surface.inverse.negative-hover",
+      "reference" : "SurfaceInverseNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF475A"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeHover",
+      "name" : "light.surface.inverse.negative-hover",
+      "reference" : "SurfaceInverseNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF5263"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeMinor",
+      "name" : "dark.surface.inverse.negative-minor",
+      "reference" : "SurfaceInverseNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFFE0E3"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeMinor",
+      "name" : "light.surface.inverse.negative-minor",
+      "reference" : "SurfaceInverseNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF4A0D13"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeMinorActive",
+      "name" : "dark.surface.inverse.negative-minor-active",
+      "reference" : "SurfaceInverseNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFFD6DA"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeMinorActive",
+      "name" : "light.surface.inverse.negative-minor-active",
+      "reference" : "SurfaceInverseNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF380A0F"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeMinorHover",
+      "name" : "dark.surface.inverse.negative-minor-hover",
+      "reference" : "SurfaceInverseNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFEBED"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола ошибка",
+      "displayName" : "inverseSurfaceNegativeMinorHover",
+      "name" : "light.surface.inverse.negative-minor-hover",
+      "reference" : "SurfaceInverseNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFF64121A"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositive",
+      "name" : "dark.surface.inverse.positive",
+      "reference" : "SurfaceInversePositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositive",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositive",
+      "name" : "light.surface.inverse.positive",
+      "reference" : "SurfaceInversePositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositive",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveActive",
+      "name" : "dark.surface.inverse.positive-active",
+      "reference" : "SurfaceInversePositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveActive",
+      "type" : "color",
+      "value" : "0xFF18952F"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveActive",
+      "name" : "light.surface.inverse.positive-active",
+      "reference" : "SurfaceInversePositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveActive",
+      "type" : "color",
+      "value" : "0xFF178C2C"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveHover",
+      "name" : "dark.surface.inverse.positive-hover",
+      "reference" : "SurfaceInversePositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveHover",
+      "type" : "color",
+      "value" : "0xFF1DAF37"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveHover",
+      "name" : "light.surface.inverse.positive-hover",
+      "reference" : "SurfaceInversePositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveHover",
+      "type" : "color",
+      "value" : "0xFF1EB83A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveMinor",
+      "name" : "dark.surface.inverse.positive-minor",
+      "reference" : "SurfaceInversePositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveMinor",
+      "type" : "color",
+      "value" : "0xFF9EFAAF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveMinor",
+      "name" : "light.surface.inverse.positive-minor",
+      "reference" : "SurfaceInversePositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveMinor",
+      "type" : "color",
+      "value" : "0xFF0A2B10"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveMinorActive",
+      "name" : "dark.surface.inverse.positive-minor-active",
+      "reference" : "SurfaceInversePositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF94F9A7"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveMinorActive",
+      "name" : "light.surface.inverse.positive-minor-active",
+      "reference" : "SurfaceInversePositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF061909"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveMinorHover",
+      "name" : "dark.surface.inverse.positive-minor-hover",
+      "reference" : "SurfaceInversePositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFFB1FBBF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfacePositiveMinorHover",
+      "name" : "light.surface.inverse.positive-minor-hover",
+      "reference" : "SurfaceInversePositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInversePositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF0E3A16"
+    },
+    {
+      "description" : "Инвертированный основной фон для карточек",
+      "displayName" : "inverseSurfaceSolidCard",
+      "name" : "dark.surface.inverse.solid-card",
+      "reference" : "SurfaceInverseSolidCard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidCard",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной фон для карточек",
+      "displayName" : "inverseSurfaceSolidCard",
+      "name" : "light.surface.inverse.solid-card",
+      "reference" : "SurfaceInverseSolidCard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidCard",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Инвертированный основной фон для карточек",
+      "displayName" : "inverseSurfaceSolidCardActive",
+      "name" : "dark.surface.inverse.solid-card-active",
+      "reference" : "SurfaceInverseSolidCardActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidCardActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной фон для карточек",
+      "displayName" : "inverseSurfaceSolidCardActive",
+      "name" : "light.surface.inverse.solid-card-active",
+      "reference" : "SurfaceInverseSolidCardActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidCardActive",
+      "type" : "color",
+      "value" : "0xFF0D0D0D"
+    },
+    {
+      "description" : "Инвертированный основной фон для карточек",
+      "displayName" : "inverseSurfaceSolidCardBrightness",
+      "name" : "dark.surface.inverse.solid-card-brightness",
+      "reference" : "SurfaceInverseSolidCardBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidCardBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной фон для карточек",
+      "displayName" : "inverseSurfaceSolidCardBrightness",
+      "name" : "light.surface.inverse.solid-card-brightness",
+      "reference" : "SurfaceInverseSolidCardBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidCardBrightness",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Инвертированный основной фон для карточек",
+      "displayName" : "inverseSurfaceSolidCardHover",
+      "name" : "dark.surface.inverse.solid-card-hover",
+      "reference" : "SurfaceInverseSolidCardHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidCardHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной фон для карточек",
+      "displayName" : "inverseSurfaceSolidCardHover",
+      "name" : "light.surface.inverse.solid-card-hover",
+      "reference" : "SurfaceInverseSolidCardHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidCardHover",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseSurfaceSolidDefault",
+      "name" : "dark.surface.inverse.solid-default",
+      "reference" : "SurfaceInverseSolidDefault",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidDefault",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseSurfaceSolidDefault",
+      "name" : "light.surface.inverse.solid-default",
+      "reference" : "SurfaceInverseSolidDefault",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidDefault",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseSurfaceSolidDefaultActive",
+      "name" : "dark.surface.inverse.solid-default-active",
+      "reference" : "SurfaceInverseSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFF030303"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseSurfaceSolidDefaultActive",
+      "name" : "light.surface.inverse.solid-default-active",
+      "reference" : "SurfaceInverseSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFF5F5F5"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseSurfaceSolidDefaultHover",
+      "name" : "dark.surface.inverse.solid-default-hover",
+      "reference" : "SurfaceInverseSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFF0D0D0D"
+    },
+    {
+      "description" : "Инвертированный непрозрачный фон поверхности/контрола по умолчанию",
+      "displayName" : "inverseSurfaceSolidDefaultHover",
+      "name" : "light.surface.inverse.solid-default-hover",
+      "reference" : "SurfaceInverseSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidPrimary",
+      "name" : "dark.surface.inverse.solid-primary",
+      "reference" : "SurfaceInverseSolidPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidPrimary",
+      "type" : "color",
+      "value" : "0xFFF5F5F5"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidPrimary",
+      "name" : "light.surface.inverse.solid-primary",
+      "reference" : "SurfaceInverseSolidPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidPrimary",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidPrimaryActive",
+      "name" : "dark.surface.inverse.solid-primary-active",
+      "reference" : "SurfaceInverseSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFF0F0F0"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidPrimaryActive",
+      "name" : "light.surface.inverse.solid-primary-active",
+      "reference" : "SurfaceInverseSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFF0D0D0D"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidPrimaryBrightness",
+      "name" : "dark.surface.inverse.solid-primary-brightness",
+      "reference" : "SurfaceInverseSolidPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidPrimaryBrightness",
+      "name" : "light.surface.inverse.solid-primary-brightness",
+      "reference" : "SurfaceInverseSolidPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidPrimaryHover",
+      "name" : "dark.surface.inverse.solid-primary-hover",
+      "reference" : "SurfaceInverseSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Инвертированный основной непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidPrimaryHover",
+      "name" : "light.surface.inverse.solid-primary-hover",
+      "reference" : "SurfaceInverseSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidSecondary",
+      "name" : "dark.surface.inverse.solid-secondary",
+      "reference" : "SurfaceInverseSolidSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidSecondary",
+      "type" : "color",
+      "value" : "0xFFECECEC"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidSecondary",
+      "name" : "light.surface.inverse.solid-secondary",
+      "reference" : "SurfaceInverseSolidSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidSecondaryActive",
+      "name" : "dark.surface.inverse.solid-secondary-active",
+      "reference" : "SurfaceInverseSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFFE8E8E8"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidSecondaryActive",
+      "name" : "light.surface.inverse.solid-secondary-active",
+      "reference" : "SurfaceInverseSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF1C1C1C"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidSecondaryHover",
+      "name" : "dark.surface.inverse.solid-secondary-hover",
+      "reference" : "SurfaceInverseSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFF7F7F7"
+    },
+    {
+      "description" : "Инвертированный вторичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidSecondaryHover",
+      "name" : "light.surface.inverse.solid-secondary-hover",
+      "reference" : "SurfaceInverseSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF3B3B3B"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidTertiary",
+      "name" : "dark.surface.inverse.solid-tertiary",
+      "reference" : "SurfaceInverseSolidTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidTertiary",
+      "type" : "color",
+      "value" : "0xFFDDDDDD"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidTertiary",
+      "name" : "light.surface.inverse.solid-tertiary",
+      "reference" : "SurfaceInverseSolidTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidTertiaryActive",
+      "name" : "dark.surface.inverse.solid-tertiary-active",
+      "reference" : "SurfaceInverseSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFFD9D9D9"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidTertiaryActive",
+      "name" : "light.surface.inverse.solid-tertiary-active",
+      "reference" : "SurfaceInverseSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF2B2B2B"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidTertiaryHover",
+      "name" : "dark.surface.inverse.solid-tertiary-hover",
+      "reference" : "SurfaceInverseSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFE8E8E8"
+    },
+    {
+      "description" : "Инвертированный третичный непрозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceSolidTertiaryHover",
+      "name" : "light.surface.inverse.solid-tertiary-hover",
+      "reference" : "SurfaceInverseSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF4A4A4A"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentAccent",
+      "name" : "dark.surface.inverse.transparent-accent",
+      "reference" : "SurfaceInverseTransparentAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentAccent",
+      "type" : "color",
+      "value" : "0x1F1A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentAccent",
+      "name" : "light.surface.inverse.transparent-accent",
+      "reference" : "SurfaceInverseTransparentAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentAccent",
+      "type" : "color",
+      "value" : "0x33199E31"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentAccentActive",
+      "name" : "dark.surface.inverse.transparent-accent-active",
+      "reference" : "SurfaceInverseTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x0F1A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentAccentActive",
+      "name" : "light.surface.inverse.transparent-accent-active",
+      "reference" : "SurfaceInverseTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x3D1A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentAccentHover",
+      "name" : "dark.surface.inverse.transparent-accent-hover",
+      "reference" : "SurfaceInverseTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentAccentHover",
+      "type" : "color",
+      "value" : "0x3D1A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный акцентный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentAccentHover",
+      "name" : "light.surface.inverse.transparent-accent-hover",
+      "reference" : "SurfaceInverseTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentAccentHover",
+      "type" : "color",
+      "value" : "0x1F1A9E32"
+    },
+    {
+      "description" : "Инвертированный прозрачный фон для карточек",
+      "displayName" : "inverseSurfaceTransparentCard",
+      "name" : "dark.surface.inverse.transparent-card",
+      "reference" : "SurfaceInverseTransparentCard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentCard",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный прозрачный фон для карточек",
+      "displayName" : "inverseSurfaceTransparentCard",
+      "name" : "light.surface.inverse.transparent-card",
+      "reference" : "SurfaceInverseTransparentCard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentCard",
+      "type" : "color",
+      "value" : "0x0FF9F9F9"
+    },
+    {
+      "description" : "Инвертированный прозрачный фон для карточек",
+      "displayName" : "inverseSurfaceTransparentCardActive",
+      "name" : "dark.surface.inverse.transparent-card-active",
+      "reference" : "SurfaceInverseTransparentCardActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentCardActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный прозрачный фон для карточек",
+      "displayName" : "inverseSurfaceTransparentCardActive",
+      "name" : "light.surface.inverse.transparent-card-active",
+      "reference" : "SurfaceInverseTransparentCardActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentCardActive",
+      "type" : "color",
+      "value" : "0x1AFAFAFA"
+    },
+    {
+      "description" : "Инвертированный прозрачный фон для карточек",
+      "displayName" : "inverseSurfaceTransparentCardBrightness",
+      "name" : "dark.surface.inverse.transparent-card-brightness",
+      "reference" : "SurfaceInverseTransparentCardBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentCardBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный прозрачный фон для карточек",
+      "displayName" : "inverseSurfaceTransparentCardBrightness",
+      "name" : "light.surface.inverse.transparent-card-brightness",
+      "reference" : "SurfaceInverseTransparentCardBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentCardBrightness",
+      "type" : "color",
+      "value" : "0x0FFAFAFA"
+    },
+    {
+      "description" : "Инвертированный прозрачный фон для карточек",
+      "displayName" : "inverseSurfaceTransparentCardHover",
+      "name" : "dark.surface.inverse.transparent-card-hover",
+      "reference" : "SurfaceInverseTransparentCardHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentCardHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный прозрачный фон для карточек",
+      "displayName" : "inverseSurfaceTransparentCardHover",
+      "name" : "light.surface.inverse.transparent-card-hover",
+      "reference" : "SurfaceInverseTransparentCardHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentCardHover",
+      "type" : "color",
+      "value" : "0x05FAFAFA"
+    },
+    {
+      "description" : "Инвертированный глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentDeep",
+      "name" : "dark.surface.inverse.transparent-deep",
+      "reference" : "SurfaceInverseTransparentDeep",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentDeep",
+      "type" : "color",
+      "value" : "0xA3080808"
+    },
+    {
+      "description" : "Инвертированный глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentDeep",
+      "name" : "light.surface.inverse.transparent-deep",
+      "reference" : "SurfaceInverseTransparentDeep",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentDeep",
+      "type" : "color",
+      "value" : "0xA3F9F9F9"
+    },
+    {
+      "description" : "Инвертированный глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentDeepActive",
+      "name" : "dark.surface.inverse.transparent-deep-active",
+      "reference" : "SurfaceInverseTransparentDeepActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentDeepActive",
+      "type" : "color",
+      "value" : "0x94080808"
+    },
+    {
+      "description" : "Инвертированный глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentDeepActive",
+      "name" : "light.surface.inverse.transparent-deep-active",
+      "reference" : "SurfaceInverseTransparentDeepActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentDeepActive",
+      "type" : "color",
+      "value" : "0xADFAFAFA"
+    },
+    {
+      "description" : "Инвертированный глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentDeepHover",
+      "name" : "dark.surface.inverse.transparent-deep-hover",
+      "reference" : "SurfaceInverseTransparentDeepHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentDeepHover",
+      "type" : "color",
+      "value" : "0xC2080808"
+    },
+    {
+      "description" : "Инвертированный глубокий прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentDeepHover",
+      "name" : "light.surface.inverse.transparent-deep-hover",
+      "reference" : "SurfaceInverseTransparentDeepHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentDeepHover",
+      "type" : "color",
+      "value" : "0x8FFAFAFA"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceTransparentInfo",
+      "name" : "dark.surface.inverse.transparent-info",
+      "reference" : "SurfaceInverseTransparentInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentInfo",
+      "type" : "color",
+      "value" : "0x1E118CDF"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceTransparentInfo",
+      "name" : "light.surface.inverse.transparent-info",
+      "reference" : "SurfaceInverseTransparentInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentInfo",
+      "type" : "color",
+      "value" : "0x33118CDF"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceTransparentInfoActive",
+      "name" : "dark.surface.inverse.transparent-info-active",
+      "reference" : "SurfaceInverseTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x0F118CDF"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceTransparentInfoActive",
+      "name" : "light.surface.inverse.transparent-info-active",
+      "reference" : "SurfaceInverseTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x3D118CDF"
+    },
+    {
+      "description" : "Цвет ошибки",
+      "displayName" : "textNegative",
+      "name" : "dark.text.default.negative",
+      "reference" : "TextDefaultNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegative",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Цвет ошибки",
+      "displayName" : "textNegative",
+      "name" : "light.text.default.negative",
+      "reference" : "TextDefaultNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegative",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceTransparentInfoHover",
+      "name" : "dark.surface.inverse.transparent-info-hover",
+      "reference" : "SurfaceInverseTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentInfoHover",
+      "type" : "color",
+      "value" : "0x3D118CDF"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола информация",
+      "displayName" : "inverseSurfaceTransparentInfoHover",
+      "name" : "light.surface.inverse.transparent-info-hover",
+      "reference" : "SurfaceInverseTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentInfoHover",
+      "type" : "color",
+      "value" : "0x1F118CDF"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentNegative",
+      "name" : "dark.surface.inverse.transparent-negative",
+      "reference" : "SurfaceInverseTransparentNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentNegative",
+      "type" : "color",
+      "value" : "0x1EFF293D"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentNegative",
+      "name" : "light.surface.inverse.transparent-negative",
+      "reference" : "SurfaceInverseTransparentNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentNegative",
+      "type" : "color",
+      "value" : "0x33FF293D"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentNegativeActive",
+      "name" : "dark.surface.inverse.transparent-negative-active",
+      "reference" : "SurfaceInverseTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x0FFF293E"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentNegativeActive",
+      "name" : "light.surface.inverse.transparent-negative-active",
+      "reference" : "SurfaceInverseTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x3DFF293E"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentNegativeHover",
+      "name" : "dark.surface.inverse.transparent-negative-hover",
+      "reference" : "SurfaceInverseTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0x3DFF293E"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentNegativeHover",
+      "name" : "light.surface.inverse.transparent-negative-hover",
+      "reference" : "SurfaceInverseTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0x1FFF293E"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfaceTransparentPositive",
+      "name" : "dark.surface.inverse.transparent-positive",
+      "reference" : "SurfaceInverseTransparentPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPositive",
+      "type" : "color",
+      "value" : "0x1E199E31"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfaceTransparentPositive",
+      "name" : "light.surface.inverse.transparent-positive",
+      "reference" : "SurfaceInverseTransparentPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPositive",
+      "type" : "color",
+      "value" : "0x33199E31"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfaceTransparentPositiveActive",
+      "name" : "dark.surface.inverse.transparent-positive-active",
+      "reference" : "SurfaceInverseTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x0F1A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfaceTransparentPositiveActive",
+      "name" : "light.surface.inverse.transparent-positive-active",
+      "reference" : "SurfaceInverseTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x3D1A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfaceTransparentPositiveHover",
+      "name" : "dark.surface.inverse.transparent-positive-hover",
+      "reference" : "SurfaceInverseTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0x3D1A9E32"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола успех",
+      "displayName" : "inverseSurfaceTransparentPositiveHover",
+      "name" : "light.surface.inverse.transparent-positive-hover",
+      "reference" : "SurfaceInverseTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0x1F1A9E32"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentPrimary",
+      "name" : "dark.surface.inverse.transparent-primary",
+      "reference" : "SurfaceInverseTransparentPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPrimary",
+      "type" : "color",
+      "value" : "0x08080808"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentPrimary",
+      "name" : "light.surface.inverse.transparent-primary",
+      "reference" : "SurfaceInverseTransparentPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPrimary",
+      "type" : "color",
+      "value" : "0x0FF9F9F9"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentPrimaryActive",
+      "name" : "dark.surface.inverse.transparent-primary-active",
+      "reference" : "SurfaceInverseTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x03080808"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentPrimaryActive",
+      "name" : "light.surface.inverse.transparent-primary-active",
+      "reference" : "SurfaceInverseTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x1AFAFAFA"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentPrimaryHover",
+      "name" : "dark.surface.inverse.transparent-primary-hover",
+      "reference" : "SurfaceInverseTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0x12080808"
+    },
+    {
+      "description" : "Инвертированный основной прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentPrimaryHover",
+      "name" : "light.surface.inverse.transparent-primary-hover",
+      "reference" : "SurfaceInverseTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0x05FAFAFA"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentSecondary",
+      "name" : "dark.surface.inverse.transparent-secondary",
+      "reference" : "SurfaceInverseTransparentSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentSecondary",
+      "type" : "color",
+      "value" : "0x0F080808"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentSecondary",
+      "name" : "light.surface.inverse.transparent-secondary",
+      "reference" : "SurfaceInverseTransparentSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentSecondary",
+      "type" : "color",
+      "value" : "0x1FF9F9F9"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentSecondaryActive",
+      "name" : "dark.surface.inverse.transparent-secondary-active",
+      "reference" : "SurfaceInverseTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x0A080808"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentSecondaryActive",
+      "name" : "light.surface.inverse.transparent-secondary-active",
+      "reference" : "SurfaceInverseTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x29FAFAFA"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentSecondaryHover",
+      "name" : "dark.surface.inverse.transparent-secondary-hover",
+      "reference" : "SurfaceInverseTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0x1F080808"
+    },
+    {
+      "description" : "Инвертированный вторичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentSecondaryHover",
+      "name" : "light.surface.inverse.transparent-secondary-hover",
+      "reference" : "SurfaceInverseTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0x0AFAFAFA"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentTertiary",
+      "name" : "dark.surface.inverse.transparent-tertiary",
+      "reference" : "SurfaceInverseTransparentTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentTertiary",
+      "type" : "color",
+      "value" : "0x1F080808"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentTertiary",
+      "name" : "light.surface.inverse.transparent-tertiary",
+      "reference" : "SurfaceInverseTransparentTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentTertiary",
+      "type" : "color",
+      "value" : "0x33F9F9F9"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentTertiaryActive",
+      "name" : "dark.surface.inverse.transparent-tertiary-active",
+      "reference" : "SurfaceInverseTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0x0F080808"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentTertiaryActive",
+      "name" : "light.surface.inverse.transparent-tertiary-active",
+      "reference" : "SurfaceInverseTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0x3DFAFAFA"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentTertiaryHover",
+      "name" : "dark.surface.inverse.transparent-tertiary-hover",
+      "reference" : "SurfaceInverseTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0x3D080808"
+    },
+    {
+      "description" : "Инвертированный третичный прозрачный фон поверхности/контрола",
+      "displayName" : "inverseSurfaceTransparentTertiaryHover",
+      "name" : "light.surface.inverse.transparent-tertiary-hover",
+      "reference" : "SurfaceInverseTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0x1FFAFAFA"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentWarning",
+      "name" : "dark.surface.inverse.transparent-warning",
+      "reference" : "SurfaceInverseTransparentWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentWarning",
+      "type" : "color",
+      "value" : "0x1EFA5F05"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentWarning",
+      "name" : "light.surface.inverse.transparent-warning",
+      "reference" : "SurfaceInverseTransparentWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentWarning",
+      "type" : "color",
+      "value" : "0x33FA5F05"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentWarningActive",
+      "name" : "dark.surface.inverse.transparent-warning-active",
+      "reference" : "SurfaceInverseTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x0FFA5F05"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentWarningActive",
+      "name" : "light.surface.inverse.transparent-warning-active",
+      "reference" : "SurfaceInverseTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x3DFA5F05"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentWarningHover",
+      "name" : "dark.surface.inverse.transparent-warning-hover",
+      "reference" : "SurfaceInverseTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentWarningHover",
+      "type" : "color",
+      "value" : "0x3DFA5F05"
+    },
+    {
+      "description" : "Прозрачный инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceTransparentWarningHover",
+      "name" : "light.surface.inverse.transparent-warning-hover",
+      "reference" : "SurfaceInverseTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseTransparentWarningHover",
+      "type" : "color",
+      "value" : "0x1FFA5F05"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarning",
+      "name" : "dark.surface.inverse.warning",
+      "reference" : "SurfaceInverseWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarning",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarning",
+      "name" : "light.surface.inverse.warning",
+      "reference" : "SurfaceInverseWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarning",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningActive",
+      "name" : "dark.surface.inverse.warning-active",
+      "reference" : "SurfaceInverseWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningActive",
+      "type" : "color",
+      "value" : "0xFFF05B05"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningActive",
+      "name" : "light.surface.inverse.warning-active",
+      "reference" : "SurfaceInverseWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningActive",
+      "type" : "color",
+      "value" : "0xFFE65705"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningHover",
+      "name" : "dark.surface.inverse.warning-hover",
+      "reference" : "SurfaceInverseWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningHover",
+      "type" : "color",
+      "value" : "0xFFFB7223"
+    },
+    {
+      "description" : "Инвертированный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningHover",
+      "name" : "light.surface.inverse.warning-hover",
+      "reference" : "SurfaceInverseWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningHover",
+      "type" : "color",
+      "value" : "0xFFFB782D"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningMinor",
+      "name" : "dark.surface.inverse.warning-minor",
+      "reference" : "SurfaceInverseWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFEE2D2"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningMinor",
+      "name" : "light.surface.inverse.warning-minor",
+      "reference" : "SurfaceInverseWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningMinor",
+      "type" : "color",
+      "value" : "0xFF3D1D0A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningMinorActive",
+      "name" : "dark.surface.inverse.warning-minor-active",
+      "reference" : "SurfaceInverseWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFEDCC8"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningMinorActive",
+      "name" : "light.surface.inverse.warning-minor-active",
+      "reference" : "SurfaceInverseWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFF2C1507"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningMinorHover",
+      "name" : "dark.surface.inverse.warning-minor-hover",
+      "reference" : "SurfaceInverseWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFEE9DC"
+    },
+    {
+      "description" : "Инвертированный минорный цвет фона поверхности/контрола предупреждение",
+      "displayName" : "inverseSurfaceWarningMinorHover",
+      "name" : "light.surface.inverse.warning-minor-hover",
+      "reference" : "SurfaceInverseWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceInverseWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFF58290E"
+    },
+    {
+      "description" : "Цвет ошибки",
+      "displayName" : "textNegativeActive",
+      "name" : "dark.text.default.negative-active",
+      "reference" : "TextDefaultNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF1F35"
+    },
+    {
+      "description" : "Цвет ошибки",
+      "displayName" : "textNegativeActive",
+      "name" : "light.text.default.negative-active",
+      "reference" : "TextDefaultNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeActive",
+      "type" : "color",
+      "value" : "0xFFDA0B20"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccent",
+      "name" : "dark.surface.on-dark.accent",
+      "reference" : "SurfaceOnDarkAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccent",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccent",
+      "name" : "light.surface.on-dark.accent",
+      "reference" : "SurfaceOnDarkAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccent",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentActive",
+      "name" : "dark.surface.on-dark.accent-active",
+      "reference" : "SurfaceOnDarkAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentActive",
+      "type" : "color",
+      "value" : "0xFF18952F"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentActive",
+      "name" : "light.surface.on-dark.accent-active",
+      "reference" : "SurfaceOnDarkAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentActive",
+      "type" : "color",
+      "value" : "0xFF178C2C"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentHover",
+      "name" : "dark.surface.on-dark.accent-hover",
+      "reference" : "SurfaceOnDarkAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentHover",
+      "type" : "color",
+      "value" : "0xFF1DAF37"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentHover",
+      "name" : "light.surface.on-dark.accent-hover",
+      "reference" : "SurfaceOnDarkAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentHover",
+      "type" : "color",
+      "value" : "0xFF1EB83A"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentMinor",
+      "name" : "dark.surface.on-dark.accent-minor",
+      "reference" : "SurfaceOnDarkAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentMinor",
+      "type" : "color",
+      "value" : "0xFF0A2B10"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentMinor",
+      "name" : "light.surface.on-dark.accent-minor",
+      "reference" : "SurfaceOnDarkAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentMinor",
+      "type" : "color",
+      "value" : "0xFF0A2B10"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentMinorActive",
+      "name" : "dark.surface.on-dark.accent-minor-active",
+      "reference" : "SurfaceOnDarkAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF08210C"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentMinorActive",
+      "name" : "light.surface.on-dark.accent-minor-active",
+      "reference" : "SurfaceOnDarkAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF061909"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentMinorHover",
+      "name" : "dark.surface.on-dark.accent-minor-hover",
+      "reference" : "SurfaceOnDarkAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF0E3A16"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceAccentMinorHover",
+      "name" : "light.surface.on-dark.accent-minor-hover",
+      "reference" : "SurfaceOnDarkAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF0E3A16"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на темном фоне",
+      "displayName" : "onDarkSurfaceClear",
+      "name" : "dark.surface.on-dark.clear",
+      "reference" : "SurfaceOnDarkClear",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на темном фоне",
+      "displayName" : "onDarkSurfaceClear",
+      "name" : "light.surface.on-dark.clear",
+      "reference" : "SurfaceOnDarkClear",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на темном фоне",
+      "displayName" : "onDarkSurfaceClearActive",
+      "name" : "dark.surface.on-dark.clear-active",
+      "reference" : "SurfaceOnDarkClearActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на темном фоне",
+      "displayName" : "onDarkSurfaceClearActive",
+      "name" : "light.surface.on-dark.clear-active",
+      "reference" : "SurfaceOnDarkClearActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на темном фоне",
+      "displayName" : "onDarkSurfaceClearHover",
+      "name" : "dark.surface.on-dark.clear-hover",
+      "reference" : "SurfaceOnDarkClearHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на темном фоне",
+      "displayName" : "onDarkSurfaceClearHover",
+      "name" : "light.surface.on-dark.clear-hover",
+      "reference" : "SurfaceOnDarkClearHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfo",
+      "name" : "dark.surface.on-dark.info",
+      "reference" : "SurfaceOnDarkInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfo",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfo",
+      "name" : "light.surface.on-dark.info",
+      "reference" : "SurfaceOnDarkInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfo",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoActive",
+      "name" : "dark.surface.on-dark.info-active",
+      "reference" : "SurfaceOnDarkInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoActive",
+      "type" : "color",
+      "value" : "0xFF1086D5"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoActive",
+      "name" : "light.surface.on-dark.info-active",
+      "reference" : "SurfaceOnDarkInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoActive",
+      "type" : "color",
+      "value" : "0xFF0F81CC"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoHover",
+      "name" : "dark.surface.on-dark.info-hover",
+      "reference" : "SurfaceOnDarkInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoHover",
+      "type" : "color",
+      "value" : "0xFF1798EE"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoHover",
+      "name" : "light.surface.on-dark.info-hover",
+      "reference" : "SurfaceOnDarkInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoHover",
+      "type" : "color",
+      "value" : "0xFF1798EE"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoMinor",
+      "name" : "dark.surface.on-dark.info-minor",
+      "reference" : "SurfaceOnDarkInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0C283B"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoMinor",
+      "name" : "light.surface.on-dark.info-minor",
+      "reference" : "SurfaceOnDarkInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0C283B"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoMinorActive",
+      "name" : "dark.surface.on-dark.info-minor-active",
+      "reference" : "SurfaceOnDarkInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF0A2333"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoMinorActive",
+      "name" : "light.surface.on-dark.info-minor-active",
+      "reference" : "SurfaceOnDarkInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF091D2A"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoMinorHover",
+      "name" : "dark.surface.on-dark.info-minor-hover",
+      "reference" : "SurfaceOnDarkInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF10344C"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceInfoMinorHover",
+      "name" : "light.surface.on-dark.info-minor-hover",
+      "reference" : "SurfaceOnDarkInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF10344C"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegative",
+      "name" : "dark.surface.on-dark.negative",
+      "reference" : "SurfaceOnDarkNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegative",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegative",
+      "name" : "light.surface.on-dark.negative",
+      "reference" : "SurfaceOnDarkNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegative",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeActive",
+      "name" : "dark.surface.on-dark.negative-active",
+      "reference" : "SurfaceOnDarkNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF1F35"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeActive",
+      "name" : "light.surface.on-dark.negative-active",
+      "reference" : "SurfaceOnDarkNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF142C"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeHover",
+      "name" : "dark.surface.on-dark.negative-hover",
+      "reference" : "SurfaceOnDarkNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF475A"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeHover",
+      "name" : "light.surface.on-dark.negative-hover",
+      "reference" : "SurfaceOnDarkNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF5263"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeMinor",
+      "name" : "dark.surface.on-dark.negative-minor",
+      "reference" : "SurfaceOnDarkNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF4A0D13"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeMinor",
+      "name" : "light.surface.on-dark.negative-minor",
+      "reference" : "SurfaceOnDarkNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF4A0D13"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeMinorActive",
+      "name" : "dark.surface.on-dark.negative-minor-active",
+      "reference" : "SurfaceOnDarkNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF410B11"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeMinorActive",
+      "name" : "light.surface.on-dark.negative-minor-active",
+      "reference" : "SurfaceOnDarkNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF380A0F"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeMinorHover",
+      "name" : "dark.surface.on-dark.negative-minor-hover",
+      "reference" : "SurfaceOnDarkNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFF5B1018"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на темном фоне",
+      "displayName" : "onDarkSurfaceNegativeMinorHover",
+      "name" : "light.surface.on-dark.negative-minor-hover",
+      "reference" : "SurfaceOnDarkNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFF64121A"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositive",
+      "name" : "dark.surface.on-dark.positive",
+      "reference" : "SurfaceOnDarkPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositive",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositive",
+      "name" : "light.surface.on-dark.positive",
+      "reference" : "SurfaceOnDarkPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositive",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveActive",
+      "name" : "dark.surface.on-dark.positive-active",
+      "reference" : "SurfaceOnDarkPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveActive",
+      "type" : "color",
+      "value" : "0xFF18952F"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveActive",
+      "name" : "light.surface.on-dark.positive-active",
+      "reference" : "SurfaceOnDarkPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveActive",
+      "type" : "color",
+      "value" : "0xFF178C2C"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveHover",
+      "name" : "dark.surface.on-dark.positive-hover",
+      "reference" : "SurfaceOnDarkPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveHover",
+      "type" : "color",
+      "value" : "0xFF1DAF37"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveHover",
+      "name" : "light.surface.on-dark.positive-hover",
+      "reference" : "SurfaceOnDarkPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveHover",
+      "type" : "color",
+      "value" : "0xFF1EB83A"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveMinor",
+      "name" : "dark.surface.on-dark.positive-minor",
+      "reference" : "SurfaceOnDarkPositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF0A2B10"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveMinor",
+      "name" : "light.surface.on-dark.positive-minor",
+      "reference" : "SurfaceOnDarkPositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF0A2B10"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveMinorActive",
+      "name" : "dark.surface.on-dark.positive-minor-active",
+      "reference" : "SurfaceOnDarkPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF08210C"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveMinorActive",
+      "name" : "light.surface.on-dark.positive-minor-active",
+      "reference" : "SurfaceOnDarkPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF061909"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveMinorHover",
+      "name" : "dark.surface.on-dark.positive-minor-hover",
+      "reference" : "SurfaceOnDarkPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF0E3A16"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfacePositiveMinorHover",
+      "name" : "light.surface.on-dark.positive-minor-hover",
+      "reference" : "SurfaceOnDarkPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF0E3A16"
+    },
+    {
+      "description" : "Цвет ошибки",
+      "displayName" : "textNegativeHover",
+      "name" : "dark.text.default.negative-hover",
+      "reference" : "TextDefaultNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF5C6C"
+    },
+    {
+      "description" : "Цвет ошибки",
+      "displayName" : "textNegativeHover",
+      "name" : "light.text.default.negative-hover",
+      "reference" : "TextDefaultNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF54254"
+    },
+    {
+      "description" : "Основной фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceSolidCard",
+      "name" : "dark.surface.on-dark.solid-card",
+      "reference" : "SurfaceOnDarkSolidCard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidCard",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Основной фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceSolidCard",
+      "name" : "light.surface.on-dark.solid-card",
+      "reference" : "SurfaceOnDarkSolidCard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidCard",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Основной фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceSolidCardActive",
+      "name" : "dark.surface.on-dark.solid-card-active",
+      "reference" : "SurfaceOnDarkSolidCardActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidCardActive",
+      "type" : "color",
+      "value" : "0xFF121212"
+    },
+    {
+      "description" : "Основной фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceSolidCardActive",
+      "name" : "light.surface.on-dark.solid-card-active",
+      "reference" : "SurfaceOnDarkSolidCardActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidCardActive",
+      "type" : "color",
+      "value" : "0xFF0D0D0D"
+    },
+    {
+      "description" : "Основной фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceSolidCardBrightness",
+      "name" : "dark.surface.on-dark.solid-card-brightness",
+      "reference" : "SurfaceOnDarkSolidCardBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidCardBrightness",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceSolidCardBrightness",
+      "name" : "light.surface.on-dark.solid-card-brightness",
+      "reference" : "SurfaceOnDarkSolidCardBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidCardBrightness",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceSolidCardHover",
+      "name" : "dark.surface.on-dark.solid-card-hover",
+      "reference" : "SurfaceOnDarkSolidCardHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidCardHover",
+      "type" : "color",
+      "value" : "0xFF1C1C1C"
+    },
+    {
+      "description" : "Основной фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceSolidCardHover",
+      "name" : "light.surface.on-dark.solid-card-hover",
+      "reference" : "SurfaceOnDarkSolidCardHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidCardHover",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkSurfaceSolidDefault",
+      "name" : "dark.surface.on-dark.solid-default",
+      "reference" : "SurfaceOnDarkSolidDefault",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidDefault",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkSurfaceSolidDefault",
+      "name" : "light.surface.on-dark.solid-default",
+      "reference" : "SurfaceOnDarkSolidDefault",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidDefault",
+      "type" : "color",
+      "value" : "0xFFF9F9F9"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkSurfaceSolidDefaultActive",
+      "name" : "dark.surface.on-dark.solid-default-active",
+      "reference" : "SurfaceOnDarkSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFF5F5F5"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkSurfaceSolidDefaultActive",
+      "name" : "light.surface.on-dark.solid-default-active",
+      "reference" : "SurfaceOnDarkSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFFF5F5F5"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkSurfaceSolidDefaultHover",
+      "name" : "dark.surface.on-dark.solid-default-hover",
+      "reference" : "SurfaceOnDarkSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на темном фоне",
+      "displayName" : "onDarkSurfaceSolidDefaultHover",
+      "name" : "light.surface.on-dark.solid-default-hover",
+      "reference" : "SurfaceOnDarkSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidPrimary",
+      "name" : "dark.surface.on-dark.solid-primary",
+      "reference" : "SurfaceOnDarkSolidPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidPrimary",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidPrimary",
+      "name" : "light.surface.on-dark.solid-primary",
+      "reference" : "SurfaceOnDarkSolidPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidPrimary",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidPrimaryActive",
+      "name" : "dark.surface.on-dark.solid-primary-active",
+      "reference" : "SurfaceOnDarkSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFF121212"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidPrimaryActive",
+      "name" : "light.surface.on-dark.solid-primary-active",
+      "reference" : "SurfaceOnDarkSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFF0D0D0D"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidPrimaryBrightness",
+      "name" : "dark.surface.on-dark.solid-primary-brightness",
+      "reference" : "SurfaceOnDarkSolidPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidPrimaryBrightness",
+      "name" : "light.surface.on-dark.solid-primary-brightness",
+      "reference" : "SurfaceOnDarkSolidPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidPrimaryHover",
+      "name" : "dark.surface.on-dark.solid-primary-hover",
+      "reference" : "SurfaceOnDarkSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF1C1C1C"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidPrimaryHover",
+      "name" : "light.surface.on-dark.solid-primary-hover",
+      "reference" : "SurfaceOnDarkSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidSecondary",
+      "name" : "dark.surface.on-dark.solid-secondary",
+      "reference" : "SurfaceOnDarkSolidSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidSecondary",
+      "name" : "light.surface.on-dark.solid-secondary",
+      "reference" : "SurfaceOnDarkSolidSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidSecondary",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidSecondaryActive",
+      "name" : "dark.surface.on-dark.solid-secondary-active",
+      "reference" : "SurfaceOnDarkSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF212121"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidSecondaryActive",
+      "name" : "light.surface.on-dark.solid-secondary-active",
+      "reference" : "SurfaceOnDarkSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFF1C1C1C"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidSecondaryHover",
+      "name" : "dark.surface.on-dark.solid-secondary-hover",
+      "reference" : "SurfaceOnDarkSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF303030"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidSecondaryHover",
+      "name" : "light.surface.on-dark.solid-secondary-hover",
+      "reference" : "SurfaceOnDarkSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF3B3B3B"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidTertiary",
+      "name" : "dark.surface.on-dark.solid-tertiary",
+      "reference" : "SurfaceOnDarkSolidTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidTertiary",
+      "name" : "light.surface.on-dark.solid-tertiary",
+      "reference" : "SurfaceOnDarkSolidTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidTertiary",
+      "type" : "color",
+      "value" : "0xFF363636"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidTertiaryActive",
+      "name" : "dark.surface.on-dark.solid-tertiary-active",
+      "reference" : "SurfaceOnDarkSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF303030"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidTertiaryActive",
+      "name" : "light.surface.on-dark.solid-tertiary-active",
+      "reference" : "SurfaceOnDarkSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFF2B2B2B"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidTertiaryHover",
+      "name" : "dark.surface.on-dark.solid-tertiary-hover",
+      "reference" : "SurfaceOnDarkSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF404040"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceSolidTertiaryHover",
+      "name" : "light.surface.on-dark.solid-tertiary-hover",
+      "reference" : "SurfaceOnDarkSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF4A4A4A"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentAccent",
+      "name" : "dark.surface.on-dark.transparent-accent",
+      "reference" : "SurfaceOnDarkTransparentAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentAccent",
+      "type" : "color",
+      "value" : "0x33199E31"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentAccent",
+      "name" : "light.surface.on-dark.transparent-accent",
+      "reference" : "SurfaceOnDarkTransparentAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentAccent",
+      "type" : "color",
+      "value" : "0x331A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentAccentActive",
+      "name" : "dark.surface.on-dark.transparent-accent-active",
+      "reference" : "SurfaceOnDarkTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x241A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentAccentActive",
+      "name" : "light.surface.on-dark.transparent-accent-active",
+      "reference" : "SurfaceOnDarkTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x3D1A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentAccentHover",
+      "name" : "dark.surface.on-dark.transparent-accent-hover",
+      "reference" : "SurfaceOnDarkTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentAccentHover",
+      "type" : "color",
+      "value" : "0x521A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentAccentHover",
+      "name" : "light.surface.on-dark.transparent-accent-hover",
+      "reference" : "SurfaceOnDarkTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentAccentHover",
+      "type" : "color",
+      "value" : "0x1F1A9E32"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentCard",
+      "name" : "dark.surface.on-dark.transparent-card",
+      "reference" : "SurfaceOnDarkTransparentCard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentCard",
+      "type" : "color",
+      "value" : "0x0FFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentCard",
+      "name" : "light.surface.on-dark.transparent-card",
+      "reference" : "SurfaceOnDarkTransparentCard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentCard",
+      "type" : "color",
+      "value" : "0x0FF9F9F9"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentCardActive",
+      "name" : "dark.surface.on-dark.transparent-card-active",
+      "reference" : "SurfaceOnDarkTransparentCardActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentCardActive",
+      "type" : "color",
+      "value" : "0x0AFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentCardActive",
+      "name" : "light.surface.on-dark.transparent-card-active",
+      "reference" : "SurfaceOnDarkTransparentCardActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentCardActive",
+      "type" : "color",
+      "value" : "0x1AFAFAFA"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentCardBrightness",
+      "name" : "dark.surface.on-dark.transparent-card-brightness",
+      "reference" : "SurfaceOnDarkTransparentCardBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentCardBrightness",
+      "type" : "color",
+      "value" : "0x0FFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentCardBrightness",
+      "name" : "light.surface.on-dark.transparent-card-brightness",
+      "reference" : "SurfaceOnDarkTransparentCardBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentCardBrightness",
+      "type" : "color",
+      "value" : "0x0FFAFAFA"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentCardHover",
+      "name" : "dark.surface.on-dark.transparent-card-hover",
+      "reference" : "SurfaceOnDarkTransparentCardHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentCardHover",
+      "type" : "color",
+      "value" : "0x1FFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentCardHover",
+      "name" : "light.surface.on-dark.transparent-card-hover",
+      "reference" : "SurfaceOnDarkTransparentCardHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentCardHover",
+      "type" : "color",
+      "value" : "0x05FAFAFA"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentDeep",
+      "name" : "dark.surface.on-dark.transparent-deep",
+      "reference" : "SurfaceOnDarkTransparentDeep",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentDeep",
+      "type" : "color",
+      "value" : "0xA3FFFFFF"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentDeep",
+      "name" : "light.surface.on-dark.transparent-deep",
+      "reference" : "SurfaceOnDarkTransparentDeep",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentDeep",
+      "type" : "color",
+      "value" : "0xA3F9F9F9"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentDeepActive",
+      "name" : "dark.surface.on-dark.transparent-deep-active",
+      "reference" : "SurfaceOnDarkTransparentDeepActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentDeepActive",
+      "type" : "color",
+      "value" : "0x94FFFFFF"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentDeepActive",
+      "name" : "light.surface.on-dark.transparent-deep-active",
+      "reference" : "SurfaceOnDarkTransparentDeepActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentDeepActive",
+      "type" : "color",
+      "value" : "0xADFAFAFA"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentDeepHover",
+      "name" : "dark.surface.on-dark.transparent-deep-hover",
+      "reference" : "SurfaceOnDarkTransparentDeepHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentDeepHover",
+      "type" : "color",
+      "value" : "0xC2FFFFFF"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentDeepHover",
+      "name" : "light.surface.on-dark.transparent-deep-hover",
+      "reference" : "SurfaceOnDarkTransparentDeepHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentDeepHover",
+      "type" : "color",
+      "value" : "0x8FFAFAFA"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentInfo",
+      "name" : "dark.surface.on-dark.transparent-info",
+      "reference" : "SurfaceOnDarkTransparentInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentInfo",
+      "type" : "color",
+      "value" : "0x33118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentInfo",
+      "name" : "light.surface.on-dark.transparent-info",
+      "reference" : "SurfaceOnDarkTransparentInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentInfo",
+      "type" : "color",
+      "value" : "0x33118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentInfoActive",
+      "name" : "dark.surface.on-dark.transparent-info-active",
+      "reference" : "SurfaceOnDarkTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x24118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentInfoActive",
+      "name" : "light.surface.on-dark.transparent-info-active",
+      "reference" : "SurfaceOnDarkTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x3D118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentInfoHover",
+      "name" : "dark.surface.on-dark.transparent-info-hover",
+      "reference" : "SurfaceOnDarkTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentInfoHover",
+      "type" : "color",
+      "value" : "0x52118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentInfoHover",
+      "name" : "light.surface.on-dark.transparent-info-hover",
+      "reference" : "SurfaceOnDarkTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentInfoHover",
+      "type" : "color",
+      "value" : "0x1F118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentNegative",
+      "name" : "dark.surface.on-dark.transparent-negative",
+      "reference" : "SurfaceOnDarkTransparentNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentNegative",
+      "type" : "color",
+      "value" : "0x33FF293D"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentNegative",
+      "name" : "light.surface.on-dark.transparent-negative",
+      "reference" : "SurfaceOnDarkTransparentNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentNegative",
+      "type" : "color",
+      "value" : "0x33FF293E"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentNegativeActive",
+      "name" : "dark.surface.on-dark.transparent-negative-active",
+      "reference" : "SurfaceOnDarkTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x24FF293E"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentNegativeActive",
+      "name" : "light.surface.on-dark.transparent-negative-active",
+      "reference" : "SurfaceOnDarkTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x3DFF293E"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentNegativeHover",
+      "name" : "dark.surface.on-dark.transparent-negative-hover",
+      "reference" : "SurfaceOnDarkTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0x52FF293E"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentNegativeHover",
+      "name" : "light.surface.on-dark.transparent-negative-hover",
+      "reference" : "SurfaceOnDarkTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0x1FFF293E"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPositive",
+      "name" : "dark.surface.on-dark.transparent-positive",
+      "reference" : "SurfaceOnDarkTransparentPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPositive",
+      "type" : "color",
+      "value" : "0x33199E31"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPositive",
+      "name" : "light.surface.on-dark.transparent-positive",
+      "reference" : "SurfaceOnDarkTransparentPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPositive",
+      "type" : "color",
+      "value" : "0x331A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPositiveActive",
+      "name" : "dark.surface.on-dark.transparent-positive-active",
+      "reference" : "SurfaceOnDarkTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x241A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPositiveActive",
+      "name" : "light.surface.on-dark.transparent-positive-active",
+      "reference" : "SurfaceOnDarkTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x3D1A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPositiveHover",
+      "name" : "dark.surface.on-dark.transparent-positive-hover",
+      "reference" : "SurfaceOnDarkTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0x521A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPositiveHover",
+      "name" : "light.surface.on-dark.transparent-positive-hover",
+      "reference" : "SurfaceOnDarkTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0x1F1A9E32"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPrimary",
+      "name" : "dark.surface.on-dark.transparent-primary",
+      "reference" : "SurfaceOnDarkTransparentPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPrimary",
+      "type" : "color",
+      "value" : "0x0FFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPrimary",
+      "name" : "light.surface.on-dark.transparent-primary",
+      "reference" : "SurfaceOnDarkTransparentPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPrimary",
+      "type" : "color",
+      "value" : "0x0FF9F9F9"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPrimaryActive",
+      "name" : "dark.surface.on-dark.transparent-primary-active",
+      "reference" : "SurfaceOnDarkTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x0AFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPrimaryActive",
+      "name" : "light.surface.on-dark.transparent-primary-active",
+      "reference" : "SurfaceOnDarkTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x1AFAFAFA"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPrimaryHover",
+      "name" : "dark.surface.on-dark.transparent-primary-hover",
+      "reference" : "SurfaceOnDarkTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0x1FFFFFFF"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentPrimaryHover",
+      "name" : "light.surface.on-dark.transparent-primary-hover",
+      "reference" : "SurfaceOnDarkTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0x05FAFAFA"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentSecondary",
+      "name" : "dark.surface.on-dark.transparent-secondary",
+      "reference" : "SurfaceOnDarkTransparentSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentSecondary",
+      "type" : "color",
+      "value" : "0x1FFFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentSecondary",
+      "name" : "light.surface.on-dark.transparent-secondary",
+      "reference" : "SurfaceOnDarkTransparentSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentSecondary",
+      "type" : "color",
+      "value" : "0x1FF9F9F9"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentSecondaryActive",
+      "name" : "dark.surface.on-dark.transparent-secondary-active",
+      "reference" : "SurfaceOnDarkTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x0FFFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentSecondaryActive",
+      "name" : "light.surface.on-dark.transparent-secondary-active",
+      "reference" : "SurfaceOnDarkTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x29FAFAFA"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentSecondaryHover",
+      "name" : "dark.surface.on-dark.transparent-secondary-hover",
+      "reference" : "SurfaceOnDarkTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0x3DFFFFFF"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentSecondaryHover",
+      "name" : "light.surface.on-dark.transparent-secondary-hover",
+      "reference" : "SurfaceOnDarkTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0x0AFAFAFA"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentTertiary",
+      "name" : "dark.surface.on-dark.transparent-tertiary",
+      "reference" : "SurfaceOnDarkTransparentTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentTertiary",
+      "type" : "color",
+      "value" : "0x33FFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentTertiary",
+      "name" : "light.surface.on-dark.transparent-tertiary",
+      "reference" : "SurfaceOnDarkTransparentTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentTertiary",
+      "type" : "color",
+      "value" : "0x33F9F9F9"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentTertiaryActive",
+      "name" : "dark.surface.on-dark.transparent-tertiary-active",
+      "reference" : "SurfaceOnDarkTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0x24FFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentTertiaryActive",
+      "name" : "light.surface.on-dark.transparent-tertiary-active",
+      "reference" : "SurfaceOnDarkTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0x3DFAFAFA"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentTertiaryHover",
+      "name" : "dark.surface.on-dark.transparent-tertiary-hover",
+      "reference" : "SurfaceOnDarkTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0x52FFFFFF"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentTertiaryHover",
+      "name" : "light.surface.on-dark.transparent-tertiary-hover",
+      "reference" : "SurfaceOnDarkTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0x1FFAFAFA"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentWarning",
+      "name" : "dark.surface.on-dark.transparent-warning",
+      "reference" : "SurfaceOnDarkTransparentWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentWarning",
+      "type" : "color",
+      "value" : "0x33FA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentWarning",
+      "name" : "light.surface.on-dark.transparent-warning",
+      "reference" : "SurfaceOnDarkTransparentWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentWarning",
+      "type" : "color",
+      "value" : "0x33FA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentWarningActive",
+      "name" : "dark.surface.on-dark.transparent-warning-active",
+      "reference" : "SurfaceOnDarkTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x24FA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentWarningActive",
+      "name" : "light.surface.on-dark.transparent-warning-active",
+      "reference" : "SurfaceOnDarkTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x3DFA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentWarningHover",
+      "name" : "dark.surface.on-dark.transparent-warning-hover",
+      "reference" : "SurfaceOnDarkTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentWarningHover",
+      "type" : "color",
+      "value" : "0x52FA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceTransparentWarningHover",
+      "name" : "light.surface.on-dark.transparent-warning-hover",
+      "reference" : "SurfaceOnDarkTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkTransparentWarningHover",
+      "type" : "color",
+      "value" : "0x1FFA5F05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarning",
+      "name" : "dark.surface.on-dark.warning",
+      "reference" : "SurfaceOnDarkWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarning",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarning",
+      "name" : "light.surface.on-dark.warning",
+      "reference" : "SurfaceOnDarkWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarning",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningActive",
+      "name" : "dark.surface.on-dark.warning-active",
+      "reference" : "SurfaceOnDarkWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningActive",
+      "type" : "color",
+      "value" : "0xFFF05B05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningActive",
+      "name" : "light.surface.on-dark.warning-active",
+      "reference" : "SurfaceOnDarkWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningActive",
+      "type" : "color",
+      "value" : "0xFFE65705"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningHover",
+      "name" : "dark.surface.on-dark.warning-hover",
+      "reference" : "SurfaceOnDarkWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningHover",
+      "type" : "color",
+      "value" : "0xFFFB7223"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningHover",
+      "name" : "light.surface.on-dark.warning-hover",
+      "reference" : "SurfaceOnDarkWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningHover",
+      "type" : "color",
+      "value" : "0xFFFB782D"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningMinor",
+      "name" : "dark.surface.on-dark.warning-minor",
+      "reference" : "SurfaceOnDarkWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningMinor",
+      "type" : "color",
+      "value" : "0xFF3D1D0A"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningMinor",
+      "name" : "light.surface.on-dark.warning-minor",
+      "reference" : "SurfaceOnDarkWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningMinor",
+      "type" : "color",
+      "value" : "0xFF3D1D0A"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningMinorActive",
+      "name" : "dark.surface.on-dark.warning-minor-active",
+      "reference" : "SurfaceOnDarkWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFF351909"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningMinorActive",
+      "name" : "light.surface.on-dark.warning-minor-active",
+      "reference" : "SurfaceOnDarkWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFF2C1507"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningMinorHover",
+      "name" : "dark.surface.on-dark.warning-minor-hover",
+      "reference" : "SurfaceOnDarkWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFF4F250D"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на темном фоне",
+      "displayName" : "onDarkSurfaceWarningMinorHover",
+      "name" : "light.surface.on-dark.warning-minor-hover",
+      "reference" : "SurfaceOnDarkWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnDarkWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFF58290E"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccent",
+      "name" : "dark.surface.on-light.accent",
+      "reference" : "SurfaceOnLightAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccent",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccent",
+      "name" : "light.surface.on-light.accent",
+      "reference" : "SurfaceOnLightAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccent",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentActive",
+      "name" : "dark.surface.on-light.accent-active",
+      "reference" : "SurfaceOnLightAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentActive",
+      "type" : "color",
+      "value" : "0xFF18952F"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentActive",
+      "name" : "light.surface.on-light.accent-active",
+      "reference" : "SurfaceOnLightAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentActive",
+      "type" : "color",
+      "value" : "0xFF178C2C"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentHover",
+      "name" : "dark.surface.on-light.accent-hover",
+      "reference" : "SurfaceOnLightAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentHover",
+      "type" : "color",
+      "value" : "0xFF1DAF37"
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentHover",
+      "name" : "light.surface.on-light.accent-hover",
+      "reference" : "SurfaceOnLightAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentHover",
+      "type" : "color",
+      "value" : "0xFF1EB83A"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentMinor",
+      "name" : "dark.surface.on-light.accent-minor",
+      "reference" : "SurfaceOnLightAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentMinor",
+      "type" : "color",
+      "value" : "0xFF9EFAAF"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentMinor",
+      "name" : "light.surface.on-light.accent-minor",
+      "reference" : "SurfaceOnLightAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentMinor",
+      "type" : "color",
+      "value" : "0xFF9EFAAF"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentMinorActive",
+      "name" : "dark.surface.on-light.accent-minor-active",
+      "reference" : "SurfaceOnLightAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF94F9A7"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentMinorActive",
+      "name" : "light.surface.on-light.accent-minor-active",
+      "reference" : "SurfaceOnLightAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF8BF99F"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentMinorHover",
+      "name" : "dark.surface.on-light.accent-minor-hover",
+      "reference" : "SurfaceOnLightAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFFB1FBBF"
+    },
+    {
+      "description" : "Акцентный минорный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceAccentMinorHover",
+      "name" : "light.surface.on-light.accent-minor-hover",
+      "reference" : "SurfaceOnLightAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFFB1FBBF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на светлом фоне",
+      "displayName" : "onLightSurfaceClear",
+      "name" : "dark.surface.on-light.clear",
+      "reference" : "SurfaceOnLightClear",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на светлом фоне",
+      "displayName" : "onLightSurfaceClear",
+      "name" : "light.surface.on-light.clear",
+      "reference" : "SurfaceOnLightClear",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightClear",
+      "type" : "color",
+      "value" : "0x00FFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на светлом фоне",
+      "displayName" : "onLightSurfaceClearActive",
+      "name" : "dark.surface.on-light.clear-active",
+      "reference" : "SurfaceOnLightClearActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на светлом фоне",
+      "displayName" : "onLightSurfaceClearActive",
+      "name" : "light.surface.on-light.clear-active",
+      "reference" : "SurfaceOnLightClearActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightClearActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на светлом фоне",
+      "displayName" : "onLightSurfaceClearHover",
+      "name" : "dark.surface.on-light.clear-hover",
+      "reference" : "SurfaceOnLightClearHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Фон поверхности/контрола без заливки на светлом фоне",
+      "displayName" : "onLightSurfaceClearHover",
+      "name" : "light.surface.on-light.clear-hover",
+      "reference" : "SurfaceOnLightClearHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightClearHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfo",
+      "name" : "dark.surface.on-light.info",
+      "reference" : "SurfaceOnLightInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfo",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfo",
+      "name" : "light.surface.on-light.info",
+      "reference" : "SurfaceOnLightInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfo",
+      "type" : "color",
+      "value" : "0xFF118CDF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoActive",
+      "name" : "dark.surface.on-light.info-active",
+      "reference" : "SurfaceOnLightInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoActive",
+      "type" : "color",
+      "value" : "0xFF1086D5"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoActive",
+      "name" : "light.surface.on-light.info-active",
+      "reference" : "SurfaceOnLightInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoActive",
+      "type" : "color",
+      "value" : "0xFF0F81CC"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoHover",
+      "name" : "dark.surface.on-light.info-hover",
+      "reference" : "SurfaceOnLightInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoHover",
+      "type" : "color",
+      "value" : "0xFF1798EE"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoHover",
+      "name" : "light.surface.on-light.info-hover",
+      "reference" : "SurfaceOnLightInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoHover",
+      "type" : "color",
+      "value" : "0xFF1798EE"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoMinor",
+      "name" : "dark.surface.on-light.info-minor",
+      "reference" : "SurfaceOnLightInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoMinor",
+      "type" : "color",
+      "value" : "0xFFCFECFF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoMinor",
+      "name" : "light.surface.on-light.info-minor",
+      "reference" : "SurfaceOnLightInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoMinor",
+      "type" : "color",
+      "value" : "0xFFCFECFF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoMinorActive",
+      "name" : "dark.surface.on-light.info-minor-active",
+      "reference" : "SurfaceOnLightInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFFC7E9FF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoMinorActive",
+      "name" : "light.surface.on-light.info-minor-active",
+      "reference" : "SurfaceOnLightInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFFC7E9FF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoMinorHover",
+      "name" : "dark.surface.on-light.info-minor-hover",
+      "reference" : "SurfaceOnLightInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFFDBF1FF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceInfoMinorHover",
+      "name" : "light.surface.on-light.info-minor-hover",
+      "reference" : "SurfaceOnLightInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFFE5F5FF"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegative",
+      "name" : "dark.surface.on-light.negative",
+      "reference" : "SurfaceOnLightNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegative",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegative",
+      "name" : "light.surface.on-light.negative",
+      "reference" : "SurfaceOnLightNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegative",
+      "type" : "color",
+      "value" : "0xFFFF293E"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeActive",
+      "name" : "dark.surface.on-light.negative-active",
+      "reference" : "SurfaceOnLightNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF1F35"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeActive",
+      "name" : "light.surface.on-light.negative-active",
+      "reference" : "SurfaceOnLightNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF142C"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeHover",
+      "name" : "dark.surface.on-light.negative-hover",
+      "reference" : "SurfaceOnLightNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF475A"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeHover",
+      "name" : "light.surface.on-light.negative-hover",
+      "reference" : "SurfaceOnLightNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF5263"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeMinor",
+      "name" : "dark.surface.on-light.negative-minor",
+      "reference" : "SurfaceOnLightNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFFE0E3"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeMinor",
+      "name" : "light.surface.on-light.negative-minor",
+      "reference" : "SurfaceOnLightNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFFE0E3"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeMinorActive",
+      "name" : "dark.surface.on-light.negative-minor-active",
+      "reference" : "SurfaceOnLightNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFFD6DA"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeMinorActive",
+      "name" : "light.surface.on-light.negative-minor-active",
+      "reference" : "SurfaceOnLightNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFFD6DA"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeMinorHover",
+      "name" : "dark.surface.on-light.negative-minor-hover",
+      "reference" : "SurfaceOnLightNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFEBED"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола ошибка на светлом фоне",
+      "displayName" : "onLightSurfaceNegativeMinorHover",
+      "name" : "light.surface.on-light.negative-minor-hover",
+      "reference" : "SurfaceOnLightNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFF5F6"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositive",
+      "name" : "dark.surface.on-light.positive",
+      "reference" : "SurfaceOnLightPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositive",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositive",
+      "name" : "light.surface.on-light.positive",
+      "reference" : "SurfaceOnLightPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositive",
+      "type" : "color",
+      "value" : "0xFF1A9E32"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveActive",
+      "name" : "dark.surface.on-light.positive-active",
+      "reference" : "SurfaceOnLightPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveActive",
+      "type" : "color",
+      "value" : "0xFF18952F"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveActive",
+      "name" : "light.surface.on-light.positive-active",
+      "reference" : "SurfaceOnLightPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveActive",
+      "type" : "color",
+      "value" : "0xFF178C2C"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveHover",
+      "name" : "dark.surface.on-light.positive-hover",
+      "reference" : "SurfaceOnLightPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveHover",
+      "type" : "color",
+      "value" : "0xFF1DAF37"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveHover",
+      "name" : "light.surface.on-light.positive-hover",
+      "reference" : "SurfaceOnLightPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveHover",
+      "type" : "color",
+      "value" : "0xFF1EB83A"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveMinor",
+      "name" : "dark.surface.on-light.positive-minor",
+      "reference" : "SurfaceOnLightPositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF9EFAAF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveMinor",
+      "name" : "light.surface.on-light.positive-minor",
+      "reference" : "SurfaceOnLightPositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF9EFAAF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveMinorActive",
+      "name" : "dark.surface.on-light.positive-minor-active",
+      "reference" : "SurfaceOnLightPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF94F9A7"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveMinorActive",
+      "name" : "light.surface.on-light.positive-minor-active",
+      "reference" : "SurfaceOnLightPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF8BF99F"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveMinorHover",
+      "name" : "dark.surface.on-light.positive-minor-hover",
+      "reference" : "SurfaceOnLightPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFFB1FBBF"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfacePositiveMinorHover",
+      "name" : "light.surface.on-light.positive-minor-hover",
+      "reference" : "SurfaceOnLightPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFFB1FBBF"
+    },
+    {
+      "description" : "Основной фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceSolidCard",
+      "name" : "dark.surface.on-light.solid-card",
+      "reference" : "SurfaceOnLightSolidCard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidCard",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceSolidCard",
+      "name" : "light.surface.on-light.solid-card",
+      "reference" : "SurfaceOnLightSolidCard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidCard",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceSolidCardActive",
+      "name" : "dark.surface.on-light.solid-card-active",
+      "reference" : "SurfaceOnLightSolidCardActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidCardActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceSolidCardActive",
+      "name" : "light.surface.on-light.solid-card-active",
+      "reference" : "SurfaceOnLightSolidCardActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidCardActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceSolidCardBrightness",
+      "name" : "dark.surface.on-light.solid-card-brightness",
+      "reference" : "SurfaceOnLightSolidCardBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidCardBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceSolidCardBrightness",
+      "name" : "light.surface.on-light.solid-card-brightness",
+      "reference" : "SurfaceOnLightSolidCardBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidCardBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceSolidCardHover",
+      "name" : "dark.surface.on-light.solid-card-hover",
+      "reference" : "SurfaceOnLightSolidCardHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidCardHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceSolidCardHover",
+      "name" : "light.surface.on-light.solid-card-hover",
+      "reference" : "SurfaceOnLightSolidCardHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidCardHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightSurfaceSolidDefault",
+      "name" : "dark.surface.on-light.solid-default",
+      "reference" : "SurfaceOnLightSolidDefault",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidDefault",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightSurfaceSolidDefault",
+      "name" : "light.surface.on-light.solid-default",
+      "reference" : "SurfaceOnLightSolidDefault",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidDefault",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightSurfaceSolidDefaultActive",
+      "name" : "dark.surface.on-light.solid-default-active",
+      "reference" : "SurfaceOnLightSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFF030303"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightSurfaceSolidDefaultActive",
+      "name" : "light.surface.on-light.solid-default-active",
+      "reference" : "SurfaceOnLightSolidDefaultActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidDefaultActive",
+      "type" : "color",
+      "value" : "0xFF030303"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightSurfaceSolidDefaultHover",
+      "name" : "dark.surface.on-light.solid-default-hover",
+      "reference" : "SurfaceOnLightSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFF0D0D0D"
+    },
+    {
+      "description" : "Непрозрачный фон поверхности/контрола по умолчанию на светлом фоне",
+      "displayName" : "onLightSurfaceSolidDefaultHover",
+      "name" : "light.surface.on-light.solid-default-hover",
+      "reference" : "SurfaceOnLightSolidDefaultHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidDefaultHover",
+      "type" : "color",
+      "value" : "0xFF262626"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidPrimary",
+      "name" : "dark.surface.on-light.solid-primary",
+      "reference" : "SurfaceOnLightSolidPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidPrimary",
+      "type" : "color",
+      "value" : "0xFFF5F5F5"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidPrimary",
+      "name" : "light.surface.on-light.solid-primary",
+      "reference" : "SurfaceOnLightSolidPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidPrimary",
+      "type" : "color",
+      "value" : "0xFFF5F5F5"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidPrimaryActive",
+      "name" : "dark.surface.on-light.solid-primary-active",
+      "reference" : "SurfaceOnLightSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFF0F0F0"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidPrimaryActive",
+      "name" : "light.surface.on-light.solid-primary-active",
+      "reference" : "SurfaceOnLightSolidPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidPrimaryActive",
+      "type" : "color",
+      "value" : "0xFFF0F0F0"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidPrimaryBrightness",
+      "name" : "dark.surface.on-light.solid-primary-brightness",
+      "reference" : "SurfaceOnLightSolidPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidPrimaryBrightness",
+      "name" : "light.surface.on-light.solid-primary-brightness",
+      "reference" : "SurfaceOnLightSolidPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidPrimaryHover",
+      "name" : "dark.surface.on-light.solid-primary-hover",
+      "reference" : "SurfaceOnLightSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Основной непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidPrimaryHover",
+      "name" : "light.surface.on-light.solid-primary-hover",
+      "reference" : "SurfaceOnLightSolidPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidPrimaryHover",
+      "type" : "color",
+      "value" : "0xFFFAFAFA"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidSecondary",
+      "name" : "dark.surface.on-light.solid-secondary",
+      "reference" : "SurfaceOnLightSolidSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidSecondary",
+      "type" : "color",
+      "value" : "0xFFECECEC"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidSecondary",
+      "name" : "light.surface.on-light.solid-secondary",
+      "reference" : "SurfaceOnLightSolidSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidSecondary",
+      "type" : "color",
+      "value" : "0xFFECECEC"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidSecondaryActive",
+      "name" : "dark.surface.on-light.solid-secondary-active",
+      "reference" : "SurfaceOnLightSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFFE8E8E8"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidSecondaryActive",
+      "name" : "light.surface.on-light.solid-secondary-active",
+      "reference" : "SurfaceOnLightSolidSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidSecondaryActive",
+      "type" : "color",
+      "value" : "0xFFE8E8E8"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidSecondaryHover",
+      "name" : "dark.surface.on-light.solid-secondary-hover",
+      "reference" : "SurfaceOnLightSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFF7F7F7"
+    },
+    {
+      "description" : "Вторичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidSecondaryHover",
+      "name" : "light.surface.on-light.solid-secondary-hover",
+      "reference" : "SurfaceOnLightSolidSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFF7F7F7"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidTertiary",
+      "name" : "dark.surface.on-light.solid-tertiary",
+      "reference" : "SurfaceOnLightSolidTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidTertiary",
+      "type" : "color",
+      "value" : "0xFFDDDDDD"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidTertiary",
+      "name" : "light.surface.on-light.solid-tertiary",
+      "reference" : "SurfaceOnLightSolidTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidTertiary",
+      "type" : "color",
+      "value" : "0xFFDDDDDD"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidTertiaryActive",
+      "name" : "dark.surface.on-light.solid-tertiary-active",
+      "reference" : "SurfaceOnLightSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFFD9D9D9"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidTertiaryActive",
+      "name" : "light.surface.on-light.solid-tertiary-active",
+      "reference" : "SurfaceOnLightSolidTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidTertiaryActive",
+      "type" : "color",
+      "value" : "0xFFD4D4D4"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidTertiaryHover",
+      "name" : "dark.surface.on-light.solid-tertiary-hover",
+      "reference" : "SurfaceOnLightSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFE8E8E8"
+    },
+    {
+      "description" : "Третичный непрозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceSolidTertiaryHover",
+      "name" : "light.surface.on-light.solid-tertiary-hover",
+      "reference" : "SurfaceOnLightSolidTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightSolidTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFEDEDED"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentAccent",
+      "name" : "dark.surface.on-light.transparent-accent",
+      "reference" : "SurfaceOnLightTransparentAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentAccent",
+      "type" : "color",
+      "value" : "0x1F1A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentAccent",
+      "name" : "light.surface.on-light.transparent-accent",
+      "reference" : "SurfaceOnLightTransparentAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentAccent",
+      "type" : "color",
+      "value" : "0x1F108E26"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentAccentActive",
+      "name" : "dark.surface.on-light.transparent-accent-active",
+      "reference" : "SurfaceOnLightTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x0F1A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentAccentActive",
+      "name" : "light.surface.on-light.transparent-accent-active",
+      "reference" : "SurfaceOnLightTransparentAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentAccentActive",
+      "type" : "color",
+      "value" : "0x29108E25"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentAccentHover",
+      "name" : "dark.surface.on-light.transparent-accent-hover",
+      "reference" : "SurfaceOnLightTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentAccentHover",
+      "type" : "color",
+      "value" : "0x3D1A9E32"
+    },
+    {
+      "description" : "Прозрачный акцентный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentAccentHover",
+      "name" : "light.surface.on-light.transparent-accent-hover",
+      "reference" : "SurfaceOnLightTransparentAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentAccentHover",
+      "type" : "color",
+      "value" : "0x0A108E25"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentCard",
+      "name" : "dark.surface.on-light.transparent-card",
+      "reference" : "SurfaceOnLightTransparentCard",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentCard",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentCard",
+      "name" : "light.surface.on-light.transparent-card",
+      "reference" : "SurfaceOnLightTransparentCard",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentCard",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentCardActive",
+      "name" : "dark.surface.on-light.transparent-card-active",
+      "reference" : "SurfaceOnLightTransparentCardActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentCardActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentCardActive",
+      "name" : "light.surface.on-light.transparent-card-active",
+      "reference" : "SurfaceOnLightTransparentCardActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentCardActive",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentCardBrightness",
+      "name" : "dark.surface.on-light.transparent-card-brightness",
+      "reference" : "SurfaceOnLightTransparentCardBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentCardBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentCardBrightness",
+      "name" : "light.surface.on-light.transparent-card-brightness",
+      "reference" : "SurfaceOnLightTransparentCardBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentCardBrightness",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentCardHover",
+      "name" : "dark.surface.on-light.transparent-card-hover",
+      "reference" : "SurfaceOnLightTransparentCardHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentCardHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Прозрачный фон для карточек на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentCardHover",
+      "name" : "light.surface.on-light.transparent-card-hover",
+      "reference" : "SurfaceOnLightTransparentCardHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentCardHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentDeep",
+      "name" : "dark.surface.on-light.transparent-deep",
+      "reference" : "SurfaceOnLightTransparentDeep",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentDeep",
+      "type" : "color",
+      "value" : "0xA3080808"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentDeep",
+      "name" : "light.surface.on-light.transparent-deep",
+      "reference" : "SurfaceOnLightTransparentDeep",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentDeep",
+      "type" : "color",
+      "value" : "0xA3080808"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentDeepActive",
+      "name" : "dark.surface.on-light.transparent-deep-active",
+      "reference" : "SurfaceOnLightTransparentDeepActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentDeepActive",
+      "type" : "color",
+      "value" : "0x94080808"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentDeepActive",
+      "name" : "light.surface.on-light.transparent-deep-active",
+      "reference" : "SurfaceOnLightTransparentDeepActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentDeepActive",
+      "type" : "color",
+      "value" : "0xAD080808"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentDeepHover",
+      "name" : "dark.surface.on-light.transparent-deep-hover",
+      "reference" : "SurfaceOnLightTransparentDeepHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentDeepHover",
+      "type" : "color",
+      "value" : "0xC2080808"
+    },
+    {
+      "description" : "Глубокий прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentDeepHover",
+      "name" : "light.surface.on-light.transparent-deep-hover",
+      "reference" : "SurfaceOnLightTransparentDeepHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentDeepHover",
+      "type" : "color",
+      "value" : "0x8F080808"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentInfo",
+      "name" : "dark.surface.on-light.transparent-info",
+      "reference" : "SurfaceOnLightTransparentInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentInfo",
+      "type" : "color",
+      "value" : "0x1E118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentInfo",
+      "name" : "light.surface.on-light.transparent-info",
+      "reference" : "SurfaceOnLightTransparentInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentInfo",
+      "type" : "color",
+      "value" : "0x1F0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentInfoActive",
+      "name" : "dark.surface.on-light.transparent-info-active",
+      "reference" : "SurfaceOnLightTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x0F118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentInfoActive",
+      "name" : "light.surface.on-light.transparent-info-active",
+      "reference" : "SurfaceOnLightTransparentInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentInfoActive",
+      "type" : "color",
+      "value" : "0x290B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentInfoHover",
+      "name" : "dark.surface.on-light.transparent-info-hover",
+      "reference" : "SurfaceOnLightTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentInfoHover",
+      "type" : "color",
+      "value" : "0x3D118CDF"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола информация на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentInfoHover",
+      "name" : "light.surface.on-light.transparent-info-hover",
+      "reference" : "SurfaceOnLightTransparentInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentInfoHover",
+      "type" : "color",
+      "value" : "0x0A0B7ECB"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentNegative",
+      "name" : "dark.surface.on-light.transparent-negative",
+      "reference" : "SurfaceOnLightTransparentNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentNegative",
+      "type" : "color",
+      "value" : "0x1EFF293D"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentNegative",
+      "name" : "light.surface.on-light.transparent-negative",
+      "reference" : "SurfaceOnLightTransparentNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentNegative",
+      "type" : "color",
+      "value" : "0x1FF31B31"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentNegativeActive",
+      "name" : "dark.surface.on-light.transparent-negative-active",
+      "reference" : "SurfaceOnLightTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x0FFF293E"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentNegativeActive",
+      "name" : "light.surface.on-light.transparent-negative-active",
+      "reference" : "SurfaceOnLightTransparentNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentNegativeActive",
+      "type" : "color",
+      "value" : "0x29F31B31"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentNegativeHover",
+      "name" : "dark.surface.on-light.transparent-negative-hover",
+      "reference" : "SurfaceOnLightTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0x3DFF293E"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentNegativeHover",
+      "name" : "light.surface.on-light.transparent-negative-hover",
+      "reference" : "SurfaceOnLightTransparentNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentNegativeHover",
+      "type" : "color",
+      "value" : "0x0AF31B31"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPositive",
+      "name" : "dark.surface.on-light.transparent-positive",
+      "reference" : "SurfaceOnLightTransparentPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPositive",
+      "type" : "color",
+      "value" : "0x1E199E31"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPositive",
+      "name" : "light.surface.on-light.transparent-positive",
+      "reference" : "SurfaceOnLightTransparentPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPositive",
+      "type" : "color",
+      "value" : "0x1F108E26"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPositiveActive",
+      "name" : "dark.surface.on-light.transparent-positive-active",
+      "reference" : "SurfaceOnLightTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x0F1A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPositiveActive",
+      "name" : "light.surface.on-light.transparent-positive-active",
+      "reference" : "SurfaceOnLightTransparentPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPositiveActive",
+      "type" : "color",
+      "value" : "0x29108E25"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPositiveHover",
+      "name" : "dark.surface.on-light.transparent-positive-hover",
+      "reference" : "SurfaceOnLightTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0x3D1A9E32"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола успех на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPositiveHover",
+      "name" : "light.surface.on-light.transparent-positive-hover",
+      "reference" : "SurfaceOnLightTransparentPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPositiveHover",
+      "type" : "color",
+      "value" : "0x0A108E25"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPrimary",
+      "name" : "dark.surface.on-light.transparent-primary",
+      "reference" : "SurfaceOnLightTransparentPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPrimary",
+      "type" : "color",
+      "value" : "0x08080808"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPrimary",
+      "name" : "light.surface.on-light.transparent-primary",
+      "reference" : "SurfaceOnLightTransparentPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPrimary",
+      "type" : "color",
+      "value" : "0x08080808"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPrimaryActive",
+      "name" : "dark.surface.on-light.transparent-primary-active",
+      "reference" : "SurfaceOnLightTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x03080808"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPrimaryActive",
+      "name" : "light.surface.on-light.transparent-primary-active",
+      "reference" : "SurfaceOnLightTransparentPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPrimaryActive",
+      "type" : "color",
+      "value" : "0x0D080808"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPrimaryHover",
+      "name" : "dark.surface.on-light.transparent-primary-hover",
+      "reference" : "SurfaceOnLightTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0x12080808"
+    },
+    {
+      "description" : "Основной прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentPrimaryHover",
+      "name" : "light.surface.on-light.transparent-primary-hover",
+      "reference" : "SurfaceOnLightTransparentPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentPrimaryHover",
+      "type" : "color",
+      "value" : "0x03080808"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentSecondary",
+      "name" : "dark.surface.on-light.transparent-secondary",
+      "reference" : "SurfaceOnLightTransparentSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentSecondary",
+      "type" : "color",
+      "value" : "0x0F080808"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentSecondary",
+      "name" : "light.surface.on-light.transparent-secondary",
+      "reference" : "SurfaceOnLightTransparentSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentSecondary",
+      "type" : "color",
+      "value" : "0x0F080808"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentSecondaryActive",
+      "name" : "dark.surface.on-light.transparent-secondary-active",
+      "reference" : "SurfaceOnLightTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x0A080808"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentSecondaryActive",
+      "name" : "light.surface.on-light.transparent-secondary-active",
+      "reference" : "SurfaceOnLightTransparentSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentSecondaryActive",
+      "type" : "color",
+      "value" : "0x1A080808"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentSecondaryHover",
+      "name" : "dark.surface.on-light.transparent-secondary-hover",
+      "reference" : "SurfaceOnLightTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0x1F080808"
+    },
+    {
+      "description" : "Вторичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentSecondaryHover",
+      "name" : "light.surface.on-light.transparent-secondary-hover",
+      "reference" : "SurfaceOnLightTransparentSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentSecondaryHover",
+      "type" : "color",
+      "value" : "0x05080808"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentTertiary",
+      "name" : "dark.surface.on-light.transparent-tertiary",
+      "reference" : "SurfaceOnLightTransparentTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentTertiary",
+      "type" : "color",
+      "value" : "0x1F080808"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentTertiary",
+      "name" : "light.surface.on-light.transparent-tertiary",
+      "reference" : "SurfaceOnLightTransparentTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentTertiary",
+      "type" : "color",
+      "value" : "0x1F080808"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentTertiaryActive",
+      "name" : "dark.surface.on-light.transparent-tertiary-active",
+      "reference" : "SurfaceOnLightTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0x0F080808"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentTertiaryActive",
+      "name" : "light.surface.on-light.transparent-tertiary-active",
+      "reference" : "SurfaceOnLightTransparentTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentTertiaryActive",
+      "type" : "color",
+      "value" : "0x29080808"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentTertiaryHover",
+      "name" : "dark.surface.on-light.transparent-tertiary-hover",
+      "reference" : "SurfaceOnLightTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0x3D080808"
+    },
+    {
+      "description" : "Третичный прозрачный фон поверхности/контрола на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentTertiaryHover",
+      "name" : "light.surface.on-light.transparent-tertiary-hover",
+      "reference" : "SurfaceOnLightTransparentTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentTertiaryHover",
+      "type" : "color",
+      "value" : "0x0A080808"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentWarning",
+      "name" : "dark.surface.on-light.transparent-warning",
+      "reference" : "SurfaceOnLightTransparentWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentWarning",
+      "type" : "color",
+      "value" : "0x1EFA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentWarning",
+      "name" : "light.surface.on-light.transparent-warning",
+      "reference" : "SurfaceOnLightTransparentWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentWarning",
+      "type" : "color",
+      "value" : "0x1FE85702"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentWarningActive",
+      "name" : "dark.surface.on-light.transparent-warning-active",
+      "reference" : "SurfaceOnLightTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x0FFA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentWarningActive",
+      "name" : "light.surface.on-light.transparent-warning-active",
+      "reference" : "SurfaceOnLightTransparentWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentWarningActive",
+      "type" : "color",
+      "value" : "0x29E85702"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentWarningHover",
+      "name" : "dark.surface.on-light.transparent-warning-hover",
+      "reference" : "SurfaceOnLightTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentWarningHover",
+      "type" : "color",
+      "value" : "0x3DFA5F05"
+    },
+    {
+      "description" : "Прозрачный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceTransparentWarningHover",
+      "name" : "light.surface.on-light.transparent-warning-hover",
+      "reference" : "SurfaceOnLightTransparentWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightTransparentWarningHover",
+      "type" : "color",
+      "value" : "0x0AE85702"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarning",
+      "name" : "dark.surface.on-light.warning",
+      "reference" : "SurfaceOnLightWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarning",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarning",
+      "name" : "light.surface.on-light.warning",
+      "reference" : "SurfaceOnLightWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarning",
+      "type" : "color",
+      "value" : "0xFFFA5F05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningActive",
+      "name" : "dark.surface.on-light.warning-active",
+      "reference" : "SurfaceOnLightWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningActive",
+      "type" : "color",
+      "value" : "0xFFF05B05"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningActive",
+      "name" : "light.surface.on-light.warning-active",
+      "reference" : "SurfaceOnLightWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningActive",
+      "type" : "color",
+      "value" : "0xFFE65705"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningHover",
+      "name" : "dark.surface.on-light.warning-hover",
+      "reference" : "SurfaceOnLightWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningHover",
+      "type" : "color",
+      "value" : "0xFFFB7223"
+    },
+    {
+      "description" : "Цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningHover",
+      "name" : "light.surface.on-light.warning-hover",
+      "reference" : "SurfaceOnLightWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningHover",
+      "type" : "color",
+      "value" : "0xFFFB782D"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningMinor",
+      "name" : "dark.surface.on-light.warning-minor",
+      "reference" : "SurfaceOnLightWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFEE2D2"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningMinor",
+      "name" : "light.surface.on-light.warning-minor",
+      "reference" : "SurfaceOnLightWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFEE2D2"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningMinorActive",
+      "name" : "dark.surface.on-light.warning-minor-active",
+      "reference" : "SurfaceOnLightWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFEDCC8"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningMinorActive",
+      "name" : "light.surface.on-light.warning-minor-active",
+      "reference" : "SurfaceOnLightWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFEDCC8"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningMinorHover",
+      "name" : "dark.surface.on-light.warning-minor-hover",
+      "reference" : "SurfaceOnLightWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFEE9DC"
+    },
+    {
+      "description" : "Минорный цвет фона поверхности/контрола предупреждение на светлом фоне",
+      "displayName" : "onLightSurfaceWarningMinorHover",
+      "name" : "light.surface.on-light.warning-minor-hover",
+      "reference" : "SurfaceOnLightWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.surfaceOnLightWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFEEFE6"
+    },
+    {
+      "description" : "Акцентный цвет",
+      "displayName" : "textAccent",
+      "name" : "dark.text.default.accent",
+      "reference" : "TextDefaultAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccent",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Акцентный цвет",
+      "displayName" : "textAccent",
+      "name" : "light.text.default.accent",
+      "reference" : "TextDefaultAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccent",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Акцентный цвет",
+      "displayName" : "textAccentActive",
+      "name" : "dark.text.default.accent-active",
+      "reference" : "TextDefaultAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentActive",
+      "type" : "color",
+      "value" : "0xFF1F9835"
+    },
+    {
+      "description" : "Акцентный цвет",
+      "displayName" : "textAccentActive",
+      "name" : "light.text.default.accent-active",
+      "reference" : "TextDefaultAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentActive",
+      "type" : "color",
+      "value" : "0xFF0C6A1B"
+    },
+    {
+      "description" : "Акцентный цвет",
+      "displayName" : "textAccentHover",
+      "name" : "dark.text.default.accent-hover",
+      "reference" : "TextDefaultAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentHover",
+      "type" : "color",
+      "value" : "0xFF2ACB47"
+    },
+    {
+      "description" : "Акцентный цвет",
+      "displayName" : "textAccentHover",
+      "name" : "light.text.default.accent-hover",
+      "reference" : "TextDefaultAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentHover",
+      "type" : "color",
+      "value" : "0xFF14B32E"
+    },
+    {
+      "description" : "Акцентный минорный цвет",
+      "displayName" : "textAccentMinor",
+      "name" : "dark.text.default.accent-minor",
+      "reference" : "TextDefaultAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Акцентный минорный цвет",
+      "displayName" : "textAccentMinor",
+      "name" : "light.text.default.accent-minor",
+      "reference" : "TextDefaultAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultAccentMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Минорный цвет ошибки",
+      "displayName" : "textNegativeMinor",
+      "name" : "dark.text.default.negative-minor",
+      "reference" : "TextDefaultNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF9C1422"
+    },
+    {
+      "description" : "Минорный цвет ошибки",
+      "displayName" : "textNegativeMinor",
+      "name" : "light.text.default.negative-minor",
+      "reference" : "TextDefaultNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFF8F9A"
+    },
+    {
+      "description" : "Минорный цвет ошибки",
+      "displayName" : "textNegativeMinorActive",
+      "name" : "dark.text.default.negative-minor-active",
+      "reference" : "TextDefaultNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF83111C"
+    },
+    {
+      "description" : "Минорный цвет ошибки",
+      "displayName" : "textNegativeMinorActive",
+      "name" : "light.text.default.negative-minor-active",
+      "reference" : "TextDefaultNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFF6675"
+    },
+    {
+      "description" : "Минорный цвет ошибки",
+      "displayName" : "textNegativeMinorHover",
+      "name" : "dark.text.default.negative-minor-hover",
+      "reference" : "TextDefaultNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFB91828"
+    },
+    {
+      "description" : "Минорный цвет ошибки",
+      "displayName" : "textNegativeMinorHover",
+      "name" : "light.text.default.negative-minor-hover",
+      "reference" : "TextDefaultNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFB8BF"
+    },
+    {
+      "description" : "Сплошной наборный текст",
+      "displayName" : "textParagraph",
+      "name" : "dark.text.default.paragraph",
+      "reference" : "TextDefaultParagraph",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultParagraph",
+      "type" : "color",
+      "value" : "0xCCFFFFFF"
+    },
+    {
+      "description" : "Сплошной наборный текст",
+      "displayName" : "textParagraph",
+      "name" : "light.text.default.paragraph",
+      "reference" : "TextDefaultParagraph",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultParagraph",
+      "type" : "color",
+      "value" : "0xCC080808"
+    },
+    {
+      "description" : "Сплошной наборный текст",
+      "displayName" : "textParagraphActive",
+      "name" : "dark.text.default.paragraph-active",
+      "reference" : "TextDefaultParagraphActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultParagraphActive",
+      "type" : "color",
+      "value" : "0xA3FFFFFF"
+    },
+    {
+      "description" : "Сплошной наборный текст",
+      "displayName" : "textParagraphActive",
+      "name" : "light.text.default.paragraph-active",
+      "reference" : "TextDefaultParagraphActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultParagraphActive",
+      "type" : "color",
+      "value" : "0xA3080808"
+    },
+    {
+      "description" : "Сплошной наборный текст",
+      "displayName" : "textParagraphHover",
+      "name" : "dark.text.default.paragraph-hover",
+      "reference" : "TextDefaultParagraphHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultParagraphHover",
+      "type" : "color",
+      "value" : "0x7AFFFFFF"
+    },
+    {
+      "description" : "Сплошной наборный текст",
+      "displayName" : "textParagraphHover",
+      "name" : "light.text.default.paragraph-hover",
+      "reference" : "TextDefaultParagraphHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultParagraphHover",
+      "type" : "color",
+      "value" : "0x7A080808"
+    },
+    {
+      "description" : "Цвет успеха",
+      "displayName" : "textPositive",
+      "name" : "dark.text.default.positive",
+      "reference" : "TextDefaultPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositive",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Цвет успеха",
+      "displayName" : "textPositive",
+      "name" : "light.text.default.positive",
+      "reference" : "TextDefaultPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositive",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Цвет успеха",
+      "displayName" : "textPositiveActive",
+      "name" : "dark.text.default.positive-active",
+      "reference" : "TextDefaultPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveActive",
+      "type" : "color",
+      "value" : "0xFF1F9835"
+    },
+    {
+      "description" : "Цвет успеха",
+      "displayName" : "textPositiveActive",
+      "name" : "light.text.default.positive-active",
+      "reference" : "TextDefaultPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveActive",
+      "type" : "color",
+      "value" : "0xFF0C6A1B"
+    },
+    {
+      "description" : "Цвет успеха",
+      "displayName" : "textPositiveHover",
+      "name" : "dark.text.default.positive-hover",
+      "reference" : "TextDefaultPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveHover",
+      "type" : "color",
+      "value" : "0xFF2ACB47"
+    },
+    {
+      "description" : "Цвет успеха",
+      "displayName" : "textPositiveHover",
+      "name" : "light.text.default.positive-hover",
+      "reference" : "TextDefaultPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveHover",
+      "type" : "color",
+      "value" : "0xFF14B32E"
+    },
+    {
+      "description" : "Минорный цвет успеха",
+      "displayName" : "textPositiveMinor",
+      "name" : "dark.text.default.positive-minor",
+      "reference" : "TextDefaultPositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Минорный цвет успеха",
+      "displayName" : "textPositiveMinor",
+      "name" : "light.text.default.positive-minor",
+      "reference" : "TextDefaultPositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Минорный цвет успеха",
+      "displayName" : "textPositiveMinorActive",
+      "name" : "dark.text.default.positive-minor-active",
+      "reference" : "TextDefaultPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF0C7920"
+    },
+    {
+      "description" : "Минорный цвет успеха",
+      "displayName" : "textPositiveMinorActive",
+      "name" : "light.text.default.positive-minor-active",
+      "reference" : "TextDefaultPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF21B03C"
+    },
+    {
+      "description" : "Минорный цвет успеха",
+      "displayName" : "textPositiveMinorHover",
+      "name" : "dark.text.default.positive-minor-hover",
+      "reference" : "TextDefaultPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF0F9527"
+    },
+    {
+      "description" : "Минорный цвет успеха",
+      "displayName" : "textPositiveMinorHover",
+      "name" : "light.text.default.positive-minor-hover",
+      "reference" : "TextDefaultPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF47DC62"
+    },
+    {
+      "description" : "Основной цвет текста",
+      "displayName" : "textPrimary",
+      "name" : "dark.text.default.primary",
+      "reference" : "TextDefaultPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPrimary",
+      "type" : "color",
+      "value" : "0xF5FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста",
+      "displayName" : "textPrimary",
+      "name" : "light.text.default.primary",
+      "reference" : "TextDefaultPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPrimary",
+      "type" : "color",
+      "value" : "0xF5080808"
+    },
+    {
+      "description" : "Основной цвет текста",
+      "displayName" : "textPrimaryActive",
+      "name" : "dark.text.default.primary-active",
+      "reference" : "TextDefaultPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPrimaryActive",
+      "type" : "color",
+      "value" : "0xC4FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста",
+      "displayName" : "textPrimaryActive",
+      "name" : "light.text.default.primary-active",
+      "reference" : "TextDefaultPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPrimaryActive",
+      "type" : "color",
+      "value" : "0xC4080808"
+    },
+    {
+      "description" : "Основной цвет текста",
+      "displayName" : "textPrimaryBrightness",
+      "name" : "dark.text.default.primary-brightness",
+      "reference" : "TextDefaultPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xF5FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста",
+      "displayName" : "textPrimaryBrightness",
+      "name" : "light.text.default.primary-brightness",
+      "reference" : "TextDefaultPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xF5080808"
+    },
+    {
+      "description" : "Основной цвет текста",
+      "displayName" : "textPrimaryHover",
+      "name" : "dark.text.default.primary-hover",
+      "reference" : "TextDefaultPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPrimaryHover",
+      "type" : "color",
+      "value" : "0x93FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста",
+      "displayName" : "textPrimaryHover",
+      "name" : "light.text.default.primary-hover",
+      "reference" : "TextDefaultPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultPrimaryHover",
+      "type" : "color",
+      "value" : "0x93080808"
+    },
+    {
+      "description" : "Вторичный цвет текста",
+      "displayName" : "textSecondary",
+      "name" : "dark.text.default.secondary",
+      "reference" : "TextDefaultSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultSecondary",
+      "type" : "color",
+      "value" : "0x8FFFFFFF"
+    },
+    {
+      "description" : "Вторичный цвет текста",
+      "displayName" : "textSecondary",
+      "name" : "light.text.default.secondary",
+      "reference" : "TextDefaultSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultSecondary",
+      "type" : "color",
+      "value" : "0x8F080808"
+    },
+    {
+      "description" : "Вторичный цвет текста",
+      "displayName" : "textSecondaryActive",
+      "name" : "dark.text.default.secondary-active",
+      "reference" : "TextDefaultSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultSecondaryActive",
+      "type" : "color",
+      "value" : "0xABFFFFFF"
+    },
+    {
+      "description" : "Вторичный цвет текста",
+      "displayName" : "textSecondaryActive",
+      "name" : "light.text.default.secondary-active",
+      "reference" : "TextDefaultSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultSecondaryActive",
+      "type" : "color",
+      "value" : "0xAB080808"
+    },
+    {
+      "description" : "Вторичный цвет текста",
+      "displayName" : "textSecondaryHover",
+      "name" : "dark.text.default.secondary-hover",
+      "reference" : "TextDefaultSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Вторичный цвет текста",
+      "displayName" : "textSecondaryHover",
+      "name" : "light.text.default.secondary-hover",
+      "reference" : "TextDefaultSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Третичный цвет текста",
+      "displayName" : "textTertiary",
+      "name" : "dark.text.default.tertiary",
+      "reference" : "TextDefaultTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultTertiary",
+      "type" : "color",
+      "value" : "0x47FFFFFF"
+    },
+    {
+      "description" : "Третичный цвет текста",
+      "displayName" : "textTertiary",
+      "name" : "light.text.default.tertiary",
+      "reference" : "TextDefaultTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultTertiary",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Третичный цвет текста",
+      "displayName" : "textTertiaryActive",
+      "name" : "dark.text.default.tertiary-active",
+      "reference" : "TextDefaultTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultTertiaryActive",
+      "type" : "color",
+      "value" : "0x56FFFFFF"
+    },
+    {
+      "description" : "Третичный цвет текста",
+      "displayName" : "textTertiaryActive",
+      "name" : "light.text.default.tertiary-active",
+      "reference" : "TextDefaultTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultTertiaryActive",
+      "type" : "color",
+      "value" : "0x56080808"
+    },
+    {
+      "description" : "Третичный цвет текста",
+      "displayName" : "textTertiaryHover",
+      "name" : "dark.text.default.tertiary-hover",
+      "reference" : "TextDefaultTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный цвет текста",
+      "displayName" : "textTertiaryHover",
+      "name" : "light.text.default.tertiary-hover",
+      "reference" : "TextDefaultTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Цвет предупреждения",
+      "displayName" : "textWarning",
+      "name" : "dark.text.default.warning",
+      "reference" : "TextDefaultWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarning",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Цвет предупреждения",
+      "displayName" : "textWarning",
+      "name" : "light.text.default.warning",
+      "reference" : "TextDefaultWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarning",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Цвет предупреждения",
+      "displayName" : "textWarningActive",
+      "name" : "dark.text.default.warning-active",
+      "reference" : "TextDefaultWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningActive",
+      "type" : "color",
+      "value" : "0xFFFF5D05"
+    },
+    {
+      "description" : "Цвет предупреждения",
+      "displayName" : "textWarningActive",
+      "name" : "light.text.default.warning-active",
+      "reference" : "TextDefaultWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningActive",
+      "type" : "color",
+      "value" : "0xFFC04802"
+    },
+    {
+      "description" : "Цвет предупреждения",
+      "displayName" : "textWarningHover",
+      "name" : "dark.text.default.warning-hover",
+      "reference" : "TextDefaultWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF8442"
+    },
+    {
+      "description" : "Цвет предупреждения",
+      "displayName" : "textWarningHover",
+      "name" : "light.text.default.warning-hover",
+      "reference" : "TextDefaultWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningHover",
+      "type" : "color",
+      "value" : "0xFFFD6B17"
+    },
+    {
+      "description" : "Минорный цвет предупреждения",
+      "displayName" : "textWarningMinor",
+      "name" : "dark.text.default.warning-minor",
+      "reference" : "TextDefaultWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningMinor",
+      "type" : "color",
+      "value" : "0xFF85380C"
+    },
+    {
+      "description" : "Минорный цвет предупреждения",
+      "displayName" : "textWarningMinor",
+      "name" : "light.text.default.warning-minor",
+      "reference" : "TextDefaultWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFD9C68"
+    },
+    {
+      "description" : "Минорный цвет предупреждения",
+      "displayName" : "textWarningMinorActive",
+      "name" : "dark.text.default.warning-minor-active",
+      "reference" : "TextDefaultWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFF9F440F"
+    },
+    {
+      "description" : "Минорный цвет предупреждения",
+      "displayName" : "textWarningMinorActive",
+      "name" : "light.text.default.warning-minor-active",
+      "reference" : "TextDefaultWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFC8240"
+    },
+    {
+      "description" : "Минорный цвет предупреждения",
+      "displayName" : "textWarningMinorHover",
+      "name" : "dark.text.default.warning-minor-hover",
+      "reference" : "TextDefaultWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFBB4F11"
+    },
+    {
+      "description" : "Минорный цвет предупреждения",
+      "displayName" : "textWarningMinorHover",
+      "name" : "light.text.default.warning-minor-hover",
+      "reference" : "TextDefaultWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textDefaultWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFDB790"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет",
+      "displayName" : "inverseTextAccent",
+      "name" : "dark.text.inverse.accent",
+      "reference" : "TextInverseAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccent",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет",
+      "displayName" : "inverseTextAccent",
+      "name" : "light.text.inverse.accent",
+      "reference" : "TextInverseAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccent",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет",
+      "displayName" : "inverseTextAccentActive",
+      "name" : "dark.text.inverse.accent-active",
+      "reference" : "TextInverseAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentActive",
+      "type" : "color",
+      "value" : "0xFF0D731E"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет",
+      "displayName" : "inverseTextAccentActive",
+      "name" : "light.text.inverse.accent-active",
+      "reference" : "TextInverseAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentActive",
+      "type" : "color",
+      "value" : "0xFF1D9032"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет",
+      "displayName" : "inverseTextAccentHover",
+      "name" : "dark.text.inverse.accent-hover",
+      "reference" : "TextInverseAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentHover",
+      "type" : "color",
+      "value" : "0xFF13AA2C"
+    },
+    {
+      "description" : "Инвертированный акцентный цвет",
+      "displayName" : "inverseTextAccentHover",
+      "name" : "light.text.inverse.accent-hover",
+      "reference" : "TextInverseAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentHover",
+      "type" : "color",
+      "value" : "0xFF2BD44A"
+    },
+    {
+      "description" : "Инвертированный минорный акцентный цвет",
+      "displayName" : "inverseTextAccentMinor",
+      "name" : "dark.text.inverse.accent-minor",
+      "reference" : "TextInverseAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Инвертированный минорный акцентный цвет",
+      "displayName" : "inverseTextAccentMinor",
+      "name" : "light.text.inverse.accent-minor",
+      "reference" : "TextInverseAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Инвертированный минорный акцентный цвет",
+      "displayName" : "inverseTextAccentMinorActive",
+      "name" : "dark.text.inverse.accent-minor-active",
+      "reference" : "TextInverseAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF23B83E"
+    },
+    {
+      "description" : "Инвертированный минорный акцентный цвет",
+      "displayName" : "inverseTextAccentMinorActive",
+      "name" : "light.text.inverse.accent-minor-active",
+      "reference" : "TextInverseAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF0D8222"
+    },
+    {
+      "description" : "Инвертированный минорный акцентный цвет",
+      "displayName" : "inverseTextAccentMinorHover",
+      "name" : "dark.text.inverse.accent-minor-hover",
+      "reference" : "TextInverseAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF3EDA5B"
+    },
+    {
+      "description" : "Инвертированный минорный акцентный цвет",
+      "displayName" : "inverseTextAccentMinorHover",
+      "name" : "light.text.inverse.accent-minor-hover",
+      "reference" : "TextInverseAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF11A72C"
+    },
+    {
+      "description" : "Инвертированный цвет информации",
+      "displayName" : "inverseTextInfo",
+      "name" : "dark.text.inverse.info",
+      "reference" : "TextInverseInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfo",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Инвертированный цвет информации",
+      "displayName" : "inverseTextInfo",
+      "name" : "light.text.inverse.info",
+      "reference" : "TextInverseInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfo",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "Инвертированный цвет информации",
+      "displayName" : "inverseTextInfoActive",
+      "name" : "dark.text.inverse.info-active",
+      "reference" : "TextInverseInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoActive",
+      "type" : "color",
+      "value" : "0xFF096CAE"
+    },
+    {
+      "description" : "Инвертированный цвет информации",
+      "displayName" : "inverseTextInfoActive",
+      "name" : "light.text.inverse.info-active",
+      "reference" : "TextInverseInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoActive",
+      "type" : "color",
+      "value" : "0xFF0D84D3"
+    },
+    {
+      "description" : "Инвертированный цвет информации",
+      "displayName" : "inverseTextInfoHover",
+      "name" : "dark.text.inverse.info-hover",
+      "reference" : "TextInverseInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoHover",
+      "type" : "color",
+      "value" : "0xFF34A7F4"
+    },
+    {
+      "description" : "Инвертированный цвет информации",
+      "displayName" : "inverseTextInfoHover",
+      "name" : "light.text.inverse.info-hover",
+      "reference" : "TextInverseInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoHover",
+      "type" : "color",
+      "value" : "0xFF3FABF3"
+    },
+    {
+      "description" : "Инвертированный минорный цвет информации",
+      "displayName" : "inverseTextInfoMinor",
+      "name" : "dark.text.inverse.info-minor",
+      "reference" : "TextInverseInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoMinor",
+      "type" : "color",
+      "value" : "0xFF52BAFF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет информации",
+      "displayName" : "inverseTextInfoMinor",
+      "name" : "light.text.inverse.info-minor",
+      "reference" : "TextInverseInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0D5382"
+    },
+    {
+      "description" : "Инвертированный минорный цвет информации",
+      "displayName" : "inverseTextInfoMinorActive",
+      "name" : "dark.text.inverse.info-minor-active",
+      "reference" : "TextInverseInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF33ADFF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет информации",
+      "displayName" : "inverseTextInfoMinorActive",
+      "name" : "light.text.inverse.info-minor-active",
+      "reference" : "TextInverseInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF116BA7"
+    },
+    {
+      "description" : "typography l display-s-bold",
+      "displayName" : "DisplayS B",
+      "name" : "screen-l.display.s.bold",
+      "reference" : "DisplaySBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displaySBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 68,
+        "size" : 64,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "Инвертированный минорный цвет информации",
+      "displayName" : "inverseTextInfoMinorHover",
+      "name" : "dark.text.inverse.info-minor-hover",
+      "reference" : "TextInverseInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFFA3DAFF"
+    },
+    {
+      "description" : "Инвертированный минорный цвет информации",
+      "displayName" : "inverseTextInfoMinorHover",
+      "name" : "light.text.inverse.info-minor-hover",
+      "reference" : "TextInverseInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF1483CC"
+    },
+    {
+      "description" : "Инвертированный цвет ошибки",
+      "displayName" : "inverseTextNegative",
+      "name" : "dark.text.inverse.negative",
+      "reference" : "TextInverseNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegative",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Инвертированный цвет ошибки",
+      "displayName" : "inverseTextNegative",
+      "name" : "light.text.inverse.negative",
+      "reference" : "TextInverseNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegative",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Инвертированный цвет ошибки",
+      "displayName" : "inverseTextNegativeActive",
+      "name" : "dark.text.inverse.negative-active",
+      "reference" : "TextInverseNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeActive",
+      "type" : "color",
+      "value" : "0xFFE40C22"
+    },
+    {
+      "description" : "Инвертированный цвет ошибки",
+      "displayName" : "inverseTextNegativeActive",
+      "name" : "light.text.inverse.negative-active",
+      "reference" : "TextInverseNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF142C"
+    },
+    {
+      "description" : "Инвертированный цвет ошибки",
+      "displayName" : "inverseTextNegativeHover",
+      "name" : "dark.text.inverse.negative-hover",
+      "reference" : "TextInverseNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF5384B"
+    },
+    {
+      "description" : "Инвертированный цвет ошибки",
+      "displayName" : "inverseTextNegativeHover",
+      "name" : "light.text.inverse.negative-hover",
+      "reference" : "TextInverseNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF6675"
+    },
+    {
+      "description" : "Инвертированный минорный цвет ошибки",
+      "displayName" : "inverseTextNegativeMinor",
+      "name" : "dark.text.inverse.negative-minor",
+      "reference" : "TextInverseNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFF8F9A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет ошибки",
+      "displayName" : "inverseTextNegativeMinor",
+      "name" : "light.text.inverse.negative-minor",
+      "reference" : "TextInverseNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF9C1422"
+    },
+    {
+      "description" : "Инвертированный минорный цвет ошибки",
+      "displayName" : "inverseTextNegativeMinorActive",
+      "name" : "dark.text.inverse.negative-minor-active",
+      "reference" : "TextInverseNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFF707E"
+    },
+    {
+      "description" : "Инвертированный минорный цвет ошибки",
+      "displayName" : "inverseTextNegativeMinorActive",
+      "name" : "light.text.inverse.negative-minor-active",
+      "reference" : "TextInverseNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF7A101A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет ошибки",
+      "displayName" : "inverseTextNegativeMinorHover",
+      "name" : "dark.text.inverse.negative-minor-hover",
+      "reference" : "TextInverseNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFADB6"
+    },
+    {
+      "description" : "Инвертированный минорный цвет ошибки",
+      "displayName" : "inverseTextNegativeMinorHover",
+      "name" : "light.text.inverse.negative-minor-hover",
+      "reference" : "TextInverseNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFC2192A"
+    },
+    {
+      "description" : "Инвертированный сплошной наборный текст",
+      "displayName" : "inverseTextParagraph",
+      "name" : "dark.text.inverse.paragraph",
+      "reference" : "TextInverseParagraph",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseParagraph",
+      "type" : "color",
+      "value" : "0xCC171717"
+    },
+    {
+      "description" : "Инвертированный сплошной наборный текст",
+      "displayName" : "inverseTextParagraph",
+      "name" : "light.text.inverse.paragraph",
+      "reference" : "TextInverseParagraph",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseParagraph",
+      "type" : "color",
+      "value" : "0xCCFFFFFF"
+    },
+    {
+      "description" : "Инвертированный сплошной наборный текст",
+      "displayName" : "inverseTextParagraphActive",
+      "name" : "dark.text.inverse.paragraph-active",
+      "reference" : "TextInverseParagraphActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseParagraphActive",
+      "type" : "color",
+      "value" : "0xA3171717"
+    },
+    {
+      "description" : "Инвертированный сплошной наборный текст",
+      "displayName" : "inverseTextParagraphActive",
+      "name" : "light.text.inverse.paragraph-active",
+      "reference" : "TextInverseParagraphActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseParagraphActive",
+      "type" : "color",
+      "value" : "0xA3FFFFFF"
+    },
+    {
+      "description" : "Инвертированный сплошной наборный текст",
+      "displayName" : "inverseTextParagraphHover",
+      "name" : "dark.text.inverse.paragraph-hover",
+      "reference" : "TextInverseParagraphHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseParagraphHover",
+      "type" : "color",
+      "value" : "0x7A171717"
+    },
+    {
+      "description" : "Инвертированный сплошной наборный текст",
+      "displayName" : "inverseTextParagraphHover",
+      "name" : "light.text.inverse.paragraph-hover",
+      "reference" : "TextInverseParagraphHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseParagraphHover",
+      "type" : "color",
+      "value" : "0x7AFFFFFF"
+    },
+    {
+      "description" : "Инвертированный цвет успеха",
+      "displayName" : "inverseTextPositive",
+      "name" : "dark.text.inverse.positive",
+      "reference" : "TextInversePositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositive",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Инвертированный цвет успеха",
+      "displayName" : "inverseTextPositive",
+      "name" : "light.text.inverse.positive",
+      "reference" : "TextInversePositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositive",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Инвертированный цвет успеха",
+      "displayName" : "inverseTextPositiveActive",
+      "name" : "dark.text.inverse.positive-active",
+      "reference" : "TextInversePositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveActive",
+      "type" : "color",
+      "value" : "0xFF0D731E"
+    },
+    {
+      "description" : "Инвертированный цвет успеха",
+      "displayName" : "inverseTextPositiveActive",
+      "name" : "light.text.inverse.positive-active",
+      "reference" : "TextInversePositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveActive",
+      "type" : "color",
+      "value" : "0xFF1D9032"
+    },
+    {
+      "description" : "Инвертированный цвет успеха",
+      "displayName" : "inverseTextPositiveHover",
+      "name" : "dark.text.inverse.positive-hover",
+      "reference" : "TextInversePositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveHover",
+      "type" : "color",
+      "value" : "0xFF13AA2C"
+    },
+    {
+      "description" : "Инвертированный цвет успеха",
+      "displayName" : "inverseTextPositiveHover",
+      "name" : "light.text.inverse.positive-hover",
+      "reference" : "TextInversePositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveHover",
+      "type" : "color",
+      "value" : "0xFF2BD44A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет успеха",
+      "displayName" : "inverseTextPositiveMinor",
+      "name" : "dark.text.inverse.positive-minor",
+      "reference" : "TextInversePositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Инвертированный минорный цвет успеха",
+      "displayName" : "inverseTextPositiveMinor",
+      "name" : "light.text.inverse.positive-minor",
+      "reference" : "TextInversePositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Инвертированный минорный цвет успеха",
+      "displayName" : "inverseTextPositiveMinorActive",
+      "name" : "dark.text.inverse.positive-minor-active",
+      "reference" : "TextInversePositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF23B83E"
+    },
+    {
+      "description" : "Инвертированный минорный цвет успеха",
+      "displayName" : "inverseTextPositiveMinorActive",
+      "name" : "light.text.inverse.positive-minor-active",
+      "reference" : "TextInversePositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF0D8222"
+    },
+    {
+      "description" : "Инвертированный минорный цвет успеха",
+      "displayName" : "inverseTextPositiveMinorHover",
+      "name" : "dark.text.inverse.positive-minor-hover",
+      "reference" : "TextInversePositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF3EDA5B"
+    },
+    {
+      "description" : "Инвертированный минорный цвет успеха",
+      "displayName" : "inverseTextPositiveMinorHover",
+      "name" : "light.text.inverse.positive-minor-hover",
+      "reference" : "TextInversePositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF11A72C"
+    },
+    {
+      "description" : "Инвертированный основной цвет текста",
+      "displayName" : "inverseTextPrimary",
+      "name" : "dark.text.inverse.primary",
+      "reference" : "TextInversePrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePrimary",
+      "type" : "color",
+      "value" : "0xF4171717"
+    },
+    {
+      "description" : "Инвертированный основной цвет текста",
+      "displayName" : "inverseTextPrimary",
+      "name" : "light.text.inverse.primary",
+      "reference" : "TextInversePrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePrimary",
+      "type" : "color",
+      "value" : "0xF5FFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной цвет текста",
+      "displayName" : "inverseTextPrimaryActive",
+      "name" : "dark.text.inverse.primary-active",
+      "reference" : "TextInversePrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePrimaryActive",
+      "type" : "color",
+      "value" : "0xC4171717"
+    },
+    {
+      "description" : "Инвертированный основной цвет текста",
+      "displayName" : "inverseTextPrimaryActive",
+      "name" : "light.text.inverse.primary-active",
+      "reference" : "TextInversePrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePrimaryActive",
+      "type" : "color",
+      "value" : "0xC4FFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной цвет текста",
+      "displayName" : "inverseTextPrimaryBrightness",
+      "name" : "dark.text.inverse.primary-brightness",
+      "reference" : "TextInversePrimaryBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePrimaryBrightness",
+      "type" : "color",
+      "value" : "0xF5171717"
+    },
+    {
+      "description" : "Инвертированный основной цвет текста",
+      "displayName" : "inverseTextPrimaryBrightness",
+      "name" : "light.text.inverse.primary-brightness",
+      "reference" : "TextInversePrimaryBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePrimaryBrightness",
+      "type" : "color",
+      "value" : "0xF5FFFFFF"
+    },
+    {
+      "description" : "Инвертированный основной цвет текста",
+      "displayName" : "inverseTextPrimaryHover",
+      "name" : "dark.text.inverse.primary-hover",
+      "reference" : "TextInversePrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePrimaryHover",
+      "type" : "color",
+      "value" : "0x93171717"
+    },
+    {
+      "description" : "Инвертированный основной цвет текста",
+      "displayName" : "inverseTextPrimaryHover",
+      "name" : "light.text.inverse.primary-hover",
+      "reference" : "TextInversePrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInversePrimaryHover",
+      "type" : "color",
+      "value" : "0x93FFFFFF"
+    },
+    {
+      "description" : "Инвертированный вторичный цвет текста",
+      "displayName" : "inverseTextSecondary",
+      "name" : "dark.text.inverse.secondary",
+      "reference" : "TextInverseSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseSecondary",
+      "type" : "color",
+      "value" : "0x8E171717"
+    },
+    {
+      "description" : "Инвертированный вторичный цвет текста",
+      "displayName" : "inverseTextSecondary",
+      "name" : "light.text.inverse.secondary",
+      "reference" : "TextInverseSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseSecondary",
+      "type" : "color",
+      "value" : "0x8FFFFFFF"
+    },
+    {
+      "description" : "Инвертированный вторичный цвет текста",
+      "displayName" : "inverseTextSecondaryActive",
+      "name" : "dark.text.inverse.secondary-active",
+      "reference" : "TextInverseSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseSecondaryActive",
+      "type" : "color",
+      "value" : "0xAB171717"
+    },
+    {
+      "description" : "Инвертированный вторичный цвет текста",
+      "displayName" : "inverseTextSecondaryActive",
+      "name" : "light.text.inverse.secondary-active",
+      "reference" : "TextInverseSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseSecondaryActive",
+      "type" : "color",
+      "value" : "0xABFFFFFF"
+    },
+    {
+      "description" : "Инвертированный вторичный цвет текста",
+      "displayName" : "inverseTextSecondaryHover",
+      "name" : "dark.text.inverse.secondary-hover",
+      "reference" : "TextInverseSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Инвертированный вторичный цвет текста",
+      "displayName" : "inverseTextSecondaryHover",
+      "name" : "light.text.inverse.secondary-hover",
+      "reference" : "TextInverseSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный третичный цвет текста",
+      "displayName" : "inverseTextTertiary",
+      "name" : "dark.text.inverse.tertiary",
+      "reference" : "TextInverseTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseTertiary",
+      "type" : "color",
+      "value" : "0x47171717"
+    },
+    {
+      "description" : "Инвертированный третичный цвет текста",
+      "displayName" : "inverseTextTertiary",
+      "name" : "light.text.inverse.tertiary",
+      "reference" : "TextInverseTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseTertiary",
+      "type" : "color",
+      "value" : "0x47FFFFFF"
+    },
+    {
+      "description" : "Инвертированный третичный цвет текста",
+      "displayName" : "inverseTextTertiaryActive",
+      "name" : "dark.text.inverse.tertiary-active",
+      "reference" : "TextInverseTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseTertiaryActive",
+      "type" : "color",
+      "value" : "0x56171717"
+    },
+    {
+      "description" : "Инвертированный третичный цвет текста",
+      "displayName" : "inverseTextTertiaryActive",
+      "name" : "light.text.inverse.tertiary-active",
+      "reference" : "TextInverseTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseTertiaryActive",
+      "type" : "color",
+      "value" : "0x56FFFFFF"
+    },
+    {
+      "description" : "Инвертированный третичный цвет текста",
+      "displayName" : "inverseTextTertiaryHover",
+      "name" : "dark.text.inverse.tertiary-hover",
+      "reference" : "TextInverseTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Инвертированный третичный цвет текста",
+      "displayName" : "inverseTextTertiaryHover",
+      "name" : "light.text.inverse.tertiary-hover",
+      "reference" : "TextInverseTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Инвертированный цвет предупреждения",
+      "displayName" : "inverseTextWarning",
+      "name" : "dark.text.inverse.warning",
+      "reference" : "TextInverseWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarning",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Инвертированный цвет предупреждения",
+      "displayName" : "inverseTextWarning",
+      "name" : "light.text.inverse.warning",
+      "reference" : "TextInverseWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarning",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Инвертированный цвет предупреждения",
+      "displayName" : "inverseTextWarningActive",
+      "name" : "dark.text.inverse.warning-active",
+      "reference" : "TextInverseWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningActive",
+      "type" : "color",
+      "value" : "0xFFCA4B02"
+    },
+    {
+      "description" : "Инвертированный цвет предупреждения",
+      "displayName" : "inverseTextWarningActive",
+      "name" : "light.text.inverse.warning-active",
+      "reference" : "TextInverseWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningActive",
+      "type" : "color",
+      "value" : "0xFFFA5700"
+    },
+    {
+      "description" : "Инвертированный цвет предупреждения",
+      "displayName" : "inverseTextWarningHover",
+      "name" : "dark.text.inverse.warning-hover",
+      "reference" : "TextInverseWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningHover",
+      "type" : "color",
+      "value" : "0xFFFD650D"
+    },
+    {
+      "description" : "Инвертированный цвет предупреждения",
+      "displayName" : "inverseTextWarningHover",
+      "name" : "light.text.inverse.warning-hover",
+      "reference" : "TextInverseWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF8B4D"
+    },
+    {
+      "description" : "Инвертированный минорный цвет предупреждения",
+      "displayName" : "inverseTextWarningMinor",
+      "name" : "dark.text.inverse.warning-minor",
+      "reference" : "TextInverseWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFD9C68"
+    },
+    {
+      "description" : "Инвертированный минорный цвет предупреждения",
+      "displayName" : "inverseTextWarningMinor",
+      "name" : "light.text.inverse.warning-minor",
+      "reference" : "TextInverseWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningMinor",
+      "type" : "color",
+      "value" : "0xFF85380C"
+    },
+    {
+      "description" : "Инвертированный минорный цвет предупреждения",
+      "displayName" : "inverseTextWarningMinorActive",
+      "name" : "dark.text.inverse.warning-minor-active",
+      "reference" : "TextInverseWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFC884A"
+    },
+    {
+      "description" : "Инвертированный минорный цвет предупреждения",
+      "displayName" : "inverseTextWarningMinorActive",
+      "name" : "light.text.inverse.warning-minor-active",
+      "reference" : "TextInverseWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFA84710"
+    },
+    {
+      "description" : "Инвертированный минорный цвет предупреждения",
+      "displayName" : "inverseTextWarningMinorHover",
+      "name" : "dark.text.inverse.warning-minor-hover",
+      "reference" : "TextInverseWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFDB086"
+    },
+    {
+      "description" : "Инвертированный минорный цвет предупреждения",
+      "displayName" : "inverseTextWarningMinorHover",
+      "name" : "light.text.inverse.warning-minor-hover",
+      "reference" : "TextInverseWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textInverseWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFCD5713"
+    },
+    {
+      "description" : "Акцентный цвет на темном фоне",
+      "displayName" : "onDarkTextAccent",
+      "name" : "dark.text.on-dark.accent",
+      "reference" : "TextOnDarkAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccent",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Акцентный цвет на темном фоне",
+      "displayName" : "onDarkTextAccent",
+      "name" : "light.text.on-dark.accent",
+      "reference" : "TextOnDarkAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccent",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "typography l display-s-medium",
+      "displayName" : "DisplayS M",
+      "name" : "screen-l.display.s.medium",
+      "reference" : "DisplaySMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displaySMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 68,
+        "size" : 64,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "Акцентный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentActive",
+      "name" : "dark.text.on-dark.accent-active",
+      "reference" : "TextOnDarkAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentActive",
+      "type" : "color",
+      "value" : "0xFF1F9835"
+    },
+    {
+      "description" : "Акцентный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentActive",
+      "name" : "light.text.on-dark.accent-active",
+      "reference" : "TextOnDarkAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentActive",
+      "type" : "color",
+      "value" : "0xFF1D9032"
+    },
+    {
+      "description" : "Акцентный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentHover",
+      "name" : "dark.text.on-dark.accent-hover",
+      "reference" : "TextOnDarkAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentHover",
+      "type" : "color",
+      "value" : "0xFF2ACB47"
+    },
+    {
+      "description" : "Акцентный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentHover",
+      "name" : "light.text.on-dark.accent-hover",
+      "reference" : "TextOnDarkAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentHover",
+      "type" : "color",
+      "value" : "0xFF2BD44A"
+    },
+    {
+      "description" : "Акцентный минорный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentMinor",
+      "name" : "dark.text.on-dark.accent-minor",
+      "reference" : "TextOnDarkAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Акцентный минорный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentMinor",
+      "name" : "light.text.on-dark.accent-minor",
+      "reference" : "TextOnDarkAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Акцентный минорный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentMinorActive",
+      "name" : "dark.text.on-dark.accent-minor-active",
+      "reference" : "TextOnDarkAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF0C7920"
+    },
+    {
+      "description" : "Акцентный минорный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentMinorActive",
+      "name" : "light.text.on-dark.accent-minor-active",
+      "reference" : "TextOnDarkAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF0D8222"
+    },
+    {
+      "description" : "Акцентный минорный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentMinorHover",
+      "name" : "dark.text.on-dark.accent-minor-hover",
+      "reference" : "TextOnDarkAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF0F9527"
+    },
+    {
+      "description" : "Акцентный минорный цвет на темном фоне",
+      "displayName" : "onDarkTextAccentMinorHover",
+      "name" : "light.text.on-dark.accent-minor-hover",
+      "reference" : "TextOnDarkAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF11A72C"
+    },
+    {
+      "description" : "Цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfo",
+      "name" : "dark.text.on-dark.info",
+      "reference" : "TextOnDarkInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfo",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "Цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfo",
+      "name" : "light.text.on-dark.info",
+      "reference" : "TextOnDarkInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfo",
+      "type" : "color",
+      "value" : "0xFF199AF0"
+    },
+    {
+      "description" : "Цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoActive",
+      "name" : "dark.text.on-dark.info-active",
+      "reference" : "TextOnDarkInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoActive",
+      "type" : "color",
+      "value" : "0xFF0E8ADD"
+    },
+    {
+      "description" : "Цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoActive",
+      "name" : "light.text.on-dark.info-active",
+      "reference" : "TextOnDarkInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoActive",
+      "type" : "color",
+      "value" : "0xFF0D84D3"
+    },
+    {
+      "description" : "Цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoHover",
+      "name" : "dark.text.on-dark.info-hover",
+      "reference" : "TextOnDarkInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoHover",
+      "type" : "color",
+      "value" : "0xFF66BCF5"
+    },
+    {
+      "description" : "Цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoHover",
+      "name" : "light.text.on-dark.info-hover",
+      "reference" : "TextOnDarkInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoHover",
+      "type" : "color",
+      "value" : "0xFF3FABF3"
+    },
+    {
+      "description" : "Минорный цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoMinor",
+      "name" : "dark.text.on-dark.info-minor",
+      "reference" : "TextOnDarkInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0D5382"
+    },
+    {
+      "description" : "Минорный цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoMinor",
+      "name" : "light.text.on-dark.info-minor",
+      "reference" : "TextOnDarkInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoMinor",
+      "type" : "color",
+      "value" : "0xFF0D5382"
+    },
+    {
+      "description" : "Минорный цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoMinorActive",
+      "name" : "dark.text.on-dark.info-minor-active",
+      "reference" : "TextOnDarkInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF10659E"
+    },
+    {
+      "description" : "Минорный цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoMinorActive",
+      "name" : "light.text.on-dark.info-minor-active",
+      "reference" : "TextOnDarkInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF116BA7"
+    },
+    {
+      "description" : "Минорный цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoMinorHover",
+      "name" : "dark.text.on-dark.info-minor-hover",
+      "reference" : "TextOnDarkInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF1277BA"
+    },
+    {
+      "description" : "Минорный цвет информации на темном фоне",
+      "displayName" : "onDarkTextInfoMinorHover",
+      "name" : "light.text.on-dark.info-minor-hover",
+      "reference" : "TextOnDarkInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF1483CC"
+    },
+    {
+      "description" : "Цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegative",
+      "name" : "dark.text.on-dark.negative",
+      "reference" : "TextOnDarkNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegative",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegative",
+      "name" : "light.text.on-dark.negative",
+      "reference" : "TextOnDarkNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegative",
+      "type" : "color",
+      "value" : "0xFFFF3D51"
+    },
+    {
+      "description" : "Цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeActive",
+      "name" : "dark.text.on-dark.negative-active",
+      "reference" : "TextOnDarkNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF1F35"
+    },
+    {
+      "description" : "Цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeActive",
+      "name" : "light.text.on-dark.negative-active",
+      "reference" : "TextOnDarkNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeActive",
+      "type" : "color",
+      "value" : "0xFFFF142C"
+    },
+    {
+      "description" : "Цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeHover",
+      "name" : "dark.text.on-dark.negative-hover",
+      "reference" : "TextOnDarkNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF5C6C"
+    },
+    {
+      "description" : "Цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeHover",
+      "name" : "light.text.on-dark.negative-hover",
+      "reference" : "TextOnDarkNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeHover",
+      "type" : "color",
+      "value" : "0xFFFF6675"
+    },
+    {
+      "description" : "Минорный цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeMinor",
+      "name" : "dark.text.on-dark.negative-minor",
+      "reference" : "TextOnDarkNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF9C1422"
+    },
+    {
+      "description" : "Минорный цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeMinor",
+      "name" : "light.text.on-dark.negative-minor",
+      "reference" : "TextOnDarkNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeMinor",
+      "type" : "color",
+      "value" : "0xFF9C1422"
+    },
+    {
+      "description" : "Минорный цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeMinorActive",
+      "name" : "dark.text.on-dark.negative-minor-active",
+      "reference" : "TextOnDarkNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF83111C"
+    },
+    {
+      "description" : "Минорный цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeMinorActive",
+      "name" : "light.text.on-dark.negative-minor-active",
+      "reference" : "TextOnDarkNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFF7A101A"
+    },
+    {
+      "description" : "Минорный цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeMinorHover",
+      "name" : "dark.text.on-dark.negative-minor-hover",
+      "reference" : "TextOnDarkNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFB91828"
+    },
+    {
+      "description" : "Минорный цвет ошибки на темном фоне",
+      "displayName" : "onDarkTextNegativeMinorHover",
+      "name" : "light.text.on-dark.negative-minor-hover",
+      "reference" : "TextOnDarkNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFC2192A"
+    },
+    {
+      "description" : "Сплошной наборный текст на темном фоне",
+      "displayName" : "onDarkTextParagraph",
+      "name" : "dark.text.on-dark.paragraph",
+      "reference" : "TextOnDarkParagraph",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkParagraph",
+      "type" : "color",
+      "value" : "0xCCFFFFFF"
+    },
+    {
+      "description" : "Сплошной наборный текст на темном фоне",
+      "displayName" : "onDarkTextParagraph",
+      "name" : "light.text.on-dark.paragraph",
+      "reference" : "TextOnDarkParagraph",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkParagraph",
+      "type" : "color",
+      "value" : "0xCCFFFFFF"
+    },
+    {
+      "description" : "Сплошной наборный текст на темном фоне",
+      "displayName" : "onDarkTextParagraphActive",
+      "name" : "dark.text.on-dark.paragraph-active",
+      "reference" : "TextOnDarkParagraphActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkParagraphActive",
+      "type" : "color",
+      "value" : "0xA3FFFFFF"
+    },
+    {
+      "description" : "Сплошной наборный текст на темном фоне",
+      "displayName" : "onDarkTextParagraphActive",
+      "name" : "light.text.on-dark.paragraph-active",
+      "reference" : "TextOnDarkParagraphActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkParagraphActive",
+      "type" : "color",
+      "value" : "0xA3FFFFFF"
+    },
+    {
+      "description" : "Сплошной наборный текст на темном фоне",
+      "displayName" : "onDarkTextParagraphHover",
+      "name" : "dark.text.on-dark.paragraph-hover",
+      "reference" : "TextOnDarkParagraphHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkParagraphHover",
+      "type" : "color",
+      "value" : "0x7AFFFFFF"
+    },
+    {
+      "description" : "Сплошной наборный текст на темном фоне",
+      "displayName" : "onDarkTextParagraphHover",
+      "name" : "light.text.on-dark.paragraph-hover",
+      "reference" : "TextOnDarkParagraphHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkParagraphHover",
+      "type" : "color",
+      "value" : "0x7AFFFFFF"
+    },
+    {
+      "description" : "Цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositive",
+      "name" : "dark.text.on-dark.positive",
+      "reference" : "TextOnDarkPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositive",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositive",
+      "name" : "light.text.on-dark.positive",
+      "reference" : "TextOnDarkPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositive",
+      "type" : "color",
+      "value" : "0xFF24B23E"
+    },
+    {
+      "description" : "Цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveActive",
+      "name" : "dark.text.on-dark.positive-active",
+      "reference" : "TextOnDarkPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveActive",
+      "type" : "color",
+      "value" : "0xFF1F9835"
+    },
+    {
+      "description" : "Цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveActive",
+      "name" : "light.text.on-dark.positive-active",
+      "reference" : "TextOnDarkPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveActive",
+      "type" : "color",
+      "value" : "0xFF1D9032"
+    },
+    {
+      "description" : "Цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveHover",
+      "name" : "dark.text.on-dark.positive-hover",
+      "reference" : "TextOnDarkPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveHover",
+      "type" : "color",
+      "value" : "0xFF2ACB47"
+    },
+    {
+      "description" : "Цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveHover",
+      "name" : "light.text.on-dark.positive-hover",
+      "reference" : "TextOnDarkPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveHover",
+      "type" : "color",
+      "value" : "0xFF2BD44A"
+    },
+    {
+      "description" : "Минорный цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveMinor",
+      "name" : "dark.text.on-dark.positive-minor",
+      "reference" : "TextOnDarkPositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Минорный цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveMinor",
+      "name" : "light.text.on-dark.positive-minor",
+      "reference" : "TextOnDarkPositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF095C18"
+    },
+    {
+      "description" : "Минорный цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveMinorActive",
+      "name" : "dark.text.on-dark.positive-minor-active",
+      "reference" : "TextOnDarkPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF0C7920"
+    },
+    {
+      "description" : "Минорный цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveMinorActive",
+      "name" : "light.text.on-dark.positive-minor-active",
+      "reference" : "TextOnDarkPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF0D8222"
+    },
+    {
+      "description" : "Минорный цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveMinorHover",
+      "name" : "dark.text.on-dark.positive-minor-hover",
+      "reference" : "TextOnDarkPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF0F9527"
+    },
+    {
+      "description" : "Минорный цвет успеха на темном фоне",
+      "displayName" : "onDarkTextPositiveMinorHover",
+      "name" : "light.text.on-dark.positive-minor-hover",
+      "reference" : "TextOnDarkPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF11A72C"
+    },
+    {
+      "description" : "Основной цвет текста на темном фоне",
+      "displayName" : "onDarkTextPrimary",
+      "name" : "dark.text.on-dark.primary",
+      "reference" : "TextOnDarkPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPrimary",
+      "type" : "color",
+      "value" : "0xF5FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста на темном фоне",
+      "displayName" : "onDarkTextPrimary",
+      "name" : "light.text.on-dark.primary",
+      "reference" : "TextOnDarkPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPrimary",
+      "type" : "color",
+      "value" : "0xF5FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста на темном фоне",
+      "displayName" : "onDarkTextPrimaryActive",
+      "name" : "dark.text.on-dark.primary-active",
+      "reference" : "TextOnDarkPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPrimaryActive",
+      "type" : "color",
+      "value" : "0xC4FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста на темном фоне",
+      "displayName" : "onDarkTextPrimaryActive",
+      "name" : "light.text.on-dark.primary-active",
+      "reference" : "TextOnDarkPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPrimaryActive",
+      "type" : "color",
+      "value" : "0xC4FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста на темном фоне",
+      "displayName" : "onDarkTextPrimaryBrightness",
+      "name" : "dark.text.on-dark.primary-brightness",
+      "reference" : "TextOnDarkPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xF5FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста на темном фоне",
+      "displayName" : "onDarkTextPrimaryBrightness",
+      "name" : "light.text.on-dark.primary-brightness",
+      "reference" : "TextOnDarkPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xF5FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста на темном фоне",
+      "displayName" : "onDarkTextPrimaryHover",
+      "name" : "dark.text.on-dark.primary-hover",
+      "reference" : "TextOnDarkPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPrimaryHover",
+      "type" : "color",
+      "value" : "0x93FFFFFF"
+    },
+    {
+      "description" : "Основной цвет текста на темном фоне",
+      "displayName" : "onDarkTextPrimaryHover",
+      "name" : "light.text.on-dark.primary-hover",
+      "reference" : "TextOnDarkPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkPrimaryHover",
+      "type" : "color",
+      "value" : "0x93FFFFFF"
+    },
+    {
+      "description" : "Вторичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextSecondary",
+      "name" : "dark.text.on-dark.secondary",
+      "reference" : "TextOnDarkSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkSecondary",
+      "type" : "color",
+      "value" : "0x8FFFFFFF"
+    },
+    {
+      "description" : "Вторичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextSecondary",
+      "name" : "light.text.on-dark.secondary",
+      "reference" : "TextOnDarkSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkSecondary",
+      "type" : "color",
+      "value" : "0x8FFFFFFF"
+    },
+    {
+      "description" : "Вторичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextSecondaryActive",
+      "name" : "dark.text.on-dark.secondary-active",
+      "reference" : "TextOnDarkSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkSecondaryActive",
+      "type" : "color",
+      "value" : "0xABFFFFFF"
+    },
+    {
+      "description" : "Вторичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextSecondaryActive",
+      "name" : "light.text.on-dark.secondary-active",
+      "reference" : "TextOnDarkSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkSecondaryActive",
+      "type" : "color",
+      "value" : "0xABFFFFFF"
+    },
+    {
+      "description" : "Вторичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextSecondaryHover",
+      "name" : "dark.text.on-dark.secondary-hover",
+      "reference" : "TextOnDarkSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Вторичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextSecondaryHover",
+      "name" : "light.text.on-dark.secondary-hover",
+      "reference" : "TextOnDarkSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkSecondaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextTertiary",
+      "name" : "dark.text.on-dark.tertiary",
+      "reference" : "TextOnDarkTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkTertiary",
+      "type" : "color",
+      "value" : "0x47FFFFFF"
+    },
+    {
+      "description" : "Третичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextTertiary",
+      "name" : "light.text.on-dark.tertiary",
+      "reference" : "TextOnDarkTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkTertiary",
+      "type" : "color",
+      "value" : "0x47FFFFFF"
+    },
+    {
+      "description" : "typography l display-s",
+      "displayName" : "DisplayS N",
+      "name" : "screen-l.display.s.normal",
+      "reference" : "DisplaySNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displaySNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 68,
+        "size" : 64,
+        "style" : "normal",
+        "weight" : "light"
+      }
+    },
+    {
+      "description" : "Третичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextTertiaryActive",
+      "name" : "dark.text.on-dark.tertiary-active",
+      "reference" : "TextOnDarkTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkTertiaryActive",
+      "type" : "color",
+      "value" : "0x56FFFFFF"
+    },
+    {
+      "description" : "Третичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextTertiaryActive",
+      "name" : "light.text.on-dark.tertiary-active",
+      "reference" : "TextOnDarkTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkTertiaryActive",
+      "type" : "color",
+      "value" : "0x56FFFFFF"
+    },
+    {
+      "description" : "Третичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextTertiaryHover",
+      "name" : "dark.text.on-dark.tertiary-hover",
+      "reference" : "TextOnDarkTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Третичный цвет текста на темном фоне",
+      "displayName" : "onDarkTextTertiaryHover",
+      "name" : "light.text.on-dark.tertiary-hover",
+      "reference" : "TextOnDarkTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkTertiaryHover",
+      "type" : "color",
+      "value" : "0xFFFFFFFF"
+    },
+    {
+      "description" : "Цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarning",
+      "name" : "dark.text.on-dark.warning",
+      "reference" : "TextOnDarkWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarning",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarning",
+      "name" : "light.text.on-dark.warning",
+      "reference" : "TextOnDarkWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarning",
+      "type" : "color",
+      "value" : "0xFFFF7024"
+    },
+    {
+      "description" : "Цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningActive",
+      "name" : "dark.text.on-dark.warning-active",
+      "reference" : "TextOnDarkWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningActive",
+      "type" : "color",
+      "value" : "0xFFFF5D05"
+    },
+    {
+      "description" : "Цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningActive",
+      "name" : "light.text.on-dark.warning-active",
+      "reference" : "TextOnDarkWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningActive",
+      "type" : "color",
+      "value" : "0xFFFA5700"
+    },
+    {
+      "description" : "Цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningHover",
+      "name" : "dark.text.on-dark.warning-hover",
+      "reference" : "TextOnDarkWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF8442"
+    },
+    {
+      "description" : "Цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningHover",
+      "name" : "light.text.on-dark.warning-hover",
+      "reference" : "TextOnDarkWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningHover",
+      "type" : "color",
+      "value" : "0xFFFF8B4D"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningMinor",
+      "name" : "dark.text.on-dark.warning-minor",
+      "reference" : "TextOnDarkWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningMinor",
+      "type" : "color",
+      "value" : "0xFF85380C"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningMinor",
+      "name" : "light.text.on-dark.warning-minor",
+      "reference" : "TextOnDarkWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningMinor",
+      "type" : "color",
+      "value" : "0xFF85380C"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningMinorActive",
+      "name" : "dark.text.on-dark.warning-minor-active",
+      "reference" : "TextOnDarkWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFF9F440F"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningMinorActive",
+      "name" : "light.text.on-dark.warning-minor-active",
+      "reference" : "TextOnDarkWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFA84710"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningMinorHover",
+      "name" : "dark.text.on-dark.warning-minor-hover",
+      "reference" : "TextOnDarkWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFBB4F11"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на темном фоне",
+      "displayName" : "onDarkTextWarningMinorHover",
+      "name" : "light.text.on-dark.warning-minor-hover",
+      "reference" : "TextOnDarkWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnDarkWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFCD5713"
+    },
+    {
+      "description" : "Акцентный цвет на светлом фоне",
+      "displayName" : "onLightTextAccent",
+      "name" : "dark.text.on-light.accent",
+      "reference" : "TextOnLightAccent",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccent",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Акцентный цвет на светлом фоне",
+      "displayName" : "onLightTextAccent",
+      "name" : "light.text.on-light.accent",
+      "reference" : "TextOnLightAccent",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccent",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Акцентный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentActive",
+      "name" : "dark.text.on-light.accent-active",
+      "reference" : "TextOnLightAccentActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentActive",
+      "type" : "color",
+      "value" : "0xFF0D731E"
+    },
+    {
+      "description" : "Акцентный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentActive",
+      "name" : "light.text.on-light.accent-active",
+      "reference" : "TextOnLightAccentActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentActive",
+      "type" : "color",
+      "value" : "0xFF0C6A1B"
+    },
+    {
+      "description" : "Акцентный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentHover",
+      "name" : "dark.text.on-light.accent-hover",
+      "reference" : "TextOnLightAccentHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentHover",
+      "type" : "color",
+      "value" : "0xFF13AA2C"
+    },
+    {
+      "description" : "Акцентный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentHover",
+      "name" : "light.text.on-light.accent-hover",
+      "reference" : "TextOnLightAccentHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentHover",
+      "type" : "color",
+      "value" : "0xFF14B32E"
+    },
+    {
+      "description" : "Акцентный минорный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentMinor",
+      "name" : "dark.text.on-light.accent-minor",
+      "reference" : "TextOnLightAccentMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Акцентный минорный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentMinor",
+      "name" : "light.text.on-light.accent-minor",
+      "reference" : "TextOnLightAccentMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Акцентный минорный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentMinorActive",
+      "name" : "dark.text.on-light.accent-minor-active",
+      "reference" : "TextOnLightAccentMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF23B83E"
+    },
+    {
+      "description" : "Акцентный минорный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentMinorActive",
+      "name" : "light.text.on-light.accent-minor-active",
+      "reference" : "TextOnLightAccentMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentMinorActive",
+      "type" : "color",
+      "value" : "0xFF21B03C"
+    },
+    {
+      "description" : "Акцентный минорный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentMinorHover",
+      "name" : "dark.text.on-light.accent-minor-hover",
+      "reference" : "TextOnLightAccentMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF3EDA5B"
+    },
+    {
+      "description" : "Акцентный минорный цвет на светлом фоне",
+      "displayName" : "onLightTextAccentMinorHover",
+      "name" : "light.text.on-light.accent-minor-hover",
+      "reference" : "TextOnLightAccentMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightAccentMinorHover",
+      "type" : "color",
+      "value" : "0xFF47DC62"
+    },
+    {
+      "description" : "Цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfo",
+      "name" : "dark.text.on-light.info",
+      "reference" : "TextOnLightInfo",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfo",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfo",
+      "name" : "light.text.on-light.info",
+      "reference" : "TextOnLightInfo",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfo",
+      "type" : "color",
+      "value" : "0xFF0B7ECB"
+    },
+    {
+      "description" : "Цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoActive",
+      "name" : "dark.text.on-light.info-active",
+      "reference" : "TextOnLightInfoActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoActive",
+      "type" : "color",
+      "value" : "0xFF096CAE"
+    },
+    {
+      "description" : "Цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoActive",
+      "name" : "light.text.on-light.info-active",
+      "reference" : "TextOnLightInfoActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoActive",
+      "type" : "color",
+      "value" : "0xFF0966A5"
+    },
+    {
+      "description" : "Цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoHover",
+      "name" : "dark.text.on-light.info-hover",
+      "reference" : "TextOnLightInfoHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoHover",
+      "type" : "color",
+      "value" : "0xFF34A7F4"
+    },
+    {
+      "description" : "Цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoHover",
+      "name" : "light.text.on-light.info-hover",
+      "reference" : "TextOnLightInfoHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoHover",
+      "type" : "color",
+      "value" : "0xFF0D96F2"
+    },
+    {
+      "description" : "Минорный цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoMinor",
+      "name" : "dark.text.on-light.info-minor",
+      "reference" : "TextOnLightInfoMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoMinor",
+      "type" : "color",
+      "value" : "0xFF52BAFF"
+    },
+    {
+      "description" : "Минорный цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoMinor",
+      "name" : "light.text.on-light.info-minor",
+      "reference" : "TextOnLightInfoMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoMinor",
+      "type" : "color",
+      "value" : "0xFF52BAFF"
+    },
+    {
+      "description" : "Минорный цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoMinorActive",
+      "name" : "dark.text.on-light.info-minor-active",
+      "reference" : "TextOnLightInfoMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF33ADFF"
+    },
+    {
+      "description" : "Минорный цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoMinorActive",
+      "name" : "light.text.on-light.info-minor-active",
+      "reference" : "TextOnLightInfoMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoMinorActive",
+      "type" : "color",
+      "value" : "0xFF29A9FF"
+    },
+    {
+      "description" : "Минорный цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoMinorHover",
+      "name" : "dark.text.on-light.info-minor-hover",
+      "reference" : "TextOnLightInfoMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFFA3DAFF"
+    },
+    {
+      "description" : "Минорный цвет информации на светлом фоне",
+      "displayName" : "onLightTextInfoMinorHover",
+      "name" : "light.text.on-light.info-minor-hover",
+      "reference" : "TextOnLightInfoMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightInfoMinorHover",
+      "type" : "color",
+      "value" : "0xFF7ACAFF"
+    },
+    {
+      "description" : "Цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegative",
+      "name" : "dark.text.on-light.negative",
+      "reference" : "TextOnLightNegative",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegative",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegative",
+      "name" : "light.text.on-light.negative",
+      "reference" : "TextOnLightNegative",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegative",
+      "type" : "color",
+      "value" : "0xFFF31B31"
+    },
+    {
+      "description" : "Цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeActive",
+      "name" : "dark.text.on-light.negative-active",
+      "reference" : "TextOnLightNegativeActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeActive",
+      "type" : "color",
+      "value" : "0xFFE40C22"
+    },
+    {
+      "description" : "Цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeActive",
+      "name" : "light.text.on-light.negative-active",
+      "reference" : "TextOnLightNegativeActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeActive",
+      "type" : "color",
+      "value" : "0xFFDA0B20"
+    },
+    {
+      "description" : "Цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeHover",
+      "name" : "dark.text.on-light.negative-hover",
+      "reference" : "TextOnLightNegativeHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF5384B"
+    },
+    {
+      "description" : "Цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeHover",
+      "name" : "light.text.on-light.negative-hover",
+      "reference" : "TextOnLightNegativeHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeHover",
+      "type" : "color",
+      "value" : "0xFFF54254"
+    },
+    {
+      "description" : "Минорный цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeMinor",
+      "name" : "dark.text.on-light.negative-minor",
+      "reference" : "TextOnLightNegativeMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFF8F9A"
+    },
+    {
+      "description" : "Минорный цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeMinor",
+      "name" : "light.text.on-light.negative-minor",
+      "reference" : "TextOnLightNegativeMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeMinor",
+      "type" : "color",
+      "value" : "0xFFFF8F9A"
+    },
+    {
+      "description" : "Минорный цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeMinorActive",
+      "name" : "dark.text.on-light.negative-minor-active",
+      "reference" : "TextOnLightNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFF707E"
+    },
+    {
+      "description" : "Минорный цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeMinorActive",
+      "name" : "light.text.on-light.negative-minor-active",
+      "reference" : "TextOnLightNegativeMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeMinorActive",
+      "type" : "color",
+      "value" : "0xFFFF6675"
+    },
+    {
+      "description" : "Минорный цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeMinorHover",
+      "name" : "dark.text.on-light.negative-minor-hover",
+      "reference" : "TextOnLightNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFADB6"
+    },
+    {
+      "description" : "Минорный цвет ошибки на светлом фоне",
+      "displayName" : "onLightTextNegativeMinorHover",
+      "name" : "light.text.on-light.negative-minor-hover",
+      "reference" : "TextOnLightNegativeMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightNegativeMinorHover",
+      "type" : "color",
+      "value" : "0xFFFFB8BF"
+    },
+    {
+      "description" : "Сплошной наборный текст на светлом фоне",
+      "displayName" : "onLightTextParagraph",
+      "name" : "dark.text.on-light.paragraph",
+      "reference" : "TextOnLightParagraph",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightParagraph",
+      "type" : "color",
+      "value" : "0xCC171717"
+    },
+    {
+      "description" : "Сплошной наборный текст на светлом фоне",
+      "displayName" : "onLightTextParagraph",
+      "name" : "light.text.on-light.paragraph",
+      "reference" : "TextOnLightParagraph",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightParagraph",
+      "type" : "color",
+      "value" : "0xCC080808"
+    },
+    {
+      "description" : "Сплошной наборный текст на светлом фоне",
+      "displayName" : "onLightTextParagraphActive",
+      "name" : "dark.text.on-light.paragraph-active",
+      "reference" : "TextOnLightParagraphActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightParagraphActive",
+      "type" : "color",
+      "value" : "0xA3171717"
+    },
+    {
+      "description" : "Сплошной наборный текст на светлом фоне",
+      "displayName" : "onLightTextParagraphActive",
+      "name" : "light.text.on-light.paragraph-active",
+      "reference" : "TextOnLightParagraphActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightParagraphActive",
+      "type" : "color",
+      "value" : "0xA3080808"
+    },
+    {
+      "description" : "Сплошной наборный текст на светлом фоне",
+      "displayName" : "onLightTextParagraphHover",
+      "name" : "dark.text.on-light.paragraph-hover",
+      "reference" : "TextOnLightParagraphHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightParagraphHover",
+      "type" : "color",
+      "value" : "0x7A171717"
+    },
+    {
+      "description" : "Сплошной наборный текст на светлом фоне",
+      "displayName" : "onLightTextParagraphHover",
+      "name" : "light.text.on-light.paragraph-hover",
+      "reference" : "TextOnLightParagraphHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightParagraphHover",
+      "type" : "color",
+      "value" : "0x7A080808"
+    },
+    {
+      "description" : "Цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositive",
+      "name" : "dark.text.on-light.positive",
+      "reference" : "TextOnLightPositive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositive",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositive",
+      "name" : "light.text.on-light.positive",
+      "reference" : "TextOnLightPositive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositive",
+      "type" : "color",
+      "value" : "0xFF108E26"
+    },
+    {
+      "description" : "Цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveActive",
+      "name" : "dark.text.on-light.positive-active",
+      "reference" : "TextOnLightPositiveActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveActive",
+      "type" : "color",
+      "value" : "0xFF0D731E"
+    },
+    {
+      "description" : "Цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveActive",
+      "name" : "light.text.on-light.positive-active",
+      "reference" : "TextOnLightPositiveActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveActive",
+      "type" : "color",
+      "value" : "0xFF0C6A1B"
+    },
+    {
+      "description" : "Цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveHover",
+      "name" : "dark.text.on-light.positive-hover",
+      "reference" : "TextOnLightPositiveHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveHover",
+      "type" : "color",
+      "value" : "0xFF13AA2C"
+    },
+    {
+      "description" : "Цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveHover",
+      "name" : "light.text.on-light.positive-hover",
+      "reference" : "TextOnLightPositiveHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveHover",
+      "type" : "color",
+      "value" : "0xFF14B32E"
+    },
+    {
+      "description" : "Минорный цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveMinor",
+      "name" : "dark.text.on-light.positive-minor",
+      "reference" : "TextOnLightPositiveMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Минорный цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveMinor",
+      "name" : "light.text.on-light.positive-minor",
+      "reference" : "TextOnLightPositiveMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveMinor",
+      "type" : "color",
+      "value" : "0xFF28D247"
+    },
+    {
+      "description" : "Минорный цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveMinorActive",
+      "name" : "dark.text.on-light.positive-minor-active",
+      "reference" : "TextOnLightPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF23B83E"
+    },
+    {
+      "description" : "Минорный цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveMinorActive",
+      "name" : "light.text.on-light.positive-minor-active",
+      "reference" : "TextOnLightPositiveMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveMinorActive",
+      "type" : "color",
+      "value" : "0xFF21B03C"
+    },
+    {
+      "description" : "Минорный цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveMinorHover",
+      "name" : "dark.text.on-light.positive-minor-hover",
+      "reference" : "TextOnLightPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF3EDA5B"
+    },
+    {
+      "description" : "Минорный цвет успеха на светлом фоне",
+      "displayName" : "onLightTextPositiveMinorHover",
+      "name" : "light.text.on-light.positive-minor-hover",
+      "reference" : "TextOnLightPositiveMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPositiveMinorHover",
+      "type" : "color",
+      "value" : "0xFF47DC62"
+    },
+    {
+      "description" : "Основной цвет текста на светлом фоне",
+      "displayName" : "onLightTextPrimary",
+      "name" : "dark.text.on-light.primary",
+      "reference" : "TextOnLightPrimary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPrimary",
+      "type" : "color",
+      "value" : "0xF5171717"
+    },
+    {
+      "description" : "Основной цвет текста на светлом фоне",
+      "displayName" : "onLightTextPrimary",
+      "name" : "light.text.on-light.primary",
+      "reference" : "TextOnLightPrimary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPrimary",
+      "type" : "color",
+      "value" : "0xF5080808"
+    },
+    {
+      "description" : "Основной цвет текста на светлом фоне",
+      "displayName" : "onLightTextPrimaryActive",
+      "name" : "dark.text.on-light.primary-active",
+      "reference" : "TextOnLightPrimaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPrimaryActive",
+      "type" : "color",
+      "value" : "0xC4171717"
+    },
+    {
+      "description" : "Основной цвет текста на светлом фоне",
+      "displayName" : "onLightTextPrimaryActive",
+      "name" : "light.text.on-light.primary-active",
+      "reference" : "TextOnLightPrimaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPrimaryActive",
+      "type" : "color",
+      "value" : "0xC4080808"
+    },
+    {
+      "description" : "Основной цвет текста на светлом фоне",
+      "displayName" : "onLightTextPrimaryBrightness",
+      "name" : "dark.text.on-light.primary-brightness",
+      "reference" : "TextOnLightPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xF5171717"
+    },
+    {
+      "description" : "Основной цвет текста на светлом фоне",
+      "displayName" : "onLightTextPrimaryBrightness",
+      "name" : "light.text.on-light.primary-brightness",
+      "reference" : "TextOnLightPrimaryBrightness",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPrimaryBrightness",
+      "type" : "color",
+      "value" : "0xF5080808"
+    },
+    {
+      "description" : "Основной цвет текста на светлом фоне",
+      "displayName" : "onLightTextPrimaryHover",
+      "name" : "dark.text.on-light.primary-hover",
+      "reference" : "TextOnLightPrimaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPrimaryHover",
+      "type" : "color",
+      "value" : "0x93171717"
+    },
+    {
+      "description" : "Основной цвет текста на светлом фоне",
+      "displayName" : "onLightTextPrimaryHover",
+      "name" : "light.text.on-light.primary-hover",
+      "reference" : "TextOnLightPrimaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightPrimaryHover",
+      "type" : "color",
+      "value" : "0x93080808"
+    },
+    {
+      "description" : "Вторичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextSecondary",
+      "name" : "dark.text.on-light.secondary",
+      "reference" : "TextOnLightSecondary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightSecondary",
+      "type" : "color",
+      "value" : "0x8E171717"
+    },
+    {
+      "description" : "Вторичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextSecondary",
+      "name" : "light.text.on-light.secondary",
+      "reference" : "TextOnLightSecondary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightSecondary",
+      "type" : "color",
+      "value" : "0x8F080808"
+    },
+    {
+      "description" : "Вторичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextSecondaryActive",
+      "name" : "dark.text.on-light.secondary-active",
+      "reference" : "TextOnLightSecondaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightSecondaryActive",
+      "type" : "color",
+      "value" : "0xAB171717"
+    },
+    {
+      "description" : "Вторичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextSecondaryActive",
+      "name" : "light.text.on-light.secondary-active",
+      "reference" : "TextOnLightSecondaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightSecondaryActive",
+      "type" : "color",
+      "value" : "0xAB080808"
+    },
+    {
+      "description" : "Вторичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextSecondaryHover",
+      "name" : "dark.text.on-light.secondary-hover",
+      "reference" : "TextOnLightSecondaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Вторичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextSecondaryHover",
+      "name" : "light.text.on-light.secondary-hover",
+      "reference" : "TextOnLightSecondaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightSecondaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Третичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextTertiary",
+      "name" : "dark.text.on-light.tertiary",
+      "reference" : "TextOnLightTertiary",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightTertiary",
+      "type" : "color",
+      "value" : "0x47171717"
+    },
+    {
+      "description" : "Третичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextTertiary",
+      "name" : "light.text.on-light.tertiary",
+      "reference" : "TextOnLightTertiary",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightTertiary",
+      "type" : "color",
+      "value" : "0x47080808"
+    },
+    {
+      "description" : "Третичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextTertiaryActive",
+      "name" : "dark.text.on-light.tertiary-active",
+      "reference" : "TextOnLightTertiaryActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightTertiaryActive",
+      "type" : "color",
+      "value" : "0x56171717"
+    },
+    {
+      "description" : "Третичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextTertiaryActive",
+      "name" : "light.text.on-light.tertiary-active",
+      "reference" : "TextOnLightTertiaryActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightTertiaryActive",
+      "type" : "color",
+      "value" : "0x56080808"
+    },
+    {
+      "description" : "Третичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextTertiaryHover",
+      "name" : "dark.text.on-light.tertiary-hover",
+      "reference" : "TextOnLightTertiaryHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF171717"
+    },
+    {
+      "description" : "Третичный цвет текста на светлом фоне",
+      "displayName" : "onLightTextTertiaryHover",
+      "name" : "light.text.on-light.tertiary-hover",
+      "reference" : "TextOnLightTertiaryHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightTertiaryHover",
+      "type" : "color",
+      "value" : "0xFF080808"
+    },
+    {
+      "description" : "Цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarning",
+      "name" : "dark.text.on-light.warning",
+      "reference" : "TextOnLightWarning",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarning",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarning",
+      "name" : "light.text.on-light.warning",
+      "reference" : "TextOnLightWarning",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarning",
+      "type" : "color",
+      "value" : "0xFFE85702"
+    },
+    {
+      "description" : "Цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningActive",
+      "name" : "dark.text.on-light.warning-active",
+      "reference" : "TextOnLightWarningActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningActive",
+      "type" : "color",
+      "value" : "0xFFCA4B02"
+    },
+    {
+      "description" : "Цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningActive",
+      "name" : "light.text.on-light.warning-active",
+      "reference" : "TextOnLightWarningActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningActive",
+      "type" : "color",
+      "value" : "0xFFC04802"
+    },
+    {
+      "description" : "Цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningHover",
+      "name" : "dark.text.on-light.warning-hover",
+      "reference" : "TextOnLightWarningHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningHover",
+      "type" : "color",
+      "value" : "0xFFFD650D"
+    },
+    {
+      "description" : "Цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningHover",
+      "name" : "light.text.on-light.warning-hover",
+      "reference" : "TextOnLightWarningHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningHover",
+      "type" : "color",
+      "value" : "0xFFFD6B17"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningMinor",
+      "name" : "dark.text.on-light.warning-minor",
+      "reference" : "TextOnLightWarningMinor",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFD9C68"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningMinor",
+      "name" : "light.text.on-light.warning-minor",
+      "reference" : "TextOnLightWarningMinor",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningMinor",
+      "type" : "color",
+      "value" : "0xFFFD9C68"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningMinorActive",
+      "name" : "dark.text.on-light.warning-minor-active",
+      "reference" : "TextOnLightWarningMinorActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFC884A"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningMinorActive",
+      "name" : "light.text.on-light.warning-minor-active",
+      "reference" : "TextOnLightWarningMinorActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningMinorActive",
+      "type" : "color",
+      "value" : "0xFFFC8240"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningMinorHover",
+      "name" : "dark.text.on-light.warning-minor-hover",
+      "reference" : "TextOnLightWarningMinorHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFDB086"
+    },
+    {
+      "description" : "Минорный цвет предупреждения на светлом фоне",
+      "displayName" : "onLightTextWarningMinorHover",
+      "name" : "light.text.on-light.warning-minor-hover",
+      "reference" : "TextOnLightWarningMinorHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.ColorToken.textOnLightWarningMinorHover",
+      "type" : "color",
+      "value" : "0xFFFDB790"
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом",
+      "displayName" : "outlineAccentGradient",
+      "name" : "dark.outline.default.accent-gradient",
+      "reference" : "OutlineDefaultAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineDefaultAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом",
+      "displayName" : "outlineAccentGradient",
+      "name" : "light.outline.default.accent-gradient",
+      "reference" : "OutlineDefaultAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineDefaultAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF0D8523",
+            "0xFF0DA8AB"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом",
+      "displayName" : "outlineAccentGradientActive",
+      "name" : "dark.outline.default.accent-gradient-active",
+      "reference" : "OutlineDefaultAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineDefaultAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом",
+      "displayName" : "outlineAccentGradientActive",
+      "name" : "light.outline.default.accent-gradient-active",
+      "reference" : "OutlineDefaultAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineDefaultAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом",
+      "displayName" : "outlineAccentGradientHover",
+      "name" : "dark.outline.default.accent-gradient-hover",
+      "reference" : "OutlineDefaultAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineDefaultAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом",
+      "displayName" : "outlineAccentGradientHover",
+      "name" : "light.outline.default.accent-gradient-hover",
+      "reference" : "OutlineDefaultAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineDefaultAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки с градиентом",
+      "displayName" : "inverseOutlineAccentGradient",
+      "name" : "dark.outline.inverse.accent-gradient",
+      "reference" : "OutlineInverseAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineInverseAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF0D8523",
+            "0xFF0DA8AB"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки с градиентом",
+      "displayName" : "inverseOutlineAccentGradient",
+      "name" : "light.outline.inverse.accent-gradient",
+      "reference" : "OutlineInverseAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineInverseAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки с градиентом",
+      "displayName" : "inverseOutlineAccentGradientActive",
+      "name" : "dark.outline.inverse.accent-gradient-active",
+      "reference" : "OutlineInverseAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineInverseAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки с градиентом",
+      "displayName" : "inverseOutlineAccentGradientActive",
+      "name" : "light.outline.inverse.accent-gradient-active",
+      "reference" : "OutlineInverseAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineInverseAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки с градиентом",
+      "displayName" : "inverseOutlineAccentGradientHover",
+      "name" : "dark.outline.inverse.accent-gradient-hover",
+      "reference" : "OutlineInverseAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineInverseAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет обводки с градиентом",
+      "displayName" : "inverseOutlineAccentGradientHover",
+      "name" : "light.outline.inverse.accent-gradient-hover",
+      "reference" : "OutlineInverseAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineInverseAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "typography l header-h1-bold",
+      "displayName" : "HeaderH1 B",
+      "name" : "screen-l.header.h1.bold",
+      "reference" : "HeaderH1Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH1Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 52,
+        "size" : 48,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на темном фоне",
+      "displayName" : "onDarkOutlineAccentGradient",
+      "name" : "dark.outline.on-dark.accent-gradient",
+      "reference" : "OutlineOnDarkAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnDarkAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на темном фоне",
+      "displayName" : "onDarkOutlineAccentGradient",
+      "name" : "light.outline.on-dark.accent-gradient",
+      "reference" : "OutlineOnDarkAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnDarkAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на темном фоне",
+      "displayName" : "onDarkOutlineAccentGradientActive",
+      "name" : "dark.outline.on-dark.accent-gradient-active",
+      "reference" : "OutlineOnDarkAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnDarkAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на темном фоне",
+      "displayName" : "onDarkOutlineAccentGradientActive",
+      "name" : "light.outline.on-dark.accent-gradient-active",
+      "reference" : "OutlineOnDarkAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnDarkAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на темном фоне",
+      "displayName" : "onDarkOutlineAccentGradientHover",
+      "name" : "dark.outline.on-dark.accent-gradient-hover",
+      "reference" : "OutlineOnDarkAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnDarkAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на темном фоне",
+      "displayName" : "onDarkOutlineAccentGradientHover",
+      "name" : "light.outline.on-dark.accent-gradient-hover",
+      "reference" : "OutlineOnDarkAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnDarkAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на светлом фоне",
+      "displayName" : "onLightOutlineAccentGradient",
+      "name" : "dark.outline.on-light.accent-gradient",
+      "reference" : "OutlineOnLightAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnLightAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF0D8523",
+            "0xFF0DA8AB"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на светлом фоне",
+      "displayName" : "onLightOutlineAccentGradient",
+      "name" : "light.outline.on-light.accent-gradient",
+      "reference" : "OutlineOnLightAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnLightAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF0D8523",
+            "0xFF0DA8AB"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на светлом фоне",
+      "displayName" : "onLightOutlineAccentGradientActive",
+      "name" : "dark.outline.on-light.accent-gradient-active",
+      "reference" : "OutlineOnLightAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnLightAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на светлом фоне",
+      "displayName" : "onLightOutlineAccentGradientActive",
+      "name" : "light.outline.on-light.accent-gradient-active",
+      "reference" : "OutlineOnLightAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnLightAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на светлом фоне",
+      "displayName" : "onLightOutlineAccentGradientHover",
+      "name" : "dark.outline.on-light.accent-gradient-hover",
+      "reference" : "OutlineOnLightAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnLightAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет обводки с градиентом на светлом фоне",
+      "displayName" : "onLightOutlineAccentGradientHover",
+      "name" : "light.outline.on-light.accent-gradient-hover",
+      "reference" : "OutlineOnLightAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.outlineOnLightAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "typography l header-h1-medium",
+      "displayName" : "HeaderH1 M",
+      "name" : "screen-l.header.h1.medium",
+      "reference" : "HeaderH1Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH1Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 52,
+        "size" : 48,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "dark overlay default overlayGradientDown",
+      "displayName" : "overlayGradientDown",
+      "name" : "dark.overlay.default.gradient-down",
+      "reference" : "OverlayDefaultGradientDown",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayDefaultGradientDown",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 180,
+          "colors" : [
+            "0x00000000",
+            "0x03000000",
+            "0x0A000000",
+            "0x14000000",
+            "0x26000000",
+            "0x3B000000",
+            "0x54000000",
+            "0x70000000",
+            "0x8F000000",
+            "0xAB000000",
+            "0xC4000000",
+            "0xD9000000",
+            "0xEB000000",
+            "0xF5000000",
+            "0xFC000000",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.09,
+            0.1,
+            0.1,
+            0.11,
+            0.12,
+            0.13,
+            0.14
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay default overlayGradientDown",
+      "displayName" : "overlayGradientDown",
+      "name" : "light.overlay.default.gradient-down",
+      "reference" : "OverlayDefaultGradientDown",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayDefaultGradientDown",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 180,
+          "colors" : [
+            "0x00FFFFFF",
+            "0x03FFFFFF",
+            "0x0AFFFFFF",
+            "0x14FFFFFF",
+            "0x26FFFFFF",
+            "0x3BFFFFFF",
+            "0x54FFFFFF",
+            "0x70FFFFFF",
+            "0x8FFFFFFF",
+            "0xABFFFFFF",
+            "0xC4FFFFFF",
+            "0xD9FFFFFF",
+            "0xEBFFFFFF",
+            "0xF5FFFFFF",
+            "0xFCFFFFFF",
+            "0xFFFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.09,
+            0.1,
+            0.1,
+            0.11,
+            0.12,
+            0.13,
+            0.14
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay default overlayGradientUp",
+      "displayName" : "overlayGradientUp",
+      "name" : "dark.overlay.default.gradient-up",
+      "reference" : "OverlayDefaultGradientUp",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayDefaultGradientUp",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 0,
+          "colors" : [
+            "0x00000000",
+            "0x03000000",
+            "0x0A000000",
+            "0x14000000",
+            "0x26000000",
+            "0x3B000000",
+            "0x54000000",
+            "0x70000000",
+            "0x8F000000",
+            "0xAB000000",
+            "0xC4000000",
+            "0xD9000000",
+            "0xEB000000",
+            "0xF5000000",
+            "0xFC000000",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.08,
+            0.09,
+            0.1,
+            0.11,
+            0.12
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay default overlayGradientUp",
+      "displayName" : "overlayGradientUp",
+      "name" : "light.overlay.default.gradient-up",
+      "reference" : "OverlayDefaultGradientUp",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayDefaultGradientUp",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 0,
+          "colors" : [
+            "0x00FFFFFF",
+            "0x03FFFFFF",
+            "0x0AFFFFFF",
+            "0x14FFFFFF",
+            "0x26FFFFFF",
+            "0x3BFFFFFF",
+            "0x54FFFFFF",
+            "0x70FFFFFF",
+            "0x8FFFFFFF",
+            "0xABFFFFFF",
+            "0xC4FFFFFF",
+            "0xD9FFFFFF",
+            "0xEBFFFFFF",
+            "0xF5FFFFFF",
+            "0xFCFFFFFF",
+            "0xFFFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.08,
+            0.09,
+            0.1,
+            0.11,
+            0.12
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay inverse overlayGradientDown",
+      "displayName" : "inverseOverlayGradientDown",
+      "name" : "dark.overlay.inverse.gradient-down",
+      "reference" : "OverlayInverseGradientDown",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayInverseGradientDown",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 180,
+          "colors" : [
+            "0x00FFFFFF",
+            "0x03FFFFFF",
+            "0x0AFFFFFF",
+            "0x14FFFFFF",
+            "0x26FFFFFF",
+            "0x3BFFFFFF",
+            "0x54FFFFFF",
+            "0x70FFFFFF",
+            "0x8FFFFFFF",
+            "0xABFFFFFF",
+            "0xC4FFFFFF",
+            "0xD9FFFFFF",
+            "0xEBFFFFFF",
+            "0xF5FFFFFF",
+            "0xFCFFFFFF",
+            "0xFFFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.09,
+            0.1,
+            0.1,
+            0.11,
+            0.12,
+            0.13,
+            0.14
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay inverse overlayGradientDown",
+      "displayName" : "inverseOverlayGradientDown",
+      "name" : "light.overlay.inverse.gradient-down",
+      "reference" : "OverlayInverseGradientDown",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayInverseGradientDown",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 180,
+          "colors" : [
+            "0x00000000",
+            "0x03000000",
+            "0x0A000000",
+            "0x14000000",
+            "0x26000000",
+            "0x3B000000",
+            "0x54000000",
+            "0x70000000",
+            "0x8F000000",
+            "0xAB000000",
+            "0xC4000000",
+            "0xD9000000",
+            "0xEB000000",
+            "0xF5000000",
+            "0xFC000000",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.09,
+            0.1,
+            0.1,
+            0.11,
+            0.12,
+            0.13,
+            0.14
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay inverse overlayGradientUp",
+      "displayName" : "inverseOverlayGradientUp",
+      "name" : "dark.overlay.inverse.gradient-up",
+      "reference" : "OverlayInverseGradientUp",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayInverseGradientUp",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 0,
+          "colors" : [
+            "0x00FFFFFF",
+            "0x03FFFFFF",
+            "0x0AFFFFFF",
+            "0x14FFFFFF",
+            "0x26FFFFFF",
+            "0x3BFFFFFF",
+            "0x54FFFFFF",
+            "0x70FFFFFF",
+            "0x8FFFFFFF",
+            "0xABFFFFFF",
+            "0xC4FFFFFF",
+            "0xD9FFFFFF",
+            "0xEBFFFFFF",
+            "0xF5FFFFFF",
+            "0xFCFFFFFF",
+            "0xFFFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.08,
+            0.09,
+            0.1,
+            0.11,
+            0.12
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay inverse overlayGradientUp",
+      "displayName" : "inverseOverlayGradientUp",
+      "name" : "light.overlay.inverse.gradient-up",
+      "reference" : "OverlayInverseGradientUp",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayInverseGradientUp",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 0,
+          "colors" : [
+            "0x00000000",
+            "0x03000000",
+            "0x0A000000",
+            "0x14000000",
+            "0x26000000",
+            "0x3B000000",
+            "0x54000000",
+            "0x70000000",
+            "0x8F000000",
+            "0xAB000000",
+            "0xC4000000",
+            "0xD9000000",
+            "0xEB000000",
+            "0xF5000000",
+            "0xFC000000",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.08,
+            0.09,
+            0.1,
+            0.11,
+            0.12
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay onDark overlayGradientDown",
+      "displayName" : "onDarkOverlayGradientDown",
+      "name" : "dark.overlay.on-dark.gradient-down",
+      "reference" : "OverlayOnDarkGradientDown",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayOnDarkGradientDown",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 180,
+          "colors" : [
+            "0x00000000",
+            "0x03000000",
+            "0x0A000000",
+            "0x14000000",
+            "0x26000000",
+            "0x3B000000",
+            "0x54000000",
+            "0x70000000",
+            "0x8F000000",
+            "0xAB000000",
+            "0xC4000000",
+            "0xD9000000",
+            "0xEB000000",
+            "0xF5000000",
+            "0xFC000000",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.09,
+            0.1,
+            0.1,
+            0.11,
+            0.12,
+            0.13,
+            0.14
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay onDark overlayGradientDown",
+      "displayName" : "onDarkOverlayGradientDown",
+      "name" : "light.overlay.on-dark.gradient-down",
+      "reference" : "OverlayOnDarkGradientDown",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayOnDarkGradientDown",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 180,
+          "colors" : [
+            "0x00000000",
+            "0x03000000",
+            "0x0A000000",
+            "0x14000000",
+            "0x26000000",
+            "0x3B000000",
+            "0x54000000",
+            "0x70000000",
+            "0x8F000000",
+            "0xAB000000",
+            "0xC4000000",
+            "0xD9000000",
+            "0xEB000000",
+            "0xF5000000",
+            "0xFC000000",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.09,
+            0.1,
+            0.1,
+            0.11,
+            0.12,
+            0.13,
+            0.14
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay onDark overlayGradientUp",
+      "displayName" : "onDarkOverlayGradientUp",
+      "name" : "dark.overlay.on-dark.gradient-up",
+      "reference" : "OverlayOnDarkGradientUp",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayOnDarkGradientUp",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 0,
+          "colors" : [
+            "0x00000000",
+            "0x03000000",
+            "0x0A000000",
+            "0x14000000",
+            "0x26000000",
+            "0x3B000000",
+            "0x54000000",
+            "0x70000000",
+            "0x8F000000",
+            "0xAB000000",
+            "0xC4000000",
+            "0xD9000000",
+            "0xEB000000",
+            "0xF5000000",
+            "0xFC000000",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.08,
+            0.09,
+            0.1,
+            0.11,
+            0.12
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay onDark overlayGradientUp",
+      "displayName" : "onDarkOverlayGradientUp",
+      "name" : "light.overlay.on-dark.gradient-up",
+      "reference" : "OverlayOnDarkGradientUp",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayOnDarkGradientUp",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 0,
+          "colors" : [
+            "0x00000000",
+            "0x03000000",
+            "0x0A000000",
+            "0x14000000",
+            "0x26000000",
+            "0x3B000000",
+            "0x54000000",
+            "0x70000000",
+            "0x8F000000",
+            "0xAB000000",
+            "0xC4000000",
+            "0xD9000000",
+            "0xEB000000",
+            "0xF5000000",
+            "0xFC000000",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.08,
+            0.09,
+            0.1,
+            0.11,
+            0.12
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay onLight overlayGradientDown",
+      "displayName" : "onLightOverlayGradientDown",
+      "name" : "dark.overlay.on-light.gradient-down",
+      "reference" : "OverlayOnLightGradientDown",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayOnLightGradientDown",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 180,
+          "colors" : [
+            "0x00FFFFFF",
+            "0x03FFFFFF",
+            "0x0AFFFFFF",
+            "0x14FFFFFF",
+            "0x26FFFFFF",
+            "0x3BFFFFFF",
+            "0x54FFFFFF",
+            "0x70FFFFFF",
+            "0x8FFFFFFF",
+            "0xABFFFFFF",
+            "0xC4FFFFFF",
+            "0xD9FFFFFF",
+            "0xEBFFFFFF",
+            "0xF5FFFFFF",
+            "0xFCFFFFFF",
+            "0xFFFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.09,
+            0.1,
+            0.1,
+            0.11,
+            0.12,
+            0.13,
+            0.14
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay onLight overlayGradientDown",
+      "displayName" : "onLightOverlayGradientDown",
+      "name" : "light.overlay.on-light.gradient-down",
+      "reference" : "OverlayOnLightGradientDown",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayOnLightGradientDown",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 180,
+          "colors" : [
+            "0x00FFFFFF",
+            "0x03FFFFFF",
+            "0x0AFFFFFF",
+            "0x14FFFFFF",
+            "0x26FFFFFF",
+            "0x3BFFFFFF",
+            "0x54FFFFFF",
+            "0x70FFFFFF",
+            "0x8FFFFFFF",
+            "0xABFFFFFF",
+            "0xC4FFFFFF",
+            "0xD9FFFFFF",
+            "0xEBFFFFFF",
+            "0xF5FFFFFF",
+            "0xFCFFFFFF",
+            "0xFFFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.09,
+            0.1,
+            0.1,
+            0.11,
+            0.12,
+            0.13,
+            0.14
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay onLight overlayGradientUp",
+      "displayName" : "onLightOverlayGradientUp",
+      "name" : "dark.overlay.on-light.gradient-up",
+      "reference" : "OverlayOnLightGradientUp",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayOnLightGradientUp",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 0,
+          "colors" : [
+            "0x00FFFFFF",
+            "0x03FFFFFF",
+            "0x0AFFFFFF",
+            "0x14FFFFFF",
+            "0x26FFFFFF",
+            "0x3BFFFFFF",
+            "0x54FFFFFF",
+            "0x70FFFFFF",
+            "0x8FFFFFFF",
+            "0xABFFFFFF",
+            "0xC4FFFFFF",
+            "0xD9FFFFFF",
+            "0xEBFFFFFF",
+            "0xF5FFFFFF",
+            "0xFCFFFFFF",
+            "0xFFFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.08,
+            0.09,
+            0.1,
+            0.11,
+            0.12
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "dark overlay onLight overlayGradientUp",
+      "displayName" : "onLightOverlayGradientUp",
+      "name" : "light.overlay.on-light.gradient-up",
+      "reference" : "OverlayOnLightGradientUp",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.overlayOnLightGradientUp",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 0,
+          "colors" : [
+            "0x00FFFFFF",
+            "0x03FFFFFF",
+            "0x0AFFFFFF",
+            "0x14FFFFFF",
+            "0x26FFFFFF",
+            "0x3BFFFFFF",
+            "0x54FFFFFF",
+            "0x70FFFFFF",
+            "0x8FFFFFFF",
+            "0xABFFFFFF",
+            "0xC4FFFFFF",
+            "0xD9FFFFFF",
+            "0xEBFFFFFF",
+            "0xF5FFFFFF",
+            "0xFCFFFFFF",
+            "0xFFFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.01,
+            0.02,
+            0.02,
+            0.03,
+            0.04,
+            0.05,
+            0.05,
+            0.06,
+            0.07,
+            0.08,
+            0.08,
+            0.09,
+            0.1,
+            0.11,
+            0.12
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "surfaceAccentGradient",
+      "name" : "dark.surface.default.accent-gradient",
+      "reference" : "SurfaceDefaultAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "surfaceAccentGradient",
+      "name" : "light.surface.default.accent-gradient",
+      "reference" : "SurfaceDefaultAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "surfaceAccentGradientActive",
+      "name" : "dark.surface.default.accent-gradient-active",
+      "reference" : "SurfaceDefaultAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "surfaceAccentGradientActive",
+      "name" : "light.surface.default.accent-gradient-active",
+      "reference" : "SurfaceDefaultAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "surfaceAccentGradientHover",
+      "name" : "dark.surface.default.accent-gradient-hover",
+      "reference" : "SurfaceDefaultAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "surfaceAccentGradientHover",
+      "name" : "light.surface.default.accent-gradient-hover",
+      "reference" : "SurfaceDefaultAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "surfaceSkeletonDeepGradient",
+      "name" : "dark.surface.default.skeleton-deep-gradient",
+      "reference" : "SurfaceDefaultSkeletonDeepGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonDeepGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x5CFFFFFF",
+            "0x52FFFFFF",
+            "0x33FFFFFF",
+            "0x0AFFFFFF",
+            "0x33FFFFFF",
+            "0x52FFFFFF",
+            "0x5CFFFFFF",
+            "0x14FFFFFF",
+            "0x33FFFFFF",
+            "0x0AFFFFFF",
+            "0x33FFFFFF",
+            "0x52FFFFFF",
+            "0x5CFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "surfaceSkeletonDeepGradient",
+      "name" : "light.surface.default.skeleton-deep-gradient",
+      "reference" : "SurfaceDefaultSkeletonDeepGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonDeepGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x5C080808",
+            "0x52080808",
+            "0x33080808",
+            "0x0A080808",
+            "0x33080808",
+            "0x52080808",
+            "0x5C080808",
+            "0x14080808",
+            "0x33080808",
+            "0x0A080808",
+            "0x33080808",
+            "0x52080808",
+            "0x5C080808"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "surfaceSkeletonDeepGradientActive",
+      "name" : "dark.surface.default.skeleton-deep-gradient-active",
+      "reference" : "SurfaceDefaultSkeletonDeepGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonDeepGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "surfaceSkeletonDeepGradientActive",
+      "name" : "light.surface.default.skeleton-deep-gradient-active",
+      "reference" : "SurfaceDefaultSkeletonDeepGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonDeepGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "surfaceSkeletonDeepGradientHover",
+      "name" : "dark.surface.default.skeleton-deep-gradient-hover",
+      "reference" : "SurfaceDefaultSkeletonDeepGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonDeepGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "surfaceSkeletonDeepGradientHover",
+      "name" : "light.surface.default.skeleton-deep-gradient-hover",
+      "reference" : "SurfaceDefaultSkeletonDeepGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonDeepGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "surfaceSkeletonGradient",
+      "name" : "dark.surface.default.skeleton-gradient",
+      "reference" : "SurfaceDefaultSkeletonGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x17FFFFFF",
+            "0x14FFFFFF",
+            "0x0DFFFFFF",
+            "0x03FFFFFF",
+            "0x0DFFFFFF",
+            "0x14FFFFFF",
+            "0x17FFFFFF",
+            "0x14FFFFFF",
+            "0x0DFFFFFF",
+            "0x03FFFFFF",
+            "0x0DFFFFFF",
+            "0x14FFFFFF",
+            "0x17FFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "surfaceSkeletonGradient",
+      "name" : "light.surface.default.skeleton-gradient",
+      "reference" : "SurfaceDefaultSkeletonGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x17080808",
+            "0x14080808",
+            "0x0D080808",
+            "0x03080808",
+            "0x0D080808",
+            "0x14080808",
+            "0x17080808",
+            "0x14080808",
+            "0x0D080808",
+            "0x03080808",
+            "0x0D080808",
+            "0x14080808",
+            "0x17080808"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "surfaceSkeletonGradientActive",
+      "name" : "dark.surface.default.skeleton-gradient-active",
+      "reference" : "SurfaceDefaultSkeletonGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "surfaceSkeletonGradientActive",
+      "name" : "light.surface.default.skeleton-gradient-active",
+      "reference" : "SurfaceDefaultSkeletonGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "surfaceSkeletonGradientHover",
+      "name" : "dark.surface.default.skeleton-gradient-hover",
+      "reference" : "SurfaceDefaultSkeletonGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "surfaceSkeletonGradientHover",
+      "name" : "light.surface.default.skeleton-gradient-hover",
+      "reference" : "SurfaceDefaultSkeletonGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceDefaultSkeletonGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "inverseSurfaceAccentGradient",
+      "name" : "dark.surface.inverse.accent-gradient",
+      "reference" : "SurfaceInverseAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "inverseSurfaceAccentGradient",
+      "name" : "light.surface.inverse.accent-gradient",
+      "reference" : "SurfaceInverseAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "inverseSurfaceAccentGradientActive",
+      "name" : "dark.surface.inverse.accent-gradient-active",
+      "reference" : "SurfaceInverseAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "inverseSurfaceAccentGradientActive",
+      "name" : "light.surface.inverse.accent-gradient-active",
+      "reference" : "SurfaceInverseAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "inverseSurfaceAccentGradientHover",
+      "name" : "dark.surface.inverse.accent-gradient-hover",
+      "reference" : "SurfaceInverseAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный фон поверхности/контрола с градиентом",
+      "displayName" : "inverseSurfaceAccentGradientHover",
+      "name" : "light.surface.inverse.accent-gradient-hover",
+      "reference" : "SurfaceInverseAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonDeepGradient",
+      "name" : "dark.surface.inverse.skeleton-deep-gradient",
+      "reference" : "SurfaceInverseSkeletonDeepGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonDeepGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x5C080808",
+            "0x52080808",
+            "0x33080808",
+            "0x0A080808",
+            "0x33080808",
+            "0x52080808",
+            "0x5C080808",
+            "0x14080808",
+            "0x33080808",
+            "0x0A080808",
+            "0x33080808",
+            "0x52080808",
+            "0x5C080808"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonDeepGradient",
+      "name" : "light.surface.inverse.skeleton-deep-gradient",
+      "reference" : "SurfaceInverseSkeletonDeepGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonDeepGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x5CFFFFFF",
+            "0x52FFFFFF",
+            "0x33FFFFFF",
+            "0x0AFFFFFF",
+            "0x33FFFFFF",
+            "0x52FFFFFF",
+            "0x5CFFFFFF",
+            "0x14FFFFFF",
+            "0x33FFFFFF",
+            "0x0AFFFFFF",
+            "0x33FFFFFF",
+            "0x52FFFFFF",
+            "0x5CFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonDeepGradientActive",
+      "name" : "dark.surface.inverse.skeleton-deep-gradient-active",
+      "reference" : "SurfaceInverseSkeletonDeepGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonDeepGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonDeepGradientActive",
+      "name" : "light.surface.inverse.skeleton-deep-gradient-active",
+      "reference" : "SurfaceInverseSkeletonDeepGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonDeepGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonDeepGradientHover",
+      "name" : "dark.surface.inverse.skeleton-deep-gradient-hover",
+      "reference" : "SurfaceInverseSkeletonDeepGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonDeepGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonDeepGradientHover",
+      "name" : "light.surface.inverse.skeleton-deep-gradient-hover",
+      "reference" : "SurfaceInverseSkeletonDeepGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonDeepGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonGradient",
+      "name" : "dark.surface.inverse.skeleton-gradient",
+      "reference" : "SurfaceInverseSkeletonGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x17080808",
+            "0x14080808",
+            "0x0D080808",
+            "0x03080808",
+            "0x0D080808",
+            "0x14080808",
+            "0x17080808",
+            "0x14080808",
+            "0x0D080808",
+            "0x03080808",
+            "0x0D080808",
+            "0x14080808",
+            "0x17080808"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonGradient",
+      "name" : "light.surface.inverse.skeleton-gradient",
+      "reference" : "SurfaceInverseSkeletonGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x17FFFFFF",
+            "0x14FFFFFF",
+            "0x0DFFFFFF",
+            "0x03FFFFFF",
+            "0x0DFFFFFF",
+            "0x14FFFFFF",
+            "0x17FFFFFF",
+            "0x14FFFFFF",
+            "0x0DFFFFFF",
+            "0x03FFFFFF",
+            "0x0DFFFFFF",
+            "0x14FFFFFF",
+            "0x17FFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonGradientActive",
+      "name" : "dark.surface.inverse.skeleton-gradient-active",
+      "reference" : "SurfaceInverseSkeletonGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonGradientActive",
+      "name" : "light.surface.inverse.skeleton-gradient-active",
+      "reference" : "SurfaceInverseSkeletonGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonGradientHover",
+      "name" : "dark.surface.inverse.skeleton-gradient-hover",
+      "reference" : "SurfaceInverseSkeletonGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "inverseSurfaceSkeletonGradientHover",
+      "name" : "light.surface.inverse.skeleton-gradient-hover",
+      "reference" : "SurfaceInverseSkeletonGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceInverseSkeletonGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на темном фоне",
+      "displayName" : "onDarkSurfaceAccentGradient",
+      "name" : "dark.surface.on-dark.accent-gradient",
+      "reference" : "SurfaceOnDarkAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на темном фоне",
+      "displayName" : "onDarkSurfaceAccentGradient",
+      "name" : "light.surface.on-dark.accent-gradient",
+      "reference" : "SurfaceOnDarkAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на темном фоне",
+      "displayName" : "onDarkSurfaceAccentGradientActive",
+      "name" : "dark.surface.on-dark.accent-gradient-active",
+      "reference" : "SurfaceOnDarkAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на темном фоне",
+      "displayName" : "onDarkSurfaceAccentGradientActive",
+      "name" : "light.surface.on-dark.accent-gradient-active",
+      "reference" : "SurfaceOnDarkAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на темном фоне",
+      "displayName" : "onDarkSurfaceAccentGradientHover",
+      "name" : "dark.surface.on-dark.accent-gradient-hover",
+      "reference" : "SurfaceOnDarkAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на темном фоне",
+      "displayName" : "onDarkSurfaceAccentGradientHover",
+      "name" : "light.surface.on-dark.accent-gradient-hover",
+      "reference" : "SurfaceOnDarkAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonDeepGradient",
+      "name" : "dark.surface.on-dark.skeleton-deep-gradient",
+      "reference" : "SurfaceOnDarkSkeletonDeepGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonDeepGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x5CFFFFFF",
+            "0x52FFFFFF",
+            "0x33FFFFFF",
+            "0x0AFFFFFF",
+            "0x33FFFFFF",
+            "0x52FFFFFF",
+            "0x5CFFFFFF",
+            "0x14FFFFFF",
+            "0x33FFFFFF",
+            "0x0AFFFFFF",
+            "0x33FFFFFF",
+            "0x52FFFFFF",
+            "0x5CFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonDeepGradient",
+      "name" : "light.surface.on-dark.skeleton-deep-gradient",
+      "reference" : "SurfaceOnDarkSkeletonDeepGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonDeepGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x5CFFFFFF",
+            "0x52FFFFFF",
+            "0x33FFFFFF",
+            "0x0AFFFFFF",
+            "0x33FFFFFF",
+            "0x52FFFFFF",
+            "0x5CFFFFFF",
+            "0x14FFFFFF",
+            "0x33FFFFFF",
+            "0x0AFFFFFF",
+            "0x33FFFFFF",
+            "0x52FFFFFF",
+            "0x5CFFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonDeepGradientActive",
+      "name" : "dark.surface.on-dark.skeleton-deep-gradient-active",
+      "reference" : "SurfaceOnDarkSkeletonDeepGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonDeepGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonDeepGradientActive",
+      "name" : "light.surface.on-dark.skeleton-deep-gradient-active",
+      "reference" : "SurfaceOnDarkSkeletonDeepGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonDeepGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonDeepGradientHover",
+      "name" : "dark.surface.on-dark.skeleton-deep-gradient-hover",
+      "reference" : "SurfaceOnDarkSkeletonDeepGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonDeepGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonDeepGradientHover",
+      "name" : "light.surface.on-dark.skeleton-deep-gradient-hover",
+      "reference" : "SurfaceOnDarkSkeletonDeepGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonDeepGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonGradient",
+      "name" : "dark.surface.on-dark.skeleton-gradient",
+      "reference" : "SurfaceOnDarkSkeletonGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x17FFFFFF",
+            "0x14FFFFFF",
+            "0x0DFFFFFF",
+            "0x03FFFFFF",
+            "0x0DFFFFFF",
+            "0x14FFFFFF",
+            "0x17FFFFFF",
+            "0x14FFFFFF",
+            "0x0DFFFFFF",
+            "0x03FFFFFF",
+            "0x0DFFFFFF",
+            "0x14FFFFFF",
+            "0x17FFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonGradient",
+      "name" : "light.surface.on-dark.skeleton-gradient",
+      "reference" : "SurfaceOnDarkSkeletonGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x17FFFFFF",
+            "0x14FFFFFF",
+            "0x0DFFFFFF",
+            "0x03FFFFFF",
+            "0x0DFFFFFF",
+            "0x14FFFFFF",
+            "0x17FFFFFF",
+            "0x14FFFFFF",
+            "0x0DFFFFFF",
+            "0x03FFFFFF",
+            "0x0DFFFFFF",
+            "0x14FFFFFF",
+            "0x17FFFFFF"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonGradientActive",
+      "name" : "dark.surface.on-dark.skeleton-gradient-active",
+      "reference" : "SurfaceOnDarkSkeletonGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonGradientActive",
+      "name" : "light.surface.on-dark.skeleton-gradient-active",
+      "reference" : "SurfaceOnDarkSkeletonGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonGradientHover",
+      "name" : "dark.surface.on-dark.skeleton-gradient-hover",
+      "reference" : "SurfaceOnDarkSkeletonGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onDarkSurfaceSkeletonGradientHover",
+      "name" : "light.surface.on-dark.skeleton-gradient-hover",
+      "reference" : "SurfaceOnDarkSkeletonGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnDarkSkeletonGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на светлом фоне",
+      "displayName" : "onLightSurfaceAccentGradient",
+      "name" : "dark.surface.on-light.accent-gradient",
+      "reference" : "SurfaceOnLightAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на светлом фоне",
+      "displayName" : "onLightSurfaceAccentGradient",
+      "name" : "light.surface.on-light.accent-gradient",
+      "reference" : "SurfaceOnLightAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на светлом фоне",
+      "displayName" : "onLightSurfaceAccentGradientActive",
+      "name" : "dark.surface.on-light.accent-gradient-active",
+      "reference" : "SurfaceOnLightAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на светлом фоне",
+      "displayName" : "onLightSurfaceAccentGradientActive",
+      "name" : "light.surface.on-light.accent-gradient-active",
+      "reference" : "SurfaceOnLightAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "typography l header-h1",
+      "displayName" : "HeaderH1 N",
+      "name" : "screen-l.header.h1.normal",
+      "reference" : "HeaderH1Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH1Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 52,
+        "size" : 48,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на светлом фоне",
+      "displayName" : "onLightSurfaceAccentGradientHover",
+      "name" : "dark.surface.on-light.accent-gradient-hover",
+      "reference" : "SurfaceOnLightAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный фон поверхности/контрола с градиентом на светлом фоне",
+      "displayName" : "onLightSurfaceAccentGradientHover",
+      "name" : "light.surface.on-light.accent-gradient-hover",
+      "reference" : "SurfaceOnLightAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonDeepGradient",
+      "name" : "dark.surface.on-light.skeleton-deep-gradient",
+      "reference" : "SurfaceOnLightSkeletonDeepGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonDeepGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x5C080808",
+            "0x52080808",
+            "0x33080808",
+            "0x0A080808",
+            "0x33080808",
+            "0x52080808",
+            "0x5C080808",
+            "0x14080808",
+            "0x33080808",
+            "0x0A080808",
+            "0x33080808",
+            "0x52080808",
+            "0x5C080808"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonDeepGradient",
+      "name" : "light.surface.on-light.skeleton-deep-gradient",
+      "reference" : "SurfaceOnLightSkeletonDeepGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonDeepGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x5C080808",
+            "0x52080808",
+            "0x33080808",
+            "0x0A080808",
+            "0x33080808",
+            "0x52080808",
+            "0x5C080808",
+            "0x14080808",
+            "0x33080808",
+            "0x0A080808",
+            "0x33080808",
+            "0x52080808",
+            "0x5C080808"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonDeepGradientActive",
+      "name" : "dark.surface.on-light.skeleton-deep-gradient-active",
+      "reference" : "SurfaceOnLightSkeletonDeepGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonDeepGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonDeepGradientActive",
+      "name" : "light.surface.on-light.skeleton-deep-gradient-active",
+      "reference" : "SurfaceOnLightSkeletonDeepGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonDeepGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonDeepGradientHover",
+      "name" : "dark.surface.on-light.skeleton-deep-gradient-hover",
+      "reference" : "SurfaceOnLightSkeletonDeepGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonDeepGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Яркий фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonDeepGradientHover",
+      "name" : "light.surface.on-light.skeleton-deep-gradient-hover",
+      "reference" : "SurfaceOnLightSkeletonDeepGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonDeepGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonGradient",
+      "name" : "dark.surface.on-light.skeleton-gradient",
+      "reference" : "SurfaceOnLightSkeletonGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x17080808",
+            "0x14080808",
+            "0x0D080808",
+            "0x03080808",
+            "0x0D080808",
+            "0x14080808",
+            "0x17080808",
+            "0x14080808",
+            "0x0D080808",
+            "0x03080808",
+            "0x0D080808",
+            "0x14080808",
+            "0x17080808"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonGradient",
+      "name" : "light.surface.on-light.skeleton-gradient",
+      "reference" : "SurfaceOnLightSkeletonGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0x17080808",
+            "0x14080808",
+            "0x0D080808",
+            "0x03080808",
+            "0x0D080808",
+            "0x14080808",
+            "0x17080808",
+            "0x14080808",
+            "0x0D080808",
+            "0x03080808",
+            "0x0D080808",
+            "0x14080808",
+            "0x17080808"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            0.0625,
+            0.125,
+            0.25,
+            0.375,
+            0.4375,
+            0.5,
+            0.5625,
+            0.625,
+            0.75,
+            0.875,
+            0.9375,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonGradientActive",
+      "name" : "dark.surface.on-light.skeleton-gradient-active",
+      "reference" : "SurfaceOnLightSkeletonGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonGradientActive",
+      "name" : "light.surface.on-light.skeleton-gradient-active",
+      "reference" : "SurfaceOnLightSkeletonGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonGradientHover",
+      "name" : "dark.surface.on-light.skeleton-gradient-hover",
+      "reference" : "SurfaceOnLightSkeletonGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Фон для скелетона",
+      "displayName" : "onLightSurfaceSkeletonGradientHover",
+      "name" : "light.surface.on-light.skeleton-gradient-hover",
+      "reference" : "SurfaceOnLightSkeletonGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.surfaceOnLightSkeletonGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом",
+      "displayName" : "textAccentGradient",
+      "name" : "dark.text.default.accent-gradient",
+      "reference" : "TextDefaultAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textDefaultAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом",
+      "displayName" : "textAccentGradient",
+      "name" : "light.text.default.accent-gradient",
+      "reference" : "TextDefaultAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textDefaultAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF0D8523",
+            "0xFF0DA8AB"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом",
+      "displayName" : "textAccentGradientActive",
+      "name" : "dark.text.default.accent-gradient-active",
+      "reference" : "TextDefaultAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textDefaultAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом",
+      "displayName" : "textAccentGradientActive",
+      "name" : "light.text.default.accent-gradient-active",
+      "reference" : "TextDefaultAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textDefaultAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом",
+      "displayName" : "textAccentGradientHover",
+      "name" : "dark.text.default.accent-gradient-hover",
+      "reference" : "TextDefaultAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textDefaultAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом",
+      "displayName" : "textAccentGradientHover",
+      "name" : "light.text.default.accent-gradient-hover",
+      "reference" : "TextDefaultAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textDefaultAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "typography l header-h2-bold",
+      "displayName" : "HeaderH2 B",
+      "name" : "screen-l.header.h2.bold",
+      "reference" : "HeaderH2Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 36,
+        "size" : 32,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "Инвертированный акцентный цвет с градиентом",
+      "displayName" : "inverseTextAccentGradient",
+      "name" : "dark.text.inverse.accent-gradient",
+      "reference" : "TextInverseAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textInverseAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF0D8523",
+            "0xFF0DA8AB"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет с градиентом",
+      "displayName" : "inverseTextAccentGradient",
+      "name" : "light.text.inverse.accent-gradient",
+      "reference" : "TextInverseAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textInverseAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет с градиентом",
+      "displayName" : "inverseTextAccentGradientActive",
+      "name" : "dark.text.inverse.accent-gradient-active",
+      "reference" : "TextInverseAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textInverseAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет с градиентом",
+      "displayName" : "inverseTextAccentGradientActive",
+      "name" : "light.text.inverse.accent-gradient-active",
+      "reference" : "TextInverseAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textInverseAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет с градиентом",
+      "displayName" : "inverseTextAccentGradientHover",
+      "name" : "dark.text.inverse.accent-gradient-hover",
+      "reference" : "TextInverseAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textInverseAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Инвертированный акцентный цвет с градиентом",
+      "displayName" : "inverseTextAccentGradientHover",
+      "name" : "light.text.inverse.accent-gradient-hover",
+      "reference" : "TextInverseAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textInverseAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на темном фоне",
+      "displayName" : "onDarkTextAccentGradient",
+      "name" : "dark.text.on-dark.accent-gradient",
+      "reference" : "TextOnDarkAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnDarkAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на темном фоне",
+      "displayName" : "onDarkTextAccentGradient",
+      "name" : "light.text.on-dark.accent-gradient",
+      "reference" : "TextOnDarkAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnDarkAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF1A9E32",
+            "0xFF04C6C9"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на темном фоне",
+      "displayName" : "onDarkTextAccentGradientActive",
+      "name" : "dark.text.on-dark.accent-gradient-active",
+      "reference" : "TextOnDarkAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnDarkAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на темном фоне",
+      "displayName" : "onDarkTextAccentGradientActive",
+      "name" : "light.text.on-dark.accent-gradient-active",
+      "reference" : "TextOnDarkAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnDarkAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на темном фоне",
+      "displayName" : "onDarkTextAccentGradientHover",
+      "name" : "dark.text.on-dark.accent-gradient-hover",
+      "reference" : "TextOnDarkAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnDarkAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на темном фоне",
+      "displayName" : "onDarkTextAccentGradientHover",
+      "name" : "light.text.on-dark.accent-gradient-hover",
+      "reference" : "TextOnDarkAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnDarkAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на светлом фоне",
+      "displayName" : "onLightTextAccentGradient",
+      "name" : "dark.text.on-light.accent-gradient",
+      "reference" : "TextOnLightAccentGradient",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnLightAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF0D8523",
+            "0xFF0DA8AB"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на светлом фоне",
+      "displayName" : "onLightTextAccentGradient",
+      "name" : "light.text.on-light.accent-gradient",
+      "reference" : "TextOnLightAccentGradient",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnLightAccentGradient",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 45,
+          "colors" : [
+            "0xFF0D8523",
+            "0xFF0DA8AB"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на светлом фоне",
+      "displayName" : "onLightTextAccentGradientActive",
+      "name" : "dark.text.on-light.accent-gradient-active",
+      "reference" : "TextOnLightAccentGradientActive",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnLightAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на светлом фоне",
+      "displayName" : "onLightTextAccentGradientActive",
+      "name" : "light.text.on-light.accent-gradient-active",
+      "reference" : "TextOnLightAccentGradientActive",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnLightAccentGradientActive",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на светлом фоне",
+      "displayName" : "onLightTextAccentGradientHover",
+      "name" : "dark.text.on-light.accent-gradient-hover",
+      "reference" : "TextOnLightAccentGradientHover",
+      "tenant" : "",
+      "theme" : "dark",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnLightAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "Акцентный цвет с градиентом на светлом фоне",
+      "displayName" : "onLightTextAccentGradientHover",
+      "name" : "light.text.on-light.accent-gradient-hover",
+      "reference" : "TextOnLightAccentGradientHover",
+      "tenant" : "",
+      "theme" : "light",
+      "themeReference" : "PlasmaHomeDSTheme.GradientToken.textOnLightAccentGradientHover",
+      "type" : "gradient",
+      "value" : [
+        {
+          "angle" : 90,
+          "colors" : [
+            "0xFFFFFFFF",
+            "0xFF000000"
+          ],
+          "kind" : "linear",
+          "locations" : [
+            0,
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "description" : "shadow down hard l",
+      "displayName" : "downHardL",
+      "name" : "down.hard.l",
+      "reference" : "DownHardL",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.downHardL",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 112,
+          "color" : "0x66000000",
+          "offsetX" : 0,
+          "offsetY" : 60,
+          "spreadRadius" : -8
+        }
+      ]
+    },
+    {
+      "description" : "shadow down hard m",
+      "displayName" : "downHardM",
+      "name" : "down.hard.m",
+      "reference" : "DownHardM",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.downHardM",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 32,
+          "color" : "0x3D000000",
+          "offsetX" : 0,
+          "offsetY" : 16,
+          "spreadRadius" : -8
+        }
+      ]
+    },
+    {
+      "description" : "shadow down hard s",
+      "displayName" : "downHardS",
+      "name" : "down.hard.s",
+      "reference" : "DownHardS",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.downHardS",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 12,
+          "color" : "0x29080808",
+          "offsetX" : 0,
+          "offsetY" : 4,
+          "spreadRadius" : -3
+        },
+        {
+          "blurRadius" : 4,
+          "color" : "0x14000000",
+          "offsetX" : 0,
+          "offsetY" : 1,
+          "spreadRadius" : -2
+        }
+      ]
+    },
+    {
+      "description" : "shadow down soft l",
+      "displayName" : "downSoftL",
+      "name" : "down.soft.l",
+      "reference" : "DownSoftL",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.downSoftL",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 112,
+          "color" : "0x14000000",
+          "offsetX" : 0,
+          "offsetY" : 60,
+          "spreadRadius" : -8
+        }
+      ]
+    },
+    {
+      "description" : "shadow down soft m",
+      "displayName" : "downSoftM",
+      "name" : "down.soft.m",
+      "reference" : "DownSoftM",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.downSoftM",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 48,
+          "color" : "0x14000000",
+          "offsetX" : 0,
+          "offsetY" : 24,
+          "spreadRadius" : -8
+        }
+      ]
+    },
+    {
+      "description" : "shadow down soft s",
+      "displayName" : "downSoftS",
+      "name" : "down.soft.s",
+      "reference" : "DownSoftS",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.downSoftS",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 14,
+          "color" : "0x14080808",
+          "offsetX" : 0,
+          "offsetY" : 4,
+          "spreadRadius" : -4
+        },
+        {
+          "blurRadius" : 4,
+          "color" : "0x0A000000",
+          "offsetX" : 0,
+          "offsetY" : 1,
+          "spreadRadius" : -1
+        }
+      ]
+    },
+    {
+      "description" : "shadow up hard l",
+      "displayName" : "upHardL",
+      "name" : "up.hard.l",
+      "reference" : "UpHardL",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.upHardL",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 112,
+          "color" : "0x66000000",
+          "offsetX" : 0,
+          "offsetY" : -60,
+          "spreadRadius" : -8
+        }
+      ]
+    },
+    {
+      "description" : "shadow up hard m",
+      "displayName" : "upHardM",
+      "name" : "up.hard.m",
+      "reference" : "UpHardM",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.upHardM",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 32,
+          "color" : "0x3D000000",
+          "offsetX" : 0,
+          "offsetY" : -16,
+          "spreadRadius" : -8
+        }
+      ]
+    },
+    {
+      "description" : "shadow up hard s",
+      "displayName" : "upHardS",
+      "name" : "up.hard.s",
+      "reference" : "UpHardS",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.upHardS",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 12,
+          "color" : "0x33080808",
+          "offsetX" : 0,
+          "offsetY" : -4,
+          "spreadRadius" : -3
+        },
+        {
+          "blurRadius" : 4,
+          "color" : "0x08000000",
+          "offsetX" : 0,
+          "offsetY" : -1,
+          "spreadRadius" : -1
+        }
+      ]
+    },
+    {
+      "description" : "shadow up soft l",
+      "displayName" : "upSoftL",
+      "name" : "up.soft.l",
+      "reference" : "UpSoftL",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.upSoftL",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 112,
+          "color" : "0x14000000",
+          "offsetX" : 0,
+          "offsetY" : -60,
+          "spreadRadius" : -8
+        }
+      ]
+    },
+    {
+      "description" : "shadow up soft m",
+      "displayName" : "upSoftM",
+      "name" : "up.soft.m",
+      "reference" : "UpSoftM",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.upSoftM",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 48,
+          "color" : "0x14000000",
+          "offsetX" : 0,
+          "offsetY" : -24,
+          "spreadRadius" : -8
+        }
+      ]
+    },
+    {
+      "description" : "shadow up soft s",
+      "displayName" : "upSoftS",
+      "name" : "up.soft.s",
+      "reference" : "UpSoftS",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShadowToken.upSoftS",
+      "type" : "shadow",
+      "value" : [
+        {
+          "blurRadius" : 14,
+          "color" : "0x14080808",
+          "offsetX" : 0,
+          "offsetY" : -4,
+          "spreadRadius" : -4
+        },
+        {
+          "blurRadius" : 4,
+          "color" : "0x08000000",
+          "offsetX" : 0,
+          "offsetY" : -1,
+          "spreadRadius" : -1
+        }
+      ]
+    },
+    {
+      "description" : "borderRadius l",
+      "displayName" : "roundL",
+      "name" : "round.l",
+      "reference" : "RoundL",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShapeToken.roundL",
+      "type" : "shape",
+      "value" : {
+        "cornerRadius" : 16,
+        "kind" : "round"
+      }
+    },
+    {
+      "description" : "borderRadius m",
+      "displayName" : "roundM",
+      "name" : "round.m",
+      "reference" : "RoundM",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShapeToken.roundM",
+      "type" : "shape",
+      "value" : {
+        "cornerRadius" : 12,
+        "kind" : "round"
+      }
+    },
+    {
+      "description" : "borderRadius s",
+      "displayName" : "roundS",
+      "name" : "round.s",
+      "reference" : "RoundS",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShapeToken.roundS",
+      "type" : "shape",
+      "value" : {
+        "cornerRadius" : 8,
+        "kind" : "round"
+      }
+    },
+    {
+      "description" : "borderRadius xl",
+      "displayName" : "roundXl",
+      "name" : "round.xl",
+      "reference" : "RoundXl",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShapeToken.roundXl",
+      "type" : "shape",
+      "value" : {
+        "cornerRadius" : 20,
+        "kind" : "round"
+      }
+    },
+    {
+      "description" : "borderRadius xs",
+      "displayName" : "roundXs",
+      "name" : "round.xs",
+      "reference" : "RoundXs",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShapeToken.roundXs",
+      "type" : "shape",
+      "value" : {
+        "cornerRadius" : 6,
+        "kind" : "round"
+      }
+    },
+    {
+      "description" : "borderRadius xxl",
+      "displayName" : "roundXxl",
+      "name" : "round.xxl",
+      "reference" : "RoundXxl",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShapeToken.roundXxl",
+      "type" : "shape",
+      "value" : {
+        "cornerRadius" : 32,
+        "kind" : "round"
+      }
+    },
+    {
+      "description" : "borderRadius xxs",
+      "displayName" : "roundXxs",
+      "name" : "round.xxs",
+      "reference" : "RoundXxs",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.ShapeToken.roundXxs",
+      "type" : "shape",
+      "value" : {
+        "cornerRadius" : 4,
+        "kind" : "round"
+      }
+    },
+    {
+      "description" : "spacing 0x",
+      "displayName" : "spacing0x",
+      "name" : "spacing.0x",
+      "reference" : "Spacing0x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing0x",
+      "type" : "spacing",
+      "value" : 0
+    },
+    {
+      "description" : "spacing 10x",
+      "displayName" : "spacing10x",
+      "name" : "spacing.10x",
+      "reference" : "Spacing10x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing10x",
+      "type" : "spacing",
+      "value" : 20
+    },
+    {
+      "description" : "spacing 12x",
+      "displayName" : "spacing12x",
+      "name" : "spacing.12x",
+      "reference" : "Spacing12x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing12x",
+      "type" : "spacing",
+      "value" : 24
+    },
+    {
+      "description" : "spacing 16x",
+      "displayName" : "spacing16x",
+      "name" : "spacing.16x",
+      "reference" : "Spacing16x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing16x",
+      "type" : "spacing",
+      "value" : 32
+    },
+    {
+      "description" : "spacing 1x",
+      "displayName" : "spacing1x",
+      "name" : "spacing.1x",
+      "reference" : "Spacing1x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing1x",
+      "type" : "spacing",
+      "value" : 2
+    },
+    {
+      "description" : "spacing 20x",
+      "displayName" : "spacing20x",
+      "name" : "spacing.20x",
+      "reference" : "Spacing20x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing20x",
+      "type" : "spacing",
+      "value" : 40
+    },
+    {
+      "description" : "spacing 24x",
+      "displayName" : "spacing24x",
+      "name" : "spacing.24x",
+      "reference" : "Spacing24x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing24x",
+      "type" : "spacing",
+      "value" : 48
+    },
+    {
+      "description" : "spacing 2x",
+      "displayName" : "spacing2x",
+      "name" : "spacing.2x",
+      "reference" : "Spacing2x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing2x",
+      "type" : "spacing",
+      "value" : 4
+    },
+    {
+      "description" : "spacing 32x",
+      "displayName" : "spacing32x",
+      "name" : "spacing.32x",
+      "reference" : "Spacing32x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing32x",
+      "type" : "spacing",
+      "value" : 64
+    },
+    {
+      "description" : "spacing 3x",
+      "displayName" : "spacing3x",
+      "name" : "spacing.3x",
+      "reference" : "Spacing3x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing3x",
+      "type" : "spacing",
+      "value" : 6
+    },
+    {
+      "description" : "spacing 40x",
+      "displayName" : "spacing40x",
+      "name" : "spacing.40x",
+      "reference" : "Spacing40x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing40x",
+      "type" : "spacing",
+      "value" : 80
+    },
+    {
+      "description" : "spacing 4x",
+      "displayName" : "spacing4x",
+      "name" : "spacing.4x",
+      "reference" : "Spacing4x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing4x",
+      "type" : "spacing",
+      "value" : 8
+    },
+    {
+      "description" : "spacing 60x",
+      "displayName" : "spacing60x",
+      "name" : "spacing.60x",
+      "reference" : "Spacing60x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing60x",
+      "type" : "spacing",
+      "value" : 120
+    },
+    {
+      "description" : "spacing 6x",
+      "displayName" : "spacing6x",
+      "name" : "spacing.6x",
+      "reference" : "Spacing6x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing6x",
+      "type" : "spacing",
+      "value" : 12
+    },
+    {
+      "description" : "spacing 8x",
+      "displayName" : "spacing8x",
+      "name" : "spacing.8x",
+      "reference" : "Spacing8x",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.SpacingToken.spacing8x",
+      "type" : "spacing",
+      "value" : 16
+    },
+    {
+      "description" : "typography l body-l-bold",
+      "displayName" : "BodyL B",
+      "name" : "screen-l.body.l.bold",
+      "reference" : "BodyLBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyLBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 22,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l body-l-medium",
+      "displayName" : "BodyL M",
+      "name" : "screen-l.body.l.medium",
+      "reference" : "BodyLMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyLMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 22,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l body-l",
+      "displayName" : "BodyL N",
+      "name" : "screen-l.body.l.normal",
+      "reference" : "BodyLNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyLNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 22,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l body-m-bold",
+      "displayName" : "BodyM B",
+      "name" : "screen-l.body.m.bold",
+      "reference" : "BodyMBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyMBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 16,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l body-m-medium",
+      "displayName" : "BodyM M",
+      "name" : "screen-l.body.m.medium",
+      "reference" : "BodyMMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyMMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 16,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l body-m",
+      "displayName" : "BodyM N",
+      "name" : "screen-l.body.m.normal",
+      "reference" : "BodyMNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyMNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 16,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l body-s-bold",
+      "displayName" : "BodyS B",
+      "name" : "screen-l.body.s.bold",
+      "reference" : "BodySBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodySBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 18,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l body-s-medium",
+      "displayName" : "BodyS M",
+      "name" : "screen-l.body.s.medium",
+      "reference" : "BodySMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodySMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 18,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l body-s",
+      "displayName" : "BodyS N",
+      "name" : "screen-l.body.s.normal",
+      "reference" : "BodySNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodySNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 18,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l body-xs-bold",
+      "displayName" : "BodyXs B",
+      "name" : "screen-l.body.xs.bold",
+      "reference" : "BodyXsBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXsBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 14,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l body-xs-medium",
+      "displayName" : "BodyXs M",
+      "name" : "screen-l.body.xs.medium",
+      "reference" : "BodyXsMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXsMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 14,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l body-xs",
+      "displayName" : "BodyXs N",
+      "name" : "screen-l.body.xs.normal",
+      "reference" : "BodyXsNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXsNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 14,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l body-xxs-bold",
+      "displayName" : "BodyXxs B",
+      "name" : "screen-l.body.xxs.bold",
+      "reference" : "BodyXxsBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXxsBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 12,
+        "size" : 10,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l body-xxs-medium",
+      "displayName" : "BodyXxs M",
+      "name" : "screen-l.body.xxs.medium",
+      "reference" : "BodyXxsMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXxsMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 12,
+        "size" : 10,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l body-xxs",
+      "displayName" : "BodyXxs N",
+      "name" : "screen-l.body.xxs.normal",
+      "reference" : "BodyXxsNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXxsNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 12,
+        "size" : 10,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l display-l-bold",
+      "displayName" : "DisplayL B",
+      "name" : "screen-l.display.l.bold",
+      "reference" : "DisplayLBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayLBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 128,
+        "size" : 128,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l display-l-medium",
+      "displayName" : "DisplayL M",
+      "name" : "screen-l.display.l.medium",
+      "reference" : "DisplayLMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayLMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 128,
+        "size" : 128,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l display-l",
+      "displayName" : "DisplayL N",
+      "name" : "screen-l.display.l.normal",
+      "reference" : "DisplayLNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayLNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 128,
+        "size" : 128,
+        "style" : "normal",
+        "weight" : "light"
+      }
+    },
+    {
+      "description" : "typography l display-m-bold",
+      "displayName" : "DisplayM B",
+      "name" : "screen-l.display.m.bold",
+      "reference" : "DisplayMBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayMBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 92,
+        "size" : 88,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l display-m-medium",
+      "displayName" : "DisplayM M",
+      "name" : "screen-l.display.m.medium",
+      "reference" : "DisplayMMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayMMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 92,
+        "size" : 88,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l display-m",
+      "displayName" : "DisplayM N",
+      "name" : "screen-l.display.m.normal",
+      "reference" : "DisplayMNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayMNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 92,
+        "size" : 88,
+        "style" : "normal",
+        "weight" : "light"
+      }
+    },
+    {
+      "description" : "typography l text-m",
+      "displayName" : "TextM N",
+      "name" : "screen-l.text.m.normal",
+      "reference" : "TextMNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textMNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 26,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l text-s-bold",
+      "displayName" : "TextS B",
+      "name" : "screen-l.text.s.bold",
+      "reference" : "TextSBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textSBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l text-s-medium",
+      "displayName" : "TextS M",
+      "name" : "screen-l.text.s.medium",
+      "reference" : "TextSMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textSMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l text-s",
+      "displayName" : "TextS N",
+      "name" : "screen-l.text.s.normal",
+      "reference" : "TextSNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textSNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography l text-xs-bold",
+      "displayName" : "TextXs B",
+      "name" : "screen-l.text.xs.bold",
+      "reference" : "TextXsBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textXsBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography l text-xs-medium",
+      "displayName" : "TextXs M",
+      "name" : "screen-l.text.xs.medium",
+      "reference" : "TextXsMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textXsMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography l text-xs",
+      "displayName" : "TextXs N",
+      "name" : "screen-l.text.xs.normal",
+      "reference" : "TextXsNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textXsNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m body-l-bold",
+      "displayName" : "BodyL B",
+      "name" : "screen-m.body.l.bold",
+      "reference" : "BodyLBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyLBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 22,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m body-l-medium",
+      "displayName" : "BodyL M",
+      "name" : "screen-m.body.l.medium",
+      "reference" : "BodyLMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyLMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 22,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m body-l",
+      "displayName" : "BodyL N",
+      "name" : "screen-m.body.l.normal",
+      "reference" : "BodyLNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyLNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 22,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m body-m-bold",
+      "displayName" : "BodyM B",
+      "name" : "screen-m.body.m.bold",
+      "reference" : "BodyMBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyMBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 16,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m body-m-medium",
+      "displayName" : "BodyM M",
+      "name" : "screen-m.body.m.medium",
+      "reference" : "BodyMMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyMMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 16,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m body-m",
+      "displayName" : "BodyM N",
+      "name" : "screen-m.body.m.normal",
+      "reference" : "BodyMNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyMNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 16,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m body-s-bold",
+      "displayName" : "BodyS B",
+      "name" : "screen-m.body.s.bold",
+      "reference" : "BodySBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodySBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 18,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m body-s-medium",
+      "displayName" : "BodyS M",
+      "name" : "screen-m.body.s.medium",
+      "reference" : "BodySMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodySMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 18,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m body-s",
+      "displayName" : "BodyS N",
+      "name" : "screen-m.body.s.normal",
+      "reference" : "BodySNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodySNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 18,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m body-xs-bold",
+      "displayName" : "BodyXs B",
+      "name" : "screen-m.body.xs.bold",
+      "reference" : "BodyXsBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXsBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 14,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m body-xs-medium",
+      "displayName" : "BodyXs M",
+      "name" : "screen-m.body.xs.medium",
+      "reference" : "BodyXsMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXsMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 14,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m body-xs",
+      "displayName" : "BodyXs N",
+      "name" : "screen-m.body.xs.normal",
+      "reference" : "BodyXsNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXsNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 14,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m body-xxs-bold",
+      "displayName" : "BodyXxs B",
+      "name" : "screen-m.body.xxs.bold",
+      "reference" : "BodyXxsBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXxsBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 12,
+        "size" : 10,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m body-xxs-medium",
+      "displayName" : "BodyXxs M",
+      "name" : "screen-m.body.xxs.medium",
+      "reference" : "BodyXxsMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXxsMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 12,
+        "size" : 10,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m body-xxs",
+      "displayName" : "BodyXxs N",
+      "name" : "screen-m.body.xxs.normal",
+      "reference" : "BodyXxsNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXxsNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 12,
+        "size" : 10,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m display-l-bold",
+      "displayName" : "DisplayL B",
+      "name" : "screen-m.display.l.bold",
+      "reference" : "DisplayLBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayLBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 128,
+        "size" : 128,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m display-l-medium",
+      "displayName" : "DisplayL M",
+      "name" : "screen-m.display.l.medium",
+      "reference" : "DisplayLMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayLMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 128,
+        "size" : 128,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m display-l",
+      "displayName" : "DisplayL N",
+      "name" : "screen-m.display.l.normal",
+      "reference" : "DisplayLNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayLNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 128,
+        "size" : 128,
+        "style" : "normal",
+        "weight" : "light"
+      }
+    },
+    {
+      "description" : "typography m display-m-bold",
+      "displayName" : "DisplayM B",
+      "name" : "screen-m.display.m.bold",
+      "reference" : "DisplayMBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayMBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 92,
+        "size" : 88,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m display-m-medium",
+      "displayName" : "DisplayM M",
+      "name" : "screen-m.display.m.medium",
+      "reference" : "DisplayMMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayMMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 92,
+        "size" : 88,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m display-m",
+      "displayName" : "DisplayM N",
+      "name" : "screen-m.display.m.normal",
+      "reference" : "DisplayMNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayMNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 92,
+        "size" : 88,
+        "style" : "normal",
+        "weight" : "light"
+      }
+    },
+    {
+      "description" : "typography m display-s-bold",
+      "displayName" : "DisplayS B",
+      "name" : "screen-m.display.s.bold",
+      "reference" : "DisplaySBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displaySBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 68,
+        "size" : 64,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m display-s-medium",
+      "displayName" : "DisplayS M",
+      "name" : "screen-m.display.s.medium",
+      "reference" : "DisplaySMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displaySMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 68,
+        "size" : 64,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m display-s",
+      "displayName" : "DisplayS N",
+      "name" : "screen-m.display.s.normal",
+      "reference" : "DisplaySNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displaySNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 68,
+        "size" : 64,
+        "style" : "normal",
+        "weight" : "light"
+      }
+    },
+    {
+      "description" : "typography m header-h1-bold",
+      "displayName" : "HeaderH1 B",
+      "name" : "screen-m.header.h1.bold",
+      "reference" : "HeaderH1Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH1Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 52,
+        "size" : 48,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m header-h1-medium",
+      "displayName" : "HeaderH1 M",
+      "name" : "screen-m.header.h1.medium",
+      "reference" : "HeaderH1Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH1Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 52,
+        "size" : 48,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m header-h1",
+      "displayName" : "HeaderH1 N",
+      "name" : "screen-m.header.h1.normal",
+      "reference" : "HeaderH1Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH1Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 52,
+        "size" : 48,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m header-h2-bold",
+      "displayName" : "HeaderH2 B",
+      "name" : "screen-m.header.h2.bold",
+      "reference" : "HeaderH2Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 36,
+        "size" : 32,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m header-h2-medium",
+      "displayName" : "HeaderH2 M",
+      "name" : "screen-m.header.h2.medium",
+      "reference" : "HeaderH2Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 36,
+        "size" : 32,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m header-h2",
+      "displayName" : "HeaderH2 N",
+      "name" : "screen-m.header.h2.normal",
+      "reference" : "HeaderH2Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 36,
+        "size" : 32,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m header-h3-bold",
+      "displayName" : "HeaderH3 B",
+      "name" : "screen-m.header.h3.bold",
+      "reference" : "HeaderH3Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH3Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 30,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m header-h3-medium",
+      "displayName" : "HeaderH3 M",
+      "name" : "screen-m.header.h3.medium",
+      "reference" : "HeaderH3Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH3Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 30,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m header-h3",
+      "displayName" : "HeaderH3 N",
+      "name" : "screen-m.header.h3.normal",
+      "reference" : "HeaderH3Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH3Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 30,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m header-h4-bold",
+      "displayName" : "HeaderH4 B",
+      "name" : "screen-m.header.h4.bold",
+      "reference" : "HeaderH4Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH4Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 26,
+        "size" : 20,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m header-h4-medium",
+      "displayName" : "HeaderH4 M",
+      "name" : "screen-m.header.h4.medium",
+      "reference" : "HeaderH4Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH4Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 26,
+        "size" : 20,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m header-h4",
+      "displayName" : "HeaderH4 N",
+      "name" : "screen-m.header.h4.normal",
+      "reference" : "HeaderH4Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH4Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 26,
+        "size" : 20,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m header-h5-bold",
+      "displayName" : "HeaderH5 B",
+      "name" : "screen-m.header.h5.bold",
+      "reference" : "HeaderH5Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH5Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 24,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m header-h5-medium",
+      "displayName" : "HeaderH5 M",
+      "name" : "screen-m.header.h5.medium",
+      "reference" : "HeaderH5Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH5Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 24,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m header-h5",
+      "displayName" : "HeaderH5 N",
+      "name" : "screen-m.header.h5.normal",
+      "reference" : "HeaderH5Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH5Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 24,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m header-h6-bold",
+      "displayName" : "HeaderH6 B",
+      "name" : "screen-m.header.h6.bold",
+      "reference" : "HeaderH6Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH6Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m header-h6-medium",
+      "displayName" : "HeaderH6 M",
+      "name" : "screen-m.header.h6.medium",
+      "reference" : "HeaderH6Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH6Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m header-h6",
+      "displayName" : "HeaderH6 N",
+      "name" : "screen-m.header.h6.normal",
+      "reference" : "HeaderH6Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH6Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m text-l-bold",
+      "displayName" : "TextL B",
+      "name" : "screen-m.text.l.bold",
+      "reference" : "TextLBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textLBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 32,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m text-l-medium",
+      "displayName" : "TextL M",
+      "name" : "screen-m.text.l.medium",
+      "reference" : "TextLMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textLMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 32,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m text-l",
+      "displayName" : "TextL N",
+      "name" : "screen-m.text.l.normal",
+      "reference" : "TextLNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textLNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 32,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m text-m-bold",
+      "displayName" : "TextM B",
+      "name" : "screen-m.text.m.bold",
+      "reference" : "TextMBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textMBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 26,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m text-m-medium",
+      "displayName" : "TextM M",
+      "name" : "screen-m.text.m.medium",
+      "reference" : "TextMMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textMMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 26,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m text-m",
+      "displayName" : "TextM N",
+      "name" : "screen-m.text.m.normal",
+      "reference" : "TextMNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textMNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 26,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m text-s-bold",
+      "displayName" : "TextS B",
+      "name" : "screen-m.text.s.bold",
+      "reference" : "TextSBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textSBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m text-s-medium",
+      "displayName" : "TextS M",
+      "name" : "screen-m.text.s.medium",
+      "reference" : "TextSMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textSMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m text-s",
+      "displayName" : "TextS N",
+      "name" : "screen-m.text.s.normal",
+      "reference" : "TextSNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textSNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography m text-xs-bold",
+      "displayName" : "TextXs B",
+      "name" : "screen-m.text.xs.bold",
+      "reference" : "TextXsBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textXsBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography m text-xs-medium",
+      "displayName" : "TextXs M",
+      "name" : "screen-m.text.xs.medium",
+      "reference" : "TextXsMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textXsMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography m text-xs",
+      "displayName" : "TextXs N",
+      "name" : "screen-m.text.xs.normal",
+      "reference" : "TextXsNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textXsNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s body-l-bold",
+      "displayName" : "BodyL B",
+      "name" : "screen-s.body.l.bold",
+      "reference" : "BodyLBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyLBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 22,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s body-l-medium",
+      "displayName" : "BodyL M",
+      "name" : "screen-s.body.l.medium",
+      "reference" : "BodyLMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyLMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 22,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s body-l",
+      "displayName" : "BodyL N",
+      "name" : "screen-s.body.l.normal",
+      "reference" : "BodyLNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyLNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 22,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s body-m-bold",
+      "displayName" : "BodyM B",
+      "name" : "screen-s.body.m.bold",
+      "reference" : "BodyMBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyMBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 16,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s body-m-medium",
+      "displayName" : "BodyM M",
+      "name" : "screen-s.body.m.medium",
+      "reference" : "BodyMMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyMMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 16,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s body-m",
+      "displayName" : "BodyM N",
+      "name" : "screen-s.body.m.normal",
+      "reference" : "BodyMNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyMNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 16,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s body-s-bold",
+      "displayName" : "BodyS B",
+      "name" : "screen-s.body.s.bold",
+      "reference" : "BodySBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodySBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 18,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s body-s-medium",
+      "displayName" : "BodyS M",
+      "name" : "screen-s.body.s.medium",
+      "reference" : "BodySMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodySMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 18,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s body-s",
+      "displayName" : "BodyS N",
+      "name" : "screen-s.body.s.normal",
+      "reference" : "BodySNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodySNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 18,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s body-xs-bold",
+      "displayName" : "BodyXs B",
+      "name" : "screen-s.body.xs.bold",
+      "reference" : "BodyXsBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXsBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 14,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s body-xs-medium",
+      "displayName" : "BodyXs M",
+      "name" : "screen-s.body.xs.medium",
+      "reference" : "BodyXsMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXsMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 14,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s body-xs",
+      "displayName" : "BodyXs N",
+      "name" : "screen-s.body.xs.normal",
+      "reference" : "BodyXsNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXsNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 14,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s body-xxs-bold",
+      "displayName" : "BodyXxs B",
+      "name" : "screen-s.body.xxs.bold",
+      "reference" : "BodyXxsBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXxsBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 12,
+        "size" : 10,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s body-xxs-medium",
+      "displayName" : "BodyXxs M",
+      "name" : "screen-s.body.xxs.medium",
+      "reference" : "BodyXxsMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXxsMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 12,
+        "size" : 10,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s body-xxs",
+      "displayName" : "BodyXxs N",
+      "name" : "screen-s.body.xxs.normal",
+      "reference" : "BodyXxsNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.bodyXxsNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.body",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 12,
+        "size" : 10,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s display-l-bold",
+      "displayName" : "DisplayL B",
+      "name" : "screen-s.display.l.bold",
+      "reference" : "DisplayLBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayLBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 128,
+        "size" : 128,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s display-l-medium",
+      "displayName" : "DisplayL M",
+      "name" : "screen-s.display.l.medium",
+      "reference" : "DisplayLMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayLMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 128,
+        "size" : 128,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s display-l",
+      "displayName" : "DisplayL N",
+      "name" : "screen-s.display.l.normal",
+      "reference" : "DisplayLNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayLNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 128,
+        "size" : 128,
+        "style" : "normal",
+        "weight" : "light"
+      }
+    },
+    {
+      "description" : "typography s display-m-bold",
+      "displayName" : "DisplayM B",
+      "name" : "screen-s.display.m.bold",
+      "reference" : "DisplayMBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayMBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 92,
+        "size" : 88,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s display-m-medium",
+      "displayName" : "DisplayM M",
+      "name" : "screen-s.display.m.medium",
+      "reference" : "DisplayMMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayMMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 92,
+        "size" : 88,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s display-m",
+      "displayName" : "DisplayM N",
+      "name" : "screen-s.display.m.normal",
+      "reference" : "DisplayMNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displayMNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 92,
+        "size" : 88,
+        "style" : "normal",
+        "weight" : "light"
+      }
+    },
+    {
+      "description" : "typography s display-s-bold",
+      "displayName" : "DisplayS B",
+      "name" : "screen-s.display.s.bold",
+      "reference" : "DisplaySBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displaySBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 68,
+        "size" : 64,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s display-s-medium",
+      "displayName" : "DisplayS M",
+      "name" : "screen-s.display.s.medium",
+      "reference" : "DisplaySMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displaySMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 68,
+        "size" : 64,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s display-s",
+      "displayName" : "DisplayS N",
+      "name" : "screen-s.display.s.normal",
+      "reference" : "DisplaySNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.displaySNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.display",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 68,
+        "size" : 64,
+        "style" : "normal",
+        "weight" : "light"
+      }
+    },
+    {
+      "description" : "typography s header-h1-bold",
+      "displayName" : "HeaderH1 B",
+      "name" : "screen-s.header.h1.bold",
+      "reference" : "HeaderH1Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH1Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 52,
+        "size" : 48,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s header-h1-medium",
+      "displayName" : "HeaderH1 M",
+      "name" : "screen-s.header.h1.medium",
+      "reference" : "HeaderH1Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH1Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 52,
+        "size" : 48,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s header-h1",
+      "displayName" : "HeaderH1 N",
+      "name" : "screen-s.header.h1.normal",
+      "reference" : "HeaderH1Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH1Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 52,
+        "size" : 48,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s header-h2-bold",
+      "displayName" : "HeaderH2 B",
+      "name" : "screen-s.header.h2.bold",
+      "reference" : "HeaderH2Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 36,
+        "size" : 32,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s header-h2-medium",
+      "displayName" : "HeaderH2 M",
+      "name" : "screen-s.header.h2.medium",
+      "reference" : "HeaderH2Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 36,
+        "size" : 32,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s header-h2",
+      "displayName" : "HeaderH2 N",
+      "name" : "screen-s.header.h2.normal",
+      "reference" : "HeaderH2Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 36,
+        "size" : 32,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s header-h3-bold",
+      "displayName" : "HeaderH3 B",
+      "name" : "screen-s.header.h3.bold",
+      "reference" : "HeaderH3Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH3Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 30,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s header-h3-medium",
+      "displayName" : "HeaderH3 M",
+      "name" : "screen-s.header.h3.medium",
+      "reference" : "HeaderH3Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH3Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 30,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s header-h3",
+      "displayName" : "HeaderH3 N",
+      "name" : "screen-s.header.h3.normal",
+      "reference" : "HeaderH3Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH3Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 30,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s header-h4-bold",
+      "displayName" : "HeaderH4 B",
+      "name" : "screen-s.header.h4.bold",
+      "reference" : "HeaderH4Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH4Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 26,
+        "size" : 20,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s header-h4-medium",
+      "displayName" : "HeaderH4 M",
+      "name" : "screen-s.header.h4.medium",
+      "reference" : "HeaderH4Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH4Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 26,
+        "size" : 20,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s header-h4",
+      "displayName" : "HeaderH4 N",
+      "name" : "screen-s.header.h4.normal",
+      "reference" : "HeaderH4Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH4Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 26,
+        "size" : 20,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s header-h5-bold",
+      "displayName" : "HeaderH5 B",
+      "name" : "screen-s.header.h5.bold",
+      "reference" : "HeaderH5Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH5Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 24,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s header-h5-medium",
+      "displayName" : "HeaderH5 M",
+      "name" : "screen-s.header.h5.medium",
+      "reference" : "HeaderH5Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH5Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 24,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s header-h5",
+      "displayName" : "HeaderH5 N",
+      "name" : "screen-s.header.h5.normal",
+      "reference" : "HeaderH5Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH5Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 24,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s header-h6-bold",
+      "displayName" : "HeaderH6 B",
+      "name" : "screen-s.header.h6.bold",
+      "reference" : "HeaderH6Bold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH6Bold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s header-h6-medium",
+      "displayName" : "HeaderH6 M",
+      "name" : "screen-s.header.h6.medium",
+      "reference" : "HeaderH6Medium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH6Medium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s header-h6",
+      "displayName" : "HeaderH6 N",
+      "name" : "screen-s.header.h6.normal",
+      "reference" : "HeaderH6Normal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH6Normal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.header",
+        "fontName" : "SF Pro",
+        "kerning" : 0,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s text-l-bold",
+      "displayName" : "TextL B",
+      "name" : "screen-s.text.l.bold",
+      "reference" : "TextLBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textLBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 32,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s text-l-medium",
+      "displayName" : "TextL M",
+      "name" : "screen-s.text.l.medium",
+      "reference" : "TextLMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textLMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 32,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s text-l",
+      "displayName" : "TextL N",
+      "name" : "screen-s.text.l.normal",
+      "reference" : "TextLNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textLNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 32,
+        "size" : 24,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s text-m-bold",
+      "displayName" : "TextM B",
+      "name" : "screen-s.text.m.bold",
+      "reference" : "TextMBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textMBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 26,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s text-m-medium",
+      "displayName" : "TextM M",
+      "name" : "screen-s.text.m.medium",
+      "reference" : "TextMMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textMMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 26,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s text-m",
+      "displayName" : "TextM N",
+      "name" : "screen-s.text.m.normal",
+      "reference" : "TextMNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textMNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 26,
+        "size" : 18,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s text-s-bold",
+      "displayName" : "TextS B",
+      "name" : "screen-s.text.s.bold",
+      "reference" : "TextSBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textSBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s text-s-medium",
+      "displayName" : "TextS M",
+      "name" : "screen-s.text.s.medium",
+      "reference" : "TextSMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textSMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s text-s",
+      "displayName" : "TextS N",
+      "name" : "screen-s.text.s.normal",
+      "reference" : "TextSNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textSNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 20,
+        "size" : 14,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    },
+    {
+      "description" : "typography s text-xs-bold",
+      "displayName" : "TextXs B",
+      "name" : "screen-s.text.xs.bold",
+      "reference" : "TextXsBold",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textXsBold",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "semibold"
+      }
+    },
+    {
+      "description" : "typography s text-xs-medium",
+      "displayName" : "TextXs M",
+      "name" : "screen-s.text.xs.medium",
+      "reference" : "TextXsMedium",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textXsMedium",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "medium"
+      }
+    },
+    {
+      "description" : "typography s text-xs",
+      "displayName" : "TextXs N",
+      "name" : "screen-s.text.xs.normal",
+      "reference" : "TextXsNormal",
+      "tenant" : "",
+      "theme" : "",
+      "themeReference" : "PlasmaHomeDSTheme.AdaptiveTypographyToken.textXsNormal",
+      "type" : "typography",
+      "value" : {
+        "fontFamilyRef" : "fontFamily.text",
+        "fontName" : "SF Pro",
+        "kerning" : -0.02,
+        "lineHeight" : 16,
+        "size" : 12,
+        "style" : "normal",
+        "weight" : "regular"
+      }
+    }
+  ],
+  "version" : "latest"
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.pbxproj
+++ b/SDDSThemeBuilder/SDDSThemeBuilder.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 		81CB0FED2C245052003B1064 /* SchemeValidationLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CB0FE62C245052003B1064 /* SchemeValidationLogger.swift */; };
 		81CB10022C258823003B1064 /* TemplateRendererError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CB10012C258823003B1064 /* TemplateRendererError.swift */; };
 		81CB10042C258EB5003B1064 /* SchemeTokenNameValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CB10032C258EB5003B1064 /* SchemeTokenNameValidatorTests.swift */; };
+		A10000012C258EB5003B1064 /* TokenMetaResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000022C258EB5003B1064 /* TokenMetaResolverTests.swift */; };
 		81CF634D2C6E8E82008F3BB2 /* SDDSThemeUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81CF63472C6E8E82008F3BB2 /* SDDSThemeUtilities.framework */; };
 		81CF634E2C6E8E82008F3BB2 /* SDDSThemeUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 81CF63472C6E8E82008F3BB2 /* SDDSThemeUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		81CF635A2C6E8F18008F3BB2 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CF63562C6E8F18008F3BB2 /* Extensions.swift */; };
@@ -919,6 +920,7 @@
 		81CB0FE62C245052003B1064 /* SchemeValidationLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchemeValidationLogger.swift; sourceTree = "<group>"; };
 		81CB10012C258823003B1064 /* TemplateRendererError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateRendererError.swift; sourceTree = "<group>"; };
 		81CB10032C258EB5003B1064 /* SchemeTokenNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemeTokenNameValidatorTests.swift; sourceTree = "<group>"; };
+		A10000022C258EB5003B1064 /* TokenMetaResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenMetaResolverTests.swift; sourceTree = "<group>"; };
 		81CF63472C6E8E82008F3BB2 /* SDDSThemeUtilities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDDSThemeUtilities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81CF63562C6E8F18008F3BB2 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		81CF63572C6E8F18008F3BB2 /* HexConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HexConverter.swift; sourceTree = "<group>"; };
@@ -1860,6 +1862,7 @@
 				817539942BD12ED400138866 /* DownloadCommandTests.swift */,
 				81E1EDE12BD6F2B700F86AE1 /* TemplateRendererTests.swift */,
 				81CB10032C258EB5003B1064 /* SchemeTokenNameValidatorTests.swift */,
+				A10000022C258EB5003B1064 /* TokenMetaResolverTests.swift */,
 				BE43A9FC5FEC3B62258E9804 /* SddsThemeSourceReaderTests.swift */,
 			);
 			path = SDDSThemeBuilderCoreTests;
@@ -3156,6 +3159,7 @@
 				813340142C0631D0005AD84F /* ColorContextBuilderTests.swift in Sources */,
 				813340122C063151005AD84F /* TypographyContextBuilderTests.swift in Sources */,
 				81CB10042C258EB5003B1064 /* SchemeTokenNameValidatorTests.swift in Sources */,
+				A10000012C258EB5003B1064 /* TokenMetaResolverTests.swift in Sources */,
 				81E1EDDE2BD6D6E400F86AE1 /* GeneralContextBuilderTests.swift in Sources */,
 				DA6705C207C20ABE81B6D54C /* SddsThemeSourceReaderTests.swift in Sources */,
 			);

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/App.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/App.swift
@@ -190,6 +190,59 @@ public final class App {
         commands.append(contentsOf: generateComponentVariations(themeConfig: themeConfig))
 
         runCommands(commands)
+
+        generateTokensMeta(
+            themeConfig: themeConfig,
+            schemeDirectory: schemeDirectory,
+            metaScheme: metaScheme,
+            paletteURL: paletteURL,
+            fontFamiliesContainer: fontFamiliesContainer
+        )
+    }
+
+    private func generateTokensMeta(
+        themeConfig: ThemeBuilderConfiguration.ThemeConfiguration,
+        schemeDirectory: SchemeDirectory,
+        metaScheme: Scheme,
+        paletteURL: URL,
+        fontFamiliesContainer: FontFamiliesContainer
+    ) {
+        let resolver = TokenMetaResolver(
+            namespace: "\(themeConfig.name)Theme",
+            colorJson: resolvedTokenJson(ColorContextBuilder(paletteURL: paletteURL, metaScheme: metaScheme), url: schemeDirectory.url(for: .colors)),
+            gradientJson: resolvedTokenJson(GradientContextBuilder(paletteURL: paletteURL, metaScheme: metaScheme), url: schemeDirectory.url(for: .gradients)),
+            typographyJson: resolvedTokenJson(
+                TypographyContextBuilder(fontFamiliesContainer: fontFamiliesContainer, metaScheme: metaScheme, fontFamilyOverride: themeConfig.fontFamilyOverride),
+                url: schemeDirectory.url(for: .typography)
+            ),
+            shadowJson: resolvedTokenJson(GeneralContextBuilder(kind: .shadow, metaScheme: metaScheme), url: schemeDirectory.url(for: .shadows)),
+            shapeJson: resolvedTokenJson(GeneralContextBuilder(kind: .shape, metaScheme: metaScheme), url: schemeDirectory.url(for: .shapes)),
+            spacingJson: resolvedTokenJson(GeneralContextBuilder(kind: .spacing, metaScheme: metaScheme), url: schemeDirectory.url(for: .spacing))
+        )
+
+        let file = TokensMetaFile(
+            name: metaScheme.name,
+            version: metaScheme.version,
+            tokens: resolver.entries(for: metaScheme.tokens)
+        )
+        writeTokensMeta(file)
+    }
+
+    private func resolvedTokenJson(_ builder: ContexBuilder, url: URL) -> [String: Any] {
+        guard let data = try? Data(contentsOf: url) else { return [:] }
+        return (builder.buildContext(from: data).asDictionary?["json"] as? [String: Any]) ?? [:]
+    }
+
+    private func writeTokensMeta(_ file: TokensMetaFile) {
+        let url = themeBuilderURL
+            .appending(component: ".sdds")
+            .appending(component: "config-info-tokens-ios.json")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(file) else { return }
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? data.write(to: url)
+        Logger.printText("📝 tokens meta written: \(url.path()) (\(file.tokens.count) tokens)")
     }
 
     private func generateTenantTheme(

--- a/SDDSThemeBuilder/SDDSThemeBuilderCore/Model/Scheme/Token.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCore/Model/Scheme/Token.swift
@@ -8,3 +8,204 @@ struct Token: Codable {
     let description: String
     let enabled: Bool
 }
+
+struct TokensMetaFile: Codable {
+    let name: String
+    let version: String
+    let tokens: [TokenMetaEntry]
+}
+
+struct TokenMetaEntry: Codable {
+    let theme: String
+    let type: String
+    let name: String
+    let displayName: String
+    let description: String
+    let tenant: String
+    let reference: String
+    let themeReference: String
+    let value: JSONValue
+}
+
+indirect enum JSONValue: Codable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case array([JSONValue])
+    case object([String: JSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            self = .null
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .number(let value):
+            if value == value.rounded(), abs(value) < 1e15 {
+                try container.encode(Int(value))
+            } else {
+                try container.encode(value)
+            }
+        case .bool(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    static func make(from any: Any) -> JSONValue {
+        if let number = any as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return .bool(number.boolValue)
+            }
+            return .number(number.doubleValue)
+        }
+        switch any {
+        case let value as String:
+            return .string(value)
+        case let value as [Any]:
+            return .array(value.map { JSONValue.make(from: $0) })
+        case let value as [String: Any]:
+            return .object(value.mapValues { JSONValue.make(from: $0) })
+        default:
+            return .null
+        }
+    }
+}
+
+struct TokenMetaResolver {
+    let namespace: String
+    let colorJson: [String: Any]
+    let gradientJson: [String: Any]
+    let typographyJson: [String: Any]
+    let shadowJson: [String: Any]
+    let shapeJson: [String: Any]
+    let spacingJson: [String: Any]
+
+    func entries(for tokens: [Token]) -> [TokenMetaEntry] {
+        tokens.compactMap { entry(for: $0) }
+    }
+
+    func entry(for token: Token) -> TokenMetaEntry? {
+        guard token.enabled else { return nil }
+        switch token.type {
+        case .color:
+            return modeEntry(token, json: colorJson, tokenType: "ColorToken", isGradient: false)
+        case .gradient:
+            return modeEntry(token, json: gradientJson, tokenType: "GradientToken", isGradient: true)
+        case .typography:
+            return typographyEntry(token, json: typographyJson)
+        case .shadow:
+            return plainEntry(token, json: shadowJson, tokenType: "ShadowToken")
+        case .shape:
+            return plainEntry(token, json: shapeJson, tokenType: "ShapeToken")
+        case .spacing:
+            return spacingEntry(token, json: spacingJson)
+        case .fontFamily:
+            return nil
+        }
+    }
+
+    func modeEntry(_ token: Token, json: [String: Any], tokenType: String, isGradient: Bool) -> TokenMetaEntry? {
+        let components = token.name.tokenComponents
+        guard let mode = components.first, mode == Mode.light.rawValue || mode == Mode.dark.rawValue else { return nil }
+        let varName = Array(components.dropFirst()).camelCase
+        guard let modeDict = json[varName] as? [String: Any], let raw = modeDict[mode] else { return nil }
+        let value: JSONValue = isGradient
+            ? jsonValueConvertingColors(raw)
+            : .string(Self.argb(fromRGBAHex: (raw as? String) ?? ""))
+        return makeEntry(token, theme: mode, varName: varName, tokenType: tokenType, value: value)
+    }
+
+    func typographyEntry(_ token: Token, json: [String: Any]) -> TokenMetaEntry? {
+        let components = token.name.keyComponents
+        guard let screenRaw = components.first, let screen = ScreenSize(rawValue: screenRaw) else { return nil }
+        let varName = Array(components.dropFirst()).camelCase
+        guard let screensDict = json[varName] as? [String: Any], let raw = screensDict[screen.tokenValue.rawValue] else { return nil }
+        return makeEntry(token, theme: "", varName: varName, tokenType: "AdaptiveTypographyToken", value: jsonValueConvertingColors(raw))
+    }
+
+    func plainEntry(_ token: Token, json: [String: Any], tokenType: String) -> TokenMetaEntry? {
+        let varName = token.name.camelCase
+        guard let raw = json[varName] else { return nil }
+        return makeEntry(token, theme: "", varName: varName, tokenType: tokenType, value: jsonValueConvertingColors(raw))
+    }
+
+    func spacingEntry(_ token: Token, json: [String: Any]) -> TokenMetaEntry? {
+        let varName = token.name.camelCase
+        guard let raw = json[varName] else { return nil }
+        let value: JSONValue
+        if let dict = raw as? [String: Any], let number = dict["value"] {
+            value = JSONValue.make(from: number)
+        } else {
+            value = JSONValue.make(from: raw)
+        }
+        return makeEntry(token, theme: "", varName: varName, tokenType: "SpacingToken", value: value)
+    }
+
+    private func makeEntry(_ token: Token, theme: String, varName: String, tokenType: String, value: JSONValue) -> TokenMetaEntry {
+        TokenMetaEntry(
+            theme: theme,
+            type: token.type.rawValue,
+            name: token.name,
+            displayName: token.displayName,
+            description: token.description,
+            tenant: "",
+            reference: Self.pascalCase(varName),
+            themeReference: "\(namespace).\(tokenType).\(varName)",
+            value: value
+        )
+    }
+
+    func jsonValueConvertingColors(_ any: Any) -> JSONValue {
+        switch any {
+        case let value as String:
+            return .string(value.hasPrefix("#") ? Self.argb(fromRGBAHex: value) : value)
+        case let value as [Any]:
+            return .array(value.map { jsonValueConvertingColors($0) })
+        case let value as [String: Any]:
+            return .object(value.mapValues { jsonValueConvertingColors($0) })
+        default:
+            return JSONValue.make(from: any)
+        }
+    }
+
+    static func pascalCase(_ value: String) -> String {
+        guard let first = value.first else { return value }
+        return String(first).uppercased() + String(value.dropFirst())
+    }
+
+    static func argb(fromRGBAHex value: String) -> String {
+        var hex = value.hasPrefix("#") ? String(value.dropFirst()) : value
+        if hex.count == 6 { hex += "FF" }
+        guard hex.count == 8 else { return value }
+        let rr = String(hex.prefix(2))
+        let gg = String(hex.dropFirst(2).prefix(2))
+        let bb = String(hex.dropFirst(4).prefix(2))
+        let aa = String(hex.dropFirst(6).prefix(2))
+        return "0x" + (aa + rr + gg + bb).uppercased()
+    }
+}

--- a/SDDSThemeBuilder/SDDSThemeBuilderCoreTests/TokenMetaResolverTests.swift
+++ b/SDDSThemeBuilder/SDDSThemeBuilderCoreTests/TokenMetaResolverTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import SDDSThemeBuilderCore
+
+final class TokenMetaResolverTests: XCTestCase {
+
+    private func resolver(
+        color: [String: Any] = [:],
+        gradient: [String: Any] = [:],
+        typography: [String: Any] = [:],
+        shadow: [String: Any] = [:],
+        shape: [String: Any] = [:],
+        spacing: [String: Any] = [:],
+        namespace: String = "PlasmaHomeDSTheme"
+    ) -> TokenMetaResolver {
+        TokenMetaResolver(
+            namespace: namespace,
+            colorJson: color,
+            gradientJson: gradient,
+            typographyJson: typography,
+            shadowJson: shadow,
+            shapeJson: shape,
+            spacingJson: spacing
+        )
+    }
+
+    private func token(
+        _ type: TokenKind,
+        _ name: String,
+        displayName: String = "display",
+        description: String = "desc",
+        enabled: Bool = true
+    ) -> Token {
+        Token(type: type, name: name, tags: [], displayName: displayName, description: description, enabled: enabled)
+    }
+
+    private func encoded(_ value: JSONValue) throws -> String {
+        String(data: try JSONEncoder().encode([value]), encoding: .utf8)!
+    }
+
+    func test_argb_from6DigitAddsOpaqueAlpha() {
+        XCTAssertEqual(TokenMetaResolver.argb(fromRGBAHex: "#080808"), "0xFF080808")
+        XCTAssertEqual(TokenMetaResolver.argb(fromRGBAHex: "#199AF0"), "0xFF199AF0")
+    }
+
+    func test_argb_from8DigitMovesAlphaFront() {
+        XCTAssertEqual(TokenMetaResolver.argb(fromRGBAHex: "#00000066"), "0x66000000")
+        XCTAssertEqual(TokenMetaResolver.argb(fromRGBAHex: "#F5F5F593"), "0x93F5F5F5")
+    }
+
+    func test_pascalCase() {
+        XCTAssertEqual(TokenMetaResolver.pascalCase("outlineOnDarkInfo"), "OutlineOnDarkInfo")
+        XCTAssertEqual(TokenMetaResolver.pascalCase("spacing0x"), "Spacing0x")
+    }
+
+    func test_jsonValue_zeroAndOneStayNumbers() throws {
+        XCTAssertEqual(try encoded(JSONValue.make(from: 0)), "[0]")
+        XCTAssertEqual(try encoded(JSONValue.make(from: 1)), "[1]")
+        XCTAssertEqual(try encoded(JSONValue.make(from: true)), "[true]")
+        XCTAssertEqual(try encoded(JSONValue.make(from: false)), "[false]")
+    }
+
+    func test_jsonValue_integralNumberEncodesWithoutDecimal() throws {
+        XCTAssertEqual(try encoded(JSONValue.make(from: 20.0)), "[20]")
+    }
+
+    func test_colorEntry() throws {
+        let entry = try XCTUnwrap(
+            resolver(color: ["outlineOnDarkInfo": ["dark": "#199AF0", "light": "#0E8ADD"]])
+                .entry(for: token(.color, "dark.outline.on-dark.info", displayName: "onDarkOutlineInfo"))
+        )
+        XCTAssertEqual(entry.theme, "dark")
+        XCTAssertEqual(entry.type, "color")
+        XCTAssertEqual(entry.name, "dark.outline.on-dark.info")
+        XCTAssertEqual(entry.reference, "OutlineOnDarkInfo")
+        XCTAssertEqual(entry.themeReference, "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfo")
+        XCTAssertEqual(entry.tenant, "")
+        guard case .string(let value) = entry.value else { return XCTFail("expected string value") }
+        XCTAssertEqual(value, "0xFF199AF0")
+    }
+
+    func test_gradientEntry_locationsStayNumbers_colorsToARGB() throws {
+        let json: [String: Any] = ["accentGradient": ["dark": [["kind": "linear", "angle": 45, "colors": ["#120809", "#2E090D"], "locations": [0, 1]]]]]
+        let entry = try XCTUnwrap(resolver(gradient: json).entry(for: token(.gradient, "dark.accent-gradient")))
+        let encodedValue = try encoded(entry.value)
+        XCTAssertTrue(encodedValue.contains("\"locations\":[0,1]"), encodedValue)
+        XCTAssertFalse(encodedValue.contains("false"), "locations 0/1 must not become bool")
+        XCTAssertTrue(encodedValue.contains("0xFF120809"), encodedValue)
+    }
+
+    func test_typographyEntry_usesScreenSubValue() throws {
+        let json: [String: Any] = ["headerH2Medium": ["large": ["size": 32, "weight": "medium"]]]
+        let entry = try XCTUnwrap(resolver(typography: json).entry(for: token(.typography, "screen-l.header.h2.medium")))
+        XCTAssertEqual(entry.theme, "")
+        XCTAssertEqual(entry.reference, "HeaderH2Medium")
+        XCTAssertEqual(entry.themeReference, "PlasmaHomeDSTheme.AdaptiveTypographyToken.headerH2Medium")
+        guard case .object(let object) = entry.value, case .number(let size)? = object["size"] else {
+            return XCTFail("expected object value with size")
+        }
+        XCTAssertEqual(size, 32)
+    }
+
+    func test_spacingEntry_valueIsNumber() throws {
+        let entry = try XCTUnwrap(resolver(spacing: ["spacing0x": ["value": 0]]).entry(for: token(.spacing, "spacing.0x")))
+        XCTAssertEqual(entry.themeReference, "PlasmaHomeDSTheme.SpacingToken.spacing0x")
+        XCTAssertEqual(try encoded(entry.value), "[0]")
+    }
+
+    func test_shapeEntry() throws {
+        let entry = try XCTUnwrap(resolver(shape: ["roundL": ["cornerRadius": 16, "kind": "round"]]).entry(for: token(.shape, "round.l")))
+        XCTAssertEqual(entry.reference, "RoundL")
+        XCTAssertEqual(entry.themeReference, "PlasmaHomeDSTheme.ShapeToken.roundL")
+    }
+
+    func test_fontFamilyExcluded() {
+        XCTAssertNil(resolver().entry(for: token(.fontFamily, "display")))
+    }
+
+    func test_disabledExcluded() {
+        XCTAssertNil(resolver(color: ["x": ["dark": "#000000"]]).entry(for: token(.color, "dark.x", enabled: false)))
+    }
+
+    func test_missingResolvedValueSkipsEntry() {
+        XCTAssertNil(resolver(color: [:]).entry(for: token(.color, "dark.text.primary")))
+    }
+
+    func test_entries_filtersAndMaps() {
+        let tokens = [
+            token(.color, "dark.text.primary"),
+            token(.fontFamily, "display"),
+            token(.color, "dark.x", enabled: false),
+        ]
+        let entries = resolver(color: ["textPrimary": ["dark": "#080808"]]).entries(for: tokens)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.reference, "TextPrimary")
+    }
+}

--- a/SDDSThemeBuilder/TOKEN_META.md
+++ b/SDDSThemeBuilder/TOKEN_META.md
@@ -1,0 +1,116 @@
+# Мета-информация по токенам (`config-info-tokens-ios.json`)
+
+Генератор `SDDSThemeBuilder` при генерации темы отдаёт мета-файл по всем сгенерированным
+токенам дизайн-системы. Файл нужен внешним инструментам (binding/дизайн-тулинг), чтобы
+однозначно сопоставить исходный токен, сгенерированный Swift-символ и его резолвнутое значение.
+
+## Где лежит результат
+
+```
+SDDSThemeBuilder/.sdds/config-info-tokens-ios.json
+```
+
+Файл трекается в git (как `.sdds/config.json`); данные токенов внутри `.sdds/tenants/**` —
+нет. Перезаписывается при каждой генерации темы.
+
+## Как это работает
+
+1. При генерации базовой темы (`App.generateBaseTheme`) после генерации токенов вызывается
+   `App.generateTokensMeta(...)`.
+2. Метаданные токенов (`type`, `name`, `displayName`, `description`, `enabled`) берутся из
+   `meta.json` темы (модель `Scheme.tokens` / `Token`).
+3. Резолвнутые **значения** и **сгенерированные имена** берутся из тех же context-builder'ов,
+   что генерят Swift-токены (`ColorContextBuilder`, `GradientContextBuilder`,
+   `TypographyContextBuilder`, `GeneralContextBuilder`) — они запускаются повторно read-only.
+4. Чистая логика сборки записей вынесена в `TokenMetaResolver`
+   (`SDDSThemeBuilderCore/Model/Scheme/Token.swift`) и покрыта юнит-тестами; `App` отвечает
+   только за запуск билдеров и запись файла.
+
+Источник значений — `ios_<type>.json` из схемы. Полнота зависит от источника темы:
+- **zip / theme-converter** и **наполненный `.sdds` / DS Builder** — значения есть.
+- пустой `.sdds` — часть значений может отсутствовать.
+
+## Формат файла
+
+```jsonc
+{
+  "name": "plasma_homeds_default",   // из meta.json
+  "version": "latest",               // из meta.json
+  "tokens": [
+    {
+      "theme": "dark",               // light/dark для color/gradient; "" для остальных
+      "type": "color",
+      "name": "dark.outline.on-dark.info",           // исходное имя (meta.json)
+      "displayName": "onDarkOutlineInfo",
+      "description": "Цвет обводки информация на темном фоне",
+      "tenant": "",                  // "" — базовая тема
+      "reference": "OutlineOnDarkInfo",              // PascalCase сген. символа
+      "themeReference": "PlasmaHomeDSTheme.ColorToken.outlineOnDarkInfo",
+      "value": "0xFF199AF0"          // резолвнутое значение (полиморфно по типу)
+    }
+  ]
+}
+```
+
+### Поля записи токена
+
+| Поле | Описание |
+| --- | --- |
+| `theme` | Режим `light`/`dark` для color/gradient (по префиксу имени). Для typography/shadow/shape/spacing — `""`. |
+| `type` | `color` / `gradient` / `typography` / `shadow` / `shape` / `spacing`. `fontFamily` в файл **не** попадает. |
+| `name` | Исходное имя токена из `meta.json` (как есть, с префиксом режима/экрана). |
+| `displayName`, `description` | Из `meta.json`. |
+| `tenant` | `""` (базовая тема; тенант-варианты в v1 не выгружаются). |
+| `reference` | PascalCase сгенерированного символа (`OutlineOnDarkInfo`). |
+| `themeReference` | `<Тема>Theme.<ТипТокена>.<camelVar>`. Тип токена по типу: `ColorToken`, `GradientToken`, `AdaptiveTypographyToken`, `ShadowToken`, `ShapeToken`, `SpacingToken`. |
+| `value` | Резолвнутое значение, формат зависит от типа (см. ниже). |
+
+### `value` по типам
+
+| Тип | Формат `value` | Пример |
+| --- | --- | --- |
+| color | ARGB-строка `0xAARRGGBB` (альфа первая) | `"0xFF199AF0"` |
+| gradient | массив слоёв: `kind`, `colors` (ARGB `0x…`), `locations` (числа), `angle`/… | `[{"kind":"linear","angle":45,"colors":["0xFF1A9E32","0xFF04C6C9"],"locations":[0,1]}]` |
+| typography | объект свойств одного экрана | `{"fontName":"SF Pro","weight":"medium","style":"normal","size":32,"lineHeight":36,"kerning":0}` |
+| shadow | массив слоёв `{color:0x…, offsetX, offsetY, blurRadius, spreadRadius}` | `[{"color":"0x66000000","offsetX":0,"offsetY":60,"blurRadius":112,"spreadRadius":-8}]` |
+| shape | `{cornerRadius, kind}` | `{"cornerRadius":16,"kind":"round"}` |
+| spacing | число (pt) | `20` |
+
+## Как запустить
+
+```sh
+cd SDDSThemeBuilder
+./build_cli.sh                                   # ожидаем ** BUILD SUCCEEDED **
+./build/themebuilder/SDDSThemeBuilder <config.json> --output /tmp/out
+```
+
+Признак успеха в логе:
+```
+📝 tokens meta written: .../SDDSThemeBuilder/.sdds/config-info-tokens-ios.json (N tokens)
+```
+
+Быстрый просмотр:
+```sh
+python3 -m json.tool SDDSThemeBuilder/.sdds/config-info-tokens-ios.json | head -40
+```
+
+## Автотесты
+
+```sh
+cd SDDSThemeBuilder
+xcodebuild test -project SDDSThemeBuilder.xcodeproj \
+  -scheme SDDSThemeBuilderCoreTests \
+  -only-testing:SDDSThemeBuilderCoreTests/TokenMetaResolverTests
+# ожидаем ** TEST SUCCEEDED **
+```
+
+`TokenMetaResolverTests` покрывает: конвертацию ARGB (6/8-значный hex), PascalCase,
+`0/1`→число (не bool), маппинг экрана typography, сборку записей по всем типам, исключения
+(fontFamily/disabled/отсутствие значения).
+
+## Ограничения (не баги)
+
+- Только базовая тема, `tenant: ""`.
+- Полнота значений зависит от источника темы (см. «Как это работает»).
+- `shadow`-цвета конвертируются в ARGB, только если в `ios_shadow.json` уже hex; palette-ссылка
+  останется как есть.


### PR DESCRIPTION
## What/Why changed

Добавлена возможность отдавать мета информацию по сгенерированным токенам

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme builds now generate an additional token metadata file alongside the existing output.

* **Bug Fixes**
  * Improved handling of token values so colors, gradients, typography, spacing, and shapes are written in a consistent format.
  * Disabled or unsupported tokens are skipped during metadata generation.

* **Tests**
  * Added coverage for token metadata formatting, value conversion, and filtering behavior.

* **Documentation**
  * Added guidance on the new token metadata output and how to verify it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->