### PR TITLE
chore: add ThemeBuilder CLI to release flow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -105,6 +105,28 @@ jobs:
           path: artifacts/
           retention-days: 30
 
+      - name: Build ThemeBuilder CLI
+        run: |
+          cd SDDSThemeBuilder
+          ./build_cli.sh
+          test -x build/themebuilder/SDDSThemeBuilder || { echo "❌ CLI binary not built"; exit 1; }
+
+      - name: Package ThemeBuilder CLI
+        env:
+          TAG: ${{ github.event.inputs.tag_name }}
+        run: |
+          cd SDDSThemeBuilder/build
+          rm -rf SDDSThemeBuilder-cli && mkdir -p SDDSThemeBuilder-cli
+          cp -R themebuilder/SDDSThemeBuilder themebuilder/SDDSThemeBuilderCore.framework SDDSThemeBuilder-cli/
+          ditto -c -k --sequesterRsrc --keepParent SDDSThemeBuilder-cli "SDDSThemeBuilder-cli-${TAG}.zip"
+
+      - name: Upload ThemeBuilder CLI to release
+        env:
+          TAG: ${{ github.event.inputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh release upload "${TAG}" "SDDSThemeBuilder/build/SDDSThemeBuilder-cli-${TAG}.zip" --clobber
+
       - name: Determine changed modules
         id: changed
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ThemeBuilder CLI builds are now included with published releases.
  * Each release provides a versioned, downloadable ZIP package for the CLI.
  * Release assets are refreshed automatically when a matching package already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->