### PR TITLE
PLASMA-7803: styles-API aggregator

### DIFF
--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSAccordion/AccordionAppearance/AccordionAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSAccordion/AccordionAppearance/AccordionAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct AccordionAppearance: Hashable {
     let id = UUID()
     public var accordionItemAppearance: AccordionItemAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSAccordionItem/AccordionItemAppearance/AccordionItemAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSAccordionItem/AccordionItemAppearance/AccordionItemAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct AccordionItemAppearance: Hashable {
     let id = UUID()
     public var titleTypography: TypographyConfiguration

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSAutocomplete/AutocompleteAppearance/AutocompleteAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSAutocomplete/AutocompleteAppearance/AutocompleteAppearance.swift
@@ -12,6 +12,7 @@ import SDDSThemeCore
     - textFieldAppearance: Настройки внешнего вида текстового поля
     - size: Конфигурация размеров компонента
  */
+// sdds:apiInfo
 public struct AutocompleteAppearance: Hashable {
     let id = UUID()
     public var dropdownAppearance: DropdownMenuAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSAvatar/AvatarAppearance/AvatarAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSAvatar/AvatarAppearance/AvatarAppearance.swift
@@ -13,13 +13,16 @@ import SDDSThemeCore
     - offlineStatusColor: Цвет индикатора статуса "оффлайн".
     - textTypography: Типографика текста.
  */
+// sdds:apiInfo
 public struct AvatarAppearance: Hashable {
     let id = UUID()
     public var size: AvatarSizeConfiguration
     public var textFillStyle: FillStyle
     public var backgroundFillStyle: FillStyle
     public var backgroundOpacity: CGFloat
+    // sdds:apiName=activeStatusColor
     public var onlineStatusColor: ColorToken
+    // sdds:apiName=inactiveStatusColor
     public var offlineStatusColor: ColorToken
     public var textTypography: TypographyConfiguration
     public var counterAppearance: CounterAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSAvatarGroup/AvatarGroupAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSAvatarGroup/AvatarGroupAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct AvatarGroupAppearance {
     public var size: AvatarGroupSizeConfiguration
     public var avatarAppearance: AvatarAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSAvatarGroup/SDDSAvatarGroup.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSAvatarGroup/SDDSAvatarGroup.swift
@@ -129,6 +129,8 @@ public struct SDDSAvatarGroup: View {
     - spacing: Расстояние между аватарами.
  */
 public protocol AvatarGroupSizeConfiguration {
+    // sdds:apiName=itemSpacing
     var borderWidth: CGFloat { get }
+    // sdds:apiName=itemOffset
     var spacing: CGFloat { get }
 }

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSBadge/BadgeAppearance/BadgeAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSBadge/BadgeAppearance/BadgeAppearance.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Foundation
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct BadgeAppearance {
     public var size: BadgeSizeConfiguration = DefaultBadgeSize()
     public var backgroundColor: StatefulFillStyle = StatefulFillStyle(defaultValue: .color(.clearColor), values: [])

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSBadge/BadgeAppearance/BadgeSizeConfiguration.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSBadge/BadgeAppearance/BadgeSizeConfiguration.swift
@@ -7,9 +7,12 @@ public protocol BadgeSizeConfiguration {
     var startPadding: CGFloat { get }
     var endPadding: CGFloat { get }
     var startContentSize: CGSize { get }
+    // sdds:apiName=startContentMargin
     var startContentPadding: CGFloat { get }
     var endContentSize: CGSize { get }
+    // sdds:apiName=endContentMargin
     var endContentPadding: CGFloat { get }
+    // sdds:apiName=shape
     var cornerRadius: CGFloat { get }
 }
 

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSBottomSheet/BottomSheetAppearance/BottomSheetAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSBottomSheet/BottomSheetAppearance/BottomSheetAppearance.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Foundation
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct BottomSheetAppearance {
     public var size: BottomSheetSizeConfiguration
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSButton/ButtonAppearance/ButtonAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSButton/ButtonAppearance/ButtonAppearance.swift
@@ -21,6 +21,7 @@ import SwiftUI
  - Methods:
     - init: Инициализирует стили кнопки с заданными параметрами.
  */
+// sdds:apiInfo
 public struct ButtonAppearance {
     /**
      Конфигурация размеров кнопки, определяемая `ButtonSizeConfiguration`.
@@ -35,21 +36,25 @@ public struct ButtonAppearance {
     /**
      Типографика для текста заголовка кнопки, определяемая `TypographyConfiguration`.
      */
+    // sdds:apiName=labelStyle
     public var titleTypography: TypographyConfiguration
 
     /**
      Стиль заливки текста заголовка кнопки для различных состояний, определяемый `StatefulFillStyle`.
      */
+    // sdds:apiName=labelColor
     public var titleColor: StatefulFillStyle
 
     /**
      Типографика для текста подзаголовка кнопки, определяемая `TypographyConfiguration`.
      */
+    // sdds:apiName=valueStyle
     public var subtitleTypography: TypographyConfiguration
 
     /**
      Стиль заливки текста подзаголовка кнопки для различных состояний, определяемый `StatefulFillStyle`.
      */
+    // sdds:apiName=valueColor
     public var subtitleColor: StatefulFillStyle
 
     /**

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSButton/ButtonAppearance/ButtonSize.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSButton/ButtonAppearance/ButtonSize.swift
@@ -43,11 +43,13 @@ public protocol ButtonSizeConfiguration: SizeConfiguration, CustomDebugStringCon
     /**
      Горизонтальный промежуток между иконкой и текстом кнопки.
      */
+    // sdds:apiName=iconMargin
     var iconHorizontalGap: CGFloat { get }
     
     /**
      Горизонтальный промежуток между заголовком и подзаголовком кнопки.
      */
+    // sdds:apiName=valueMargin
     var titleHorizontalGap: CGFloat { get }
     
 }

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSButtonGroup/ButtonGroupAppearance/ButtonGroupAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSButtonGroup/ButtonGroupAppearance/ButtonGroupAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `ButtonGroupAppearance` определяет внешний вид компонента ButtonGroup.
  */
+// sdds:apiInfo
 public struct ButtonGroupAppearance {
     public var buttonAppearance: ButtonAppearance?
     public var size: ButtonGroupSizeConfiguration

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCard/CardAppearance/CardAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCard/CardAppearance/CardAppearance.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Foundation
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct CardAppearance {
     public var size: CardSizeConfiguration
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCarousel/CarouselAppearance/CarouselAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCarousel/CarouselAppearance/CarouselAppearance.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @_exported import SDDSThemeCore
 
 /// Внешний вид карусели: индикатор (точки), стили и иконки кнопок навигации, размеры.
+// sdds:apiInfo
 public struct CarouselAppearance {
     public var size: CarouselSizeConfiguration
     public var indicatorAppearance: PaginationDotsAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCell/CellAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCell/CellAppearance.swift
@@ -20,6 +20,7 @@ import SwiftUI
  - switchStyle: Стиль компонента Switch.
  - radioBoxStyle: Стиль компонента RadioBox.
  */
+// sdds:apiInfo
 public struct CellAppearance {
     public var size: CellSizeConfiguration
     public var labelTypography: TypographyConfiguration
@@ -30,9 +31,12 @@ public struct CellAppearance {
     public var subtitleColor: StatefulFillStyle
     public var disclosureTextTypography: TypographyConfiguration
     public var disclosureTextColor: StatefulFillStyle
+    // sdds:apiName=disclosureIconColor
     public var disclosureImageColor: StatefulFillStyle
+    // sdds:apiName=disclosureIcon
     public var disclosureImage: Image?
     public var avatarAppearance: AvatarAppearance
+    // sdds:apiName=iconButtonStyle
     public var buttonAppearance: ButtonAppearance
     public var checkboxAppearance: CheckboxAppearance
     public var radioboxAppearance: RadioboxAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCheckbox/CheckboxAppearance/CheckboxAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCheckbox/CheckboxAppearance/CheckboxAppearance.swift
@@ -2,12 +2,17 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct CheckboxAppearance: SelectionControlAppearance, Hashable {
     let id = UUID()
     public var size: SelectionControlSizeConfiguration
+    // sdds:apiName=labelStyle
     public var titleTypography: TypographyConfiguration
+    // sdds:apiName=descriptionStyle
     public var subtitleTypography: TypographyConfiguration
+    // sdds:apiName=labelColor
     public var titleColor: StatefulFillStyle
+    // sdds:apiName=descriptionColor
     public var subtitleColor: StatefulFillStyle
     public var disabledAlpha: CGFloat
     @available(*, deprecated, message: "use 'toggleColor' instead")
@@ -15,8 +20,10 @@ public struct CheckboxAppearance: SelectionControlAppearance, Hashable {
     public var toggleColor: StatefulFillStyle
     public var toggleColorChecked: StatefulFillStyle
     public var toggleColorIndeterminate: StatefulFillStyle
+    // sdds:apiName=toggleBorderColor
     public var borderColor: StatefulFillStyle
     public var checkedIcon: PathDrawer?
+    // sdds:apiName=toggleIconColor
     public var checkedIconColor: StatefulFillStyle
     public var toggleIndeterminateIcon: PathDrawer?
     public var toggleIndeterminateIconColor: StatefulFillStyle

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCheckboxGroup/CheckboxGroupAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCheckboxGroup/CheckboxGroupAppearance.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 
+// sdds:apiInfo
 public struct CheckboxGroupAppearance {
     public var size: CheckboxGroupSizeConfiguration
     public var checkboxAppearance: CheckboxAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCheckboxGroup/SDDSCheckboxGroup.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCheckboxGroup/SDDSCheckboxGroup.swift
@@ -29,7 +29,9 @@ public enum CheckboxGroupBehaviour {
     - verticalSpacing: Вертикальный отступ между элементами.
  */
 public protocol CheckboxGroupSizeConfiguration: SizeConfiguration, CustomDebugStringConvertible {
+    // sdds:apiName=itemOffset
     var horizontalIndent: CGFloat { get }
+    // sdds:apiName=itemSpacing
     var verticalSpacing: CGFloat { get }
 }
 

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSChip/ChipAppearance/ChipAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSChip/ChipAppearance/ChipAppearance.swift
@@ -14,12 +14,17 @@ import SwiftUI
     - backgroundColor: Цвет чипа.
     - disabledAlpha: Прозрачность чипа в выключенном состоянии.
  */
+// sdds:apiInfo
 public struct ChipAppearance: Hashable {
     let id = UUID()
     public var size: ChipSizeConfiguration
+    // sdds:apiName=labelColor
     public var titleColor: StatefulFillStyle
+    // sdds:apiName=labelStyle
     public var titleTypography: TypographyConfiguration
+    // sdds:apiName=contentStartColor
     public var imageTintColor: StatefulFillStyle
+    // sdds:apiName=contentEndColor
     public var buttonTintColor: StatefulFillStyle
     public var backgroundColor: StatefulFillStyle
     public var disabledAlpha: CGFloat

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSChip/ChipAppearance/ChipSizeConfiguration.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSChip/ChipAppearance/ChipSizeConfiguration.swift
@@ -14,13 +14,18 @@ import Foundation
     - height: Высота чипа.
  */
 public protocol ChipSizeConfiguration: SizeConfiguration, CustomDebugStringConvertible {
+    // sdds:apiName=contentStartSize
     var iconImageSize: CGSize { get }
+    // sdds:apiName=contentEndSize
     var buttonImageSize: CGSize { get }
+    // sdds:apiName=paddingStart
     var leadingInset: CGFloat { get }
+    // sdds:apiName=paddingEnd
     var trailingInset: CGFloat { get }
     var contentStartPadding: CGFloat { get }
     var contentEndPadding: CGFloat { get }
     var height: CGFloat { get }
+    // sdds:apiName=shape
     var cornerRadius: CGFloat { get }
 }
 

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSChipGroup/ChipGroupAppearance/ChipGroupAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSChipGroup/ChipGroupAppearance/ChipGroupAppearance.swift
@@ -9,6 +9,7 @@ import SwiftUI
     - chipAppearance: Внешний вид отдельных чипов в группе (цвета, шрифты, скругления).
     - gap: Отступ между чипами в группе.
  */
+// sdds:apiInfo
 public struct ChipGroupAppearance {
     public var size: ChipGroupSizeConfiguration
     public var chipAppearance: ChipAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCircularProgressBar/CircularProgressBarAppearance/CircularProgressBarAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCircularProgressBar/CircularProgressBarAppearance/CircularProgressBarAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct CircularProgressBarAppearance: Hashable {
     let id = UUID()
     public var valueColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCodeField/CodeFieldAppearance/CodeFieldAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCodeField/CodeFieldAppearance/CodeFieldAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `CodeFieldAppearance` определяет внешний вид компонента CodeField.
  */
+// sdds:apiInfo
 public struct CodeFieldAppearance {
     public var valueColor: ColorToken
     public var valueColorError: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCodeInput/CodeInputAppearance/CodeInputAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCodeInput/CodeInputAppearance/CodeInputAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `CodeInputAppearance` определяет внешний вид компонента CodeInput.
  */
+// sdds:apiInfo
 public struct CodeInputAppearance {
     public var codeColor: ColorToken
     public var codeColorError: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCollapsingNavigationBar/CollapsingNavigationBarAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCollapsingNavigationBar/CollapsingNavigationBarAppearance.swift
@@ -6,6 +6,7 @@ import SwiftUI
  `CollapsingNavigationBarAppearance` определяет внешний вид компонента SDDSCollapsingNavigationBar.
  Кнопка «назад» отображается, когда задан `backIcon`.
  */
+// sdds:apiInfo
 public struct CollapsingNavigationBarAppearance {
     // Цвета
     public var backIconColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCounter/CounterAppearance/CounterAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCounter/CounterAppearance/CounterAppearance.swift
@@ -2,10 +2,12 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct CounterAppearance: Modifiable {
     public typealias ModifiableType = Self
     
     public var size: CounterSizeConfiguration
+    // sdds:apiName=labelStyle
     public var textTypography: TypographyConfiguration
     public var textColor: StatefulFillStyle
     public var backgroundColor: StatefulFillStyle

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSCounter/CounterAppearance/CounterSize.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSCounter/CounterAppearance/CounterSize.swift
@@ -13,7 +13,9 @@ public struct DefaultCounterSize: CounterSizeConfiguration {
 }
 
 public protocol CounterSizeConfiguration: SizeConfiguration, CustomDebugStringConvertible {
+    // sdds:apiName=minHeight
     var height: CGFloat { get }
+    // sdds:apiName=minWidth
     var width: CGFloat { get }
     var paddings: EdgeInsets { get }
 }

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSDivider/DividerAppearance/DividerAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSDivider/DividerAppearance/DividerAppearance.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct DividerAppearance: Hashable {
     let id = UUID()
     public var shape: PathDrawer

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSDrawer/DrawerAppearance/DrawerAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSDrawer/DrawerAppearance/DrawerAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `DrawerAppearance` определяет внешний вид компонента Drawer.
  */
+// sdds:apiInfo
 public struct DrawerAppearance: Hashable {
     let id = UUID()
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSDropdownMenu/DropdownMenuAppearance/DropdownMenuAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSDropdownMenu/DropdownMenuAppearance/DropdownMenuAppearance.swift
@@ -15,6 +15,7 @@ import SDDSThemeCore
     - shadow: Тень меню
     - size: Конфигурация размеров меню
  */
+// sdds:apiInfo
 public struct DropdownMenuAppearance: Hashable {
     let id = UUID()
     public var listAppearance: ListAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSEditable/EditableAppearance/EditableAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSEditable/EditableAppearance/EditableAppearance.swift
@@ -2,9 +2,11 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct EditableAppearance {
     public var textColorDefault: ColorToken
     public var textColorReadonly: ColorToken
+    // sdds:apiName=iconColor
     public var iconColorDefault: ColorToken
     public var iconColorReadonly: ColorToken
     public var cursorColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSFormItem/FormItemAppearance/FormItemAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSFormItem/FormItemAppearance/FormItemAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct FormItemAppearance {
     public var size: FormItemSizeConfiguration
     public var disableAlpha: CGFloat
@@ -25,6 +26,7 @@ public struct FormItemAppearance {
     public var counterColor: StatefulColor
     public var counterTypography: TypographyConfiguration
 
+    // sdds:apiName=formItemType
     public var formType: FormType
     public var topTextAlignment: FormTextAlignment
     public var bottomTextAlignment: FormTextAlignment

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSImage/ImageAppearance/ImageAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSImage/ImageAppearance/ImageAppearance.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct ImageAppearance {
     public var size: ImageSizeConfiguration
 

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSIndicator/IndicatorAppearance/IndicatorAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSIndicator/IndicatorAppearance/IndicatorAppearance.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Foundation
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct IndicatorAppearance {
     public var size: IndicatorSizeConfiguration = DefaultIndicatorSize()
     public var backgroundColor: StatefulFillStyle = StatefulFillStyle(defaultValue: .color(.clearColor), values: [])

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSList/ListAppearance/ListAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSList/ListAppearance/ListAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct ListAppearance: Hashable {
     let id = UUID()
     public var listItemAppearance: ListItemAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSListItem/ListItemAppearance/ListItemAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSListItem/ListItemAppearance/ListItemAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct ListItemAppearance: Hashable {
     let id = UUID()
     public var labelTypography: TypographyConfiguration

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSLoader/LoaderAppearance/LoaderAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSLoader/LoaderAppearance/LoaderAppearance.swift
@@ -9,6 +9,7 @@ import SwiftUI
     - spinnerAppearance: Стиль компонента Spinner.
     - circularProgressAppearance: Стиль компонента CircularProgressBar.
  */
+// sdds:apiInfo
 public struct LoaderAppearance: Hashable {
     let id = UUID()
     public var spinnerAppearance: SpinnerAppearance?

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSModal/ModalAppearance/ModalAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSModal/ModalAppearance/ModalAppearance.swift
@@ -18,6 +18,7 @@ import SwiftUI
  )
  ```
  */
+// sdds:apiInfo
 public struct ModalAppearance: Hashable {
     let id = UUID()
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSNavigationBarInternalPage/NavigationBarInternalPageAppearance/NavigationBarInternalPageAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSNavigationBarInternalPage/NavigationBarInternalPageAppearance/NavigationBarInternalPageAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `NavigationBarInternalPageAppearance` определяет внешний вид компонента NavigationBarInternalPage.
  */
+// sdds:apiInfo
 public struct NavigationBarInternalPageAppearance {
     // Цвета
     public var backIconColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSNavigationBarMainPage/NavigationBarMainPageAppearance/NavigationBarMainPageAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSNavigationBarMainPage/NavigationBarMainPageAppearance/NavigationBarMainPageAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `NavigationBarMainPageAppearance` определяет внешний вид компонента NavigationBarMainPage.
  */
+// sdds:apiInfo
 public struct NavigationBarMainPageAppearance {
     // Цвета
     public var actionStartColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSNote/NoteAppearance/NoteAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSNote/NoteAppearance/NoteAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `NoteAppearance` определяет внешний вид компонента Note.
  */
+// sdds:apiInfo
 public struct NoteAppearance {
     public var backgroundColor: ColorToken
     public var iconColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSNoteCompact/NoteCompactAppearance/NoteCompactAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSNoteCompact/NoteCompactAppearance/NoteCompactAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `NoteCompactAppearance` определяет внешний вид компонента NoteCompact.
  */
+// sdds:apiInfo
 public struct NoteCompactAppearance {
     public var backgroundColor: ColorToken
     public var iconColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSNotification/NotificationAppearance/NotificationAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSNotification/NotificationAppearance/NotificationAppearance.swift
@@ -17,6 +17,7 @@ import SwiftUI
  )
  ```
  */
+// sdds:apiInfo
 public struct NotificationAppearance: Hashable {
     let id = UUID()
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSNotificationContent/NotificationContentAppearance/NotificationContentAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSNotificationContent/NotificationContentAppearance/NotificationContentAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `NotificationContentAppearance` определяет внешний вид компонента NotificationContent.
  */
+// sdds:apiInfo
 public struct NotificationContentAppearance {
     public var iconColor: ColorToken
     public var titleColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSOverlay/OverlayAppearance/OverlayAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSOverlay/OverlayAppearance/OverlayAppearance.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct OverlayAppearance {
     public var backgroundColor: FillStyle
     public var blurRadius: CGFloat

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSPaginationDots/PaginationDotsAppearance/PaginationDotsAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSPaginationDots/PaginationDotsAppearance/PaginationDotsAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct PaginationDotsAppearance {
     public var size: PaginationDotsSizeConfiguration = DefaultPaginationDotsSize()
     @available(*, deprecated, message: "ButtonColor is deprecated and will be replaced by StatefulColor in a future release.")

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSPopover/PopoverAppearance/PopoverAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSPopover/PopoverAppearance/PopoverAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct PopoverAppearance: Hashable {
     let id = UUID()
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSProgressBar/ProgressBarAppearance/ProgressBarAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSProgressBar/ProgressBarAppearance/ProgressBarAppearance.swift
@@ -10,10 +10,13 @@ import SwiftUI
     - tintColor: Цвет индикатора прогресса.
     - trackColor: Цвет фона прогресс-бара.
  */
+// sdds:apiInfo
 public struct ProgressBarAppearance: Hashable {
     let id = UUID()
     public var size: ProgressBarSizeConfiguration
+    // sdds:apiName=indicatorColor
     public var tintFillStyle: FillStyle
+    // sdds:apiName=backgroundColor
     public var trackColor: ColorToken
     public var disabledAlpha: CGFloat
     

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSProgressBar/ProgressBarAppearance/ProgressBarSizeConfiguration.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSProgressBar/ProgressBarAppearance/ProgressBarSizeConfiguration.swift
@@ -12,6 +12,7 @@ import SwiftUI
  - indicatorCornerRadius: Радиус скругления углов индикатора прогресса.
  */
 public protocol ProgressBarSizeConfiguration: SizeConfiguration, CustomDebugStringConvertible {
+    // sdds:apiName=backgroundHeight
     var height: CGFloat { get }
     var indicatorHeight: CGFloat { get }
     var indicatorPathDrawer: PathDrawer { get }

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSRadiobox/RadioboxAppearance/RadioboxAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSRadiobox/RadioboxAppearance/RadioboxAppearance.swift
@@ -2,22 +2,29 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct RadioboxAppearance: SelectionControlAppearance, Hashable {
     let id = UUID()
     @available(*, deprecated, message: "use 'toggleColor' instead")
     public var color: StatefulFillStyle
     public var toggleColor: StatefulFillStyle
+    // sdds:apiName=toggleBorderColor
     public var borderColor: StatefulFillStyle
     public var checkedIcon: PathDrawer?
+    // sdds:apiName=toggleIconColor
     public var checkedIconColor: StatefulFillStyle
     public var toggleIndeterminateIcon: PathDrawer?
     public var toggleIndeterminateIconColor: StatefulFillStyle
     public var toggleColorChecked: StatefulFillStyle
     public var toggleColorIndeterminate: StatefulFillStyle
     public var size: SelectionControlSizeConfiguration
+    // sdds:apiName=labelStyle
     public var titleTypography: TypographyConfiguration
+    // sdds:apiName=descriptionStyle
     public var subtitleTypography: TypographyConfiguration
+    // sdds:apiName=labelColor
     public var titleColor: StatefulFillStyle
+    // sdds:apiName=descriptionColor
     public var subtitleColor: StatefulFillStyle
     public var disabledAlpha: CGFloat
     

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSRadioboxGroup/Appearance/RadioboxGroupAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSRadioboxGroup/Appearance/RadioboxGroupAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct RadioboxGroupAppearance {
     public var size: RadioboxGroupSizeConfiguration
     public var radioboxAppearance: RadioboxAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSRadioboxGroup/SDDSRadioboxGroup.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSRadioboxGroup/SDDSRadioboxGroup.swift
@@ -7,6 +7,7 @@ import SwiftUI
     - verticalSpacing: Вертикальный отступ между элементами.
  */
 public protocol RadioboxGroupSizeConfiguration: SizeConfiguration, CustomDebugStringConvertible {
+    // sdds:apiName=itemSpacing
     var verticalSpacing: CGFloat { get }
 }
 

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSRectSkeleton/SkeletonAppearance/SkeletonAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSRectSkeleton/SkeletonAppearance/SkeletonAppearance.swift
@@ -21,6 +21,7 @@ import SwiftUI
  )
  ```
  */
+// sdds:apiInfo
 public struct SkeletonAppearance {
     public var shape: PathDrawer
     public var gradient: StatefulFillStyle

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSScrollbar/ScrollbarAppearance/ScrollbarAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSScrollbar/ScrollbarAppearance/ScrollbarAppearance.swift
@@ -11,6 +11,7 @@ import SDDSThemeCore
     - trackColor: Цвет трека скроллбара.
     - shape: Форма скроллбара.
  */
+// sdds:apiInfo
 public struct ScrollbarAppearance: Hashable {
     let id = UUID()
     public var size: ScrollbarSizeConfiguration

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSSegment/SegmentAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSSegment/SegmentAppearance.swift
@@ -13,6 +13,7 @@ import SwiftUI
  - Methods:
     - init: Инициализирует стили сегмента с заданными параметрами.
  */
+// sdds:apiInfo
 public struct SegmentAppearance {
     public var size: SegmentSizeConfiguration
     @available(*, deprecated, message: "ButtonColor is deprecated and will be replaced by StatefulColor in a future release.")

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSSegmentItem/SegmentItemAppearance/SegmentItemAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSSegmentItem/SegmentItemAppearance/SegmentItemAppearance.swift
@@ -2,12 +2,15 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct SegmentItemAppearance {
     public var size: SegmentItemSizeConfiguration
     public var shapeStyle: ComponentShapeStyle
+    // sdds:apiName=labelStyle
     public var titleTypography: TypographyConfiguration
     @available(*, deprecated, message: "ButtonColor is deprecated and will be replaced by StatefulColor in a future release.")
     public var titleColor: ButtonColor
+    // sdds:apiName=valueStyle
     public var subtitleTypography: TypographyConfiguration
     @available(*, deprecated, message: "ButtonColor is deprecated and will be replaced by StatefulColor in a future release.")
     public var subtitleColor: ButtonColor

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSSelect/SelectAppearance/SelectAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSSelect/SelectAppearance/SelectAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct SelectAppearance {
     public var dropdownAppearance: DropdownMenuAppearance
     public var textFieldAppearance: TextFieldAppearance

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSSelectItem/SelectItemAppearance/SelectItemAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSSelectItem/SelectItemAppearance/SelectItemAppearance.swift
@@ -7,6 +7,7 @@ public enum SelectItemType: String, CaseIterable {
     case multiple
 }
 
+// sdds:apiInfo
 public struct SelectItemAppearance {
     public var itemType: SelectItemType
     public var iconColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSSpinner/SpinnerAppearance/SpinnerAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSSpinner/SpinnerAppearance/SpinnerAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct SpinnerAppearance: Hashable {
     let id = UUID()
     public var backgroundColor: StatefulFillStyle

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSSwitch/SwitchAppearance/SwitchAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSSwitch/SwitchAppearance/SwitchAppearance.swift
@@ -13,13 +13,19 @@ import SwiftUI
     - subtitleColor: Цвет подзаголовка, когда переключатель включен.
     - tintColor: Цвет переключателя, когда он включен.
  */
+// sdds:apiInfo
 public struct SwitchAppearance: Hashable {
     let id = UUID()
     public var size: SwitchSizeConfiguration
+    // sdds:apiName=labelStyle
     public var titleTypography: TypographyConfiguration
+    // sdds:apiName=descriptionStyle
     public var subtitleTypography: TypographyConfiguration
+    // sdds:apiName=labelColor
     public var titleColor: StatefulFillStyle
+    // sdds:apiName=descriptionColor
     public var subtitleColor: StatefulFillStyle
+    // sdds:apiName=backgroundColor
     public var toggleTrackColor: StatefulFillStyle
     public var toggleTrackColorChecked: StatefulFillStyle
     public var toggleTrackBorderColor: StatefulFillStyle

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabBar/TabBarAppearance/TabBarAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabBar/TabBarAppearance/TabBarAppearance.swift
@@ -12,6 +12,7 @@ import SDDSThemeCore
     - tabBarItemAppearance: Стиль элементов таб-бара
     - size: Конфигурация размеров и отступов таб-бара
  */
+// sdds:apiInfo
 public struct TabBarAppearance: Hashable {
     let id = UUID()
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabBar/TabBarIslandAppearance/TabBarIslandAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabBar/TabBarIslandAppearance/TabBarIslandAppearance.swift
@@ -11,6 +11,7 @@ import SDDSThemeCore
     - tabBarItemAppearance: Стиль элементов таб-бара
     - size: Конфигурация размеров и отступов островка таб-бара
  */
+// sdds:apiInfo
 public struct TabBarIslandAppearance: Hashable {
     let id = UUID()
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabBar/TabBarItemAppearance/TabBarItemAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabBar/TabBarItemAppearance/TabBarItemAppearance.swift
@@ -14,6 +14,7 @@ import SDDSThemeCore
     - indicatorAppearance: Стиль индикатора
     - size: Конфигурация размеров и отступов элемента
  */
+// sdds:apiInfo
 public struct TabBarItemAppearance: Hashable {
     let id = UUID()
     @available(*, deprecated, message: "ButtonColor is deprecated and will be replaced by StatefulColor in a future release.")

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabs/TabItemAppearance/TabItemAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabs/TabItemAppearance/TabItemAppearance.swift
@@ -18,6 +18,7 @@ import SDDSThemeCore
     - actionIcon: Иконка действия
     - indicatorColor: Цвет индикатора выбора (опционально, если nil - берется из TabsAppearance)
  */
+// sdds:apiInfo
 public struct TabItemAppearance: Hashable {
     let id = UUID()
     public var size: TabItemSizeConfiguration

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabs/TabsAppearance/TabsAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSTabs/TabsAppearance/TabsAppearance.swift
@@ -19,6 +19,7 @@ import SDDSThemeCore
     - disclosureTextTypography: Типографика текста disclosure
     - disclosureIcon: Иконка disclosure (для IconTabs)
  */
+// sdds:apiInfo
 public struct TabsAppearance: Hashable {
     let id = UUID()
     public var size: TabsSizeConfiguration

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSTextArea/TextAreaAppearance/TextAreaAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSTextArea/TextAreaAppearance/TextAreaAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct TextAreaAppearance {
     public var id = UUID()
     public var size: TextAreaSizeConfiguration

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSTextField/TextFieldAppearance/TextFieldAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSTextField/TextFieldAppearance/TextFieldAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import SDDSThemeCore
 
+// sdds:apiInfo
 public struct TextFieldAppearance {
     let id = UUID()
     public var size: TextFieldSizeConfiguration
@@ -26,13 +27,17 @@ public struct TextFieldAppearance {
     public var inputTextAlignment: TextAlignment
     public var innerTitleTextAlignment: TextAlignment
     public var innerTitleTypography: TypographyConfiguration
+    // sdds:apiName=dividerColor
     public var lineColor: ColorToken
     public var lineColorFocused: ColorToken
+    // sdds:apiName=dividerColorReadOnly
     public var lineColorReadOnly: ColorToken
+    // sdds:apiName=optionalColor
     public var optionalTitleColor: ColorToken
     public var placeholderColor: ColorToken
     public var placeholderColorFocused: ColorToken
     public var placeholderColorReadOnly: ColorToken?
+    // sdds:apiName=indicatorColor
     public var requiredIndicatorColor: ColorToken
     public var startContentColor: ColorToken
     public var startContentColorFocused: ColorToken
@@ -41,12 +46,17 @@ public struct TextFieldAppearance {
     public var textAfterTypography: TypographyConfiguration
     public var textBeforeColor: ColorToken
     public var textBeforeTypography: TypographyConfiguration
+    // sdds:apiName=valueColor
     public var textColor: ColorToken
     public var textColorFocused: ColorToken
+    // sdds:apiName=valueColorReadOnly
     public var textColorReadOnly: ColorToken?
+    // sdds:apiName=valueStyle
     public var textTypography: TypographyConfiguration
+    // sdds:apiName=labelColor
     public var titleColor: ColorToken
     public var titleTextAlignment: TextAlignment
+    // sdds:apiName=labelStyle
     public var titleTypography: TypographyConfiguration
     
     public init(

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSTextField/TextFieldAppearance/TextFieldSizeConfiguration.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSTextField/TextFieldAppearance/TextFieldSizeConfiguration.swift
@@ -3,17 +3,27 @@ import SwiftUI
 
 /// Определяет конфигурацию размеров текстового поля.
 public protocol TextFieldSizeConfiguration: CustomDebugStringConvertible {
+    // sdds:apiName=labelPadding
     var titleBottomPadding: CGFloat { get }
     var titleInnerPadding: CGFloat { get }
+    // sdds:apiName=boxPaddingStart
     var boxLeadingPadding: CGFloat { get }
+    // sdds:apiName=boxPaddingEnd
     var boxTrailingPadding: CGFloat { get }
+    // sdds:apiName=helperTextPadding
     var captionTopPadding: CGFloat { get }
     var optionalPadding: CGFloat { get }
+    // sdds:apiName=shape
     var cornerRadius: CGFloat { get }
+    // sdds:apiName=startContentPadding
     var iconPadding: CGFloat { get }
+    // sdds:apiName=endContentPadding
     var iconActionPadding: CGFloat { get }
+    // sdds:apiName=boxMinHeight
     var fieldHeight: CGFloat { get }
+    // sdds:apiName=startContentSize
     var iconSize: CGSize { get }
+    // sdds:apiName=endContentSize
     var iconActionSize: CGSize { get }
     var chipContainerHorizontalPadding: CGFloat { get }
     var dividerHeight: CGFloat { get }

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSToast/ToastAppearance/ToastAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSToast/ToastAppearance/ToastAppearance.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 @_exported import SDDSThemeCore
 
+// sdds:apiInfo
 public struct ToastAppearance: Hashable {
     let id = UUID()
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSToolbar/ToolbarAppearance/ToolbarAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSToolbar/ToolbarAppearance/ToolbarAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `ToolbarAppearance` определяет внешний вид компонента Toolbar.
  */
+// sdds:apiInfo
 public struct ToolbarAppearance: Hashable {
     private let id = UUID()
     

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSTooltip/TooltipAppearance/TooltipAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSTooltip/TooltipAppearance/TooltipAppearance.swift
@@ -26,6 +26,7 @@ import SwiftUI
  )
  ```
  */
+// sdds:apiInfo
 public struct TooltipAppearance: Hashable {
     let id = UUID()
     public var backgroundColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Components/SDDSWheel/WheelAppearance/WheelAppearance.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Components/SDDSWheel/WheelAppearance/WheelAppearance.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /**
  `WheelAppearance` определяет внешний вид компонента Wheel.
  */
+// sdds:apiInfo
 public struct WheelAppearance {    
     // Цвета текста
     public var itemTextColor: ColorToken

--- a/SDDSComponents/Sources/SDDSComponents/Views/SelectionControl/SelectionControlSizeConfiguration.swift
+++ b/SDDSComponents/Sources/SDDSComponents/Views/SelectionControl/SelectionControlSizeConfiguration.swift
@@ -3,16 +3,26 @@ import SwiftUI
 @_exported import SDDSThemeCore
 
 public protocol SelectionControlSizeConfiguration: SizeConfiguration, CustomDebugStringConvertible {
+    // sdds:apiName=toggleHeight
     var height: CGFloat { get }
+    // sdds:apiName=toggleWidth
     var width: CGFloat { get }
+    // sdds:apiName=textPadding
     var horizontalGap: CGFloat { get }
+    // sdds:apiName=descriptionPadding
     var verticalGap: CGFloat { get }
     var togglePathDrawer: PathDrawer { get }
+    // sdds:apiName=toggleBorderWidth
     var lineWidth: CGFloat { get }
+    // sdds:apiName=toggleIconWidth
     var toggleCheckedIconWidth: CGFloat { get }
+    // sdds:apiName=toggleIconHeight
     var toggleCheckedIconHeight: CGFloat { get }
+    // sdds:apiName=toggleIndeterminateWidth
     var toggleIndeterminateIconWidth: CGFloat { get }
+    // sdds:apiName=toggleIndeterminateHeight
     var toggleIndeterminateIconHeight: CGFloat { get }
+    // sdds:apiName=togglePadding
     var togglePaddings: CGFloat { get }
 }
 

--- a/SDDSThemeBuilder/.sdds/ios-api-meta.json
+++ b/SDDSThemeBuilder/.sdds/ios-api-meta.json
@@ -1,0 +1,9264 @@
+[
+  {
+    "componentName" : "Accordion",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "accordionItemAppearance",
+        "methodName" : "accordionItemAppearance",
+        "paramName" : "accordionItemAppearance",
+        "paramQualifiedType" : "AccordionItemAppearance",
+        "paramSimpleType" : "AccordionItemAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "AccordionItemAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "dividerAppearance",
+        "methodName" : "dividerAppearance",
+        "paramName" : "dividerAppearance",
+        "paramQualifiedType" : "DividerAppearance",
+        "paramSimpleType" : "DividerAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "DividerAppearance"
+      },
+      {
+        "group" : "size",
+        "id" : "itemSpacing",
+        "methodName" : "itemSpacing",
+        "paramName" : "itemSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.AccordionAppearance",
+    "resolvedTypes" : [
+      "AccordionItemAppearance",
+      "CGFloat",
+      "DividerAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.AccordionAppearance"
+  },
+  {
+    "componentName" : "AccordionItem",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingStart",
+        "methodName" : "contentPaddingStart",
+        "paramName" : "contentPaddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingEnd",
+        "methodName" : "contentPaddingEnd",
+        "paramName" : "contentPaddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingBottom",
+        "methodName" : "contentPaddingBottom",
+        "paramName" : "contentPaddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "titleStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "contentTextStyle",
+        "methodName" : "contentTextTypography",
+        "paramName" : "contentTextTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "closedIcon",
+        "methodName" : "closedIcon",
+        "paramName" : "closedIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "openedIcon",
+        "methodName" : "openedIcon",
+        "paramName" : "openedIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "size",
+        "id" : "iconPadding",
+        "methodName" : "iconPadding",
+        "paramName" : "iconPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "titleColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "contentTextColor",
+        "methodName" : "contentTextColor",
+        "paramName" : "contentTextColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "iconPlacement",
+        "methodName" : "iconPlacement",
+        "paramName" : "iconPlacement",
+        "paramQualifiedType" : "AccordionItemPlacement",
+        "paramSimpleType" : "AccordionItemPlacement",
+        "type" : "value",
+        "valueQualifiedType" : "AccordionItemPlacement"
+      },
+      {
+        "group" : "size",
+        "id" : "iconRotation",
+        "methodName" : "iconRotation",
+        "paramName" : "iconRotation",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.AccordionItemAppearance",
+    "resolvedTypes" : [
+      "AccordionItemPlacement",
+      "CGFloat",
+      "ColorToken",
+      "Image",
+      "PathDrawer",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.AccordionItemAppearance"
+  },
+  {
+    "componentName" : "Autocomplete",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "dropdownStyle",
+        "methodName" : "dropdownAppearance",
+        "paramName" : "dropdownAppearance",
+        "paramQualifiedType" : "DropdownMenuAppearance",
+        "paramSimpleType" : "DropdownMenuAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "DropdownMenuAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "textFieldStyle",
+        "methodName" : "textFieldAppearance",
+        "paramName" : "textFieldAppearance",
+        "paramQualifiedType" : "TextFieldAppearance",
+        "paramSimpleType" : "TextFieldAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "TextFieldAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.AutocompleteAppearance",
+    "resolvedTypes" : [
+      "AutocompleteSizeConfiguration",
+      "DropdownMenuAppearance",
+      "TextFieldAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.AutocompleteAppearance"
+  },
+  {
+    "componentName" : "Avatar",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "background",
+        "methodName" : "backgroundFillStyle",
+        "paramName" : "backgroundFillStyle",
+        "paramQualifiedType" : "FillStyle",
+        "paramSimpleType" : "FillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "FillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "activeStatusColor",
+        "methodName" : "onlineStatusColor",
+        "paramName" : "onlineStatusColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "inactiveStatusColor",
+        "methodName" : "offlineStatusColor",
+        "paramName" : "offlineStatusColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textFillStyle",
+        "paramName" : "textFillStyle",
+        "paramQualifiedType" : "FillStyle",
+        "paramSimpleType" : "FillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "FillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "width",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "height",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "statusOffsetX",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "statusOffsetY",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "extraOffsetX",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "extraOffsetY",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "statusStyle",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "component_style",
+        "unmapped" : true,
+        "valueQualifiedType" : "IndicatorProps"
+      },
+      {
+        "group" : "root",
+        "id" : "badgeStyle",
+        "methodName" : "badgeAppearance",
+        "paramName" : "badgeAppearance",
+        "paramQualifiedType" : "BadgeAppearance?",
+        "paramSimpleType" : "BadgeAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "BadgeAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "counterStyle",
+        "methodName" : "counterAppearance",
+        "paramName" : "counterAppearance",
+        "paramQualifiedType" : "CounterAppearance",
+        "paramSimpleType" : "CounterAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CounterAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.AvatarAppearance",
+    "resolvedTypes" : [
+      "BadgeAppearance",
+      "CGFloat",
+      "CGPoint",
+      "CGSize",
+      "ColorToken",
+      "CounterAppearance",
+      "EdgeInsets",
+      "FillStyle",
+      "IndicatorAppearance",
+      "PathDrawer",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.AvatarAppearance"
+  },
+  {
+    "componentName" : "AvatarGroup",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "itemOffset",
+        "methodName" : "spacing",
+        "paramName" : "spacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "itemSpacing",
+        "methodName" : "borderWidth",
+        "paramName" : "borderWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "avatarStyle",
+        "methodName" : "avatarAppearance",
+        "paramName" : "avatarAppearance",
+        "paramQualifiedType" : "AvatarAppearance",
+        "paramSimpleType" : "AvatarAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "AvatarAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.AvatarGroupAppearance",
+    "resolvedTypes" : [
+      "AvatarAppearance",
+      "CGFloat"
+    ],
+    "styleQualifiedName" : "SDDSComponents.AvatarGroupAppearance"
+  },
+  {
+    "componentName" : "Badge",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "cornerRadius",
+        "paramName" : "cornerRadius",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "labelTypography",
+        "paramName" : "labelTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "height",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "startPadding",
+        "methodName" : "startPadding",
+        "paramName" : "startPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "endPadding",
+        "methodName" : "endPadding",
+        "paramName" : "endPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "startContentSize",
+        "methodName" : "startContentSize",
+        "paramName" : "startContentSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "endContentSize",
+        "methodName" : "endContentSize",
+        "paramName" : "endContentSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "startContentMargin",
+        "methodName" : "startContentPadding",
+        "paramName" : "startContentPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "endContentMargin",
+        "methodName" : "endContentPadding",
+        "paramName" : "endContentPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "labelColor",
+        "paramName" : "labelColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "startContentColor",
+        "methodName" : "startContentColor",
+        "paramName" : "startContentColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "endContentColor",
+        "methodName" : "endContentColor",
+        "paramName" : "endContentColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.BadgeAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CGSize",
+      "StatefulFillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.BadgeAppearance"
+  },
+  {
+    "componentName" : "BottomSheet",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "handleShape",
+        "methodName" : "handleColor",
+        "paramName" : "handleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "handleColor",
+        "methodName" : "handleColor",
+        "paramName" : "handleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "handleWidth",
+        "methodName" : "handleWidth",
+        "paramName" : "handleWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "handleHeight",
+        "methodName" : "handleHeight",
+        "paramName" : "handleHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "handleOffset",
+        "methodName" : "handleOffset",
+        "paramName" : "handleOffset",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "handlePlacement",
+        "methodName" : "handlePlacement",
+        "paramName" : "handlePlacement",
+        "paramQualifiedType" : "BottomSheetHandlePlacement",
+        "paramSimpleType" : "BottomSheetHandlePlacement",
+        "type" : "value",
+        "valueQualifiedType" : "BottomSheetHandlePlacement"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.BottomSheetAppearance",
+    "resolvedTypes" : [
+      "BottomSheetHandlePlacement",
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer"
+    ],
+    "styleQualifiedName" : "SDDSComponents.BottomSheetAppearance"
+  },
+  {
+    "componentName" : "Button",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "loadingAlpha",
+        "methodName" : "loadingAlpha",
+        "paramName" : "loadingAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "shapeStyle",
+        "paramName" : "shapeStyle",
+        "paramQualifiedType" : "ComponentShapeStyle",
+        "paramSimpleType" : "ComponentShapeStyle",
+        "type" : "shape",
+        "valueQualifiedType" : "ComponentShapeStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "valueStyle",
+        "methodName" : "subtitleTypography",
+        "paramName" : "subtitleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "height",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "paddingStart",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "paddingEnd",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "minWidth",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "iconSize",
+        "methodName" : "iconSize",
+        "paramName" : "iconSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "spinnerSize",
+        "methodName" : "spinnerSize",
+        "paramName" : "spinnerSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "iconMargin",
+        "methodName" : "iconHorizontalGap",
+        "paramName" : "iconHorizontalGap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "valueMargin",
+        "methodName" : "titleHorizontalGap",
+        "paramName" : "titleHorizontalGap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "iconColor",
+        "methodName" : "iconColor",
+        "paramName" : "iconColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "spinnerColor",
+        "methodName" : "spinnerColor",
+        "paramName" : "spinnerColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "valueColor",
+        "methodName" : "subtitleColor",
+        "paramName" : "subtitleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ButtonAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CGSize",
+      "ComponentShapeStyle",
+      "EdgeInsets",
+      "PathDrawer",
+      "StatefulFillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ButtonAppearance"
+  },
+  {
+    "componentName" : "ButtonGroup",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "spacing",
+        "methodName" : "spacing",
+        "paramName" : "spacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "externalShape",
+        "methodName" : "externalShape",
+        "paramName" : "externalShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "internalShape",
+        "methodName" : "internalShape",
+        "paramName" : "internalShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "root",
+        "id" : "buttonStyle",
+        "methodName" : "buttonAppearance",
+        "paramName" : "buttonAppearance",
+        "paramQualifiedType" : "ButtonAppearance?",
+        "paramSimpleType" : "ButtonAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ButtonAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ButtonGroupAppearance",
+    "resolvedTypes" : [
+      "ButtonAppearance",
+      "CGFloat",
+      "PathDrawer"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ButtonGroupAppearance"
+  },
+  {
+    "componentName" : "Card",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CardAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CardAppearance"
+  },
+  {
+    "componentName" : "Carousel",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "indicatorStyle",
+        "methodName" : "indicatorAppearance",
+        "paramName" : "indicatorAppearance",
+        "paramQualifiedType" : "PaginationDotsAppearance",
+        "paramSimpleType" : "PaginationDotsAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "PaginationDotsAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "nextButtonStyle",
+        "methodName" : "nextButtonAppearance",
+        "paramName" : "nextButtonAppearance",
+        "paramQualifiedType" : "ButtonAppearance",
+        "paramSimpleType" : "ButtonAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ButtonAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "prevButtonStyle",
+        "methodName" : "prevButtonAppearance",
+        "paramName" : "prevButtonAppearance",
+        "paramQualifiedType" : "ButtonAppearance",
+        "paramSimpleType" : "ButtonAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ButtonAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "nextButtonIcon",
+        "methodName" : "nextButtonIcon",
+        "paramName" : "nextButtonIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "prevButtonIcon",
+        "methodName" : "prevButtonIcon",
+        "paramName" : "prevButtonIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "size",
+        "id" : "buttonsPlacement",
+        "methodName" : "buttonsPlacement",
+        "paramName" : "buttonsPlacement",
+        "paramQualifiedType" : "CarouselButtonsPlacement",
+        "paramSimpleType" : "CarouselButtonsPlacement",
+        "type" : "value",
+        "valueQualifiedType" : "CarouselButtonsPlacement"
+      },
+      {
+        "group" : "size",
+        "id" : "indicatorPadding",
+        "methodName" : "indicatorPadding",
+        "paramName" : "indicatorPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "nextButtonPadding",
+        "methodName" : "nextButtonPadding",
+        "paramName" : "nextButtonPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "prevButtonPadding",
+        "methodName" : "prevButtonPadding",
+        "paramName" : "prevButtonPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "gap",
+        "methodName" : "gap",
+        "paramName" : "gap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CarouselAppearance",
+    "resolvedTypes" : [
+      "ButtonAppearance",
+      "CGFloat",
+      "CarouselButtonsPlacement",
+      "Image",
+      "PaginationDotsAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CarouselAppearance"
+  },
+  {
+    "componentName" : "Cell",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "contentPaddingStart",
+        "methodName" : "contentPaddingStart",
+        "paramName" : "contentPaddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingEnd",
+        "methodName" : "contentPaddingEnd",
+        "paramName" : "contentPaddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "labelTypography",
+        "paramName" : "labelTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "titleStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "subtitleStyle",
+        "methodName" : "subtitleTypography",
+        "paramName" : "subtitleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "disclosureTextStyle",
+        "methodName" : "disclosureTextTypography",
+        "paramName" : "disclosureTextTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "avatarStyle",
+        "methodName" : "avatarAppearance",
+        "paramName" : "avatarAppearance",
+        "paramQualifiedType" : "AvatarAppearance",
+        "paramSimpleType" : "AvatarAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "AvatarAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "iconButtonStyle",
+        "methodName" : "buttonAppearance",
+        "paramName" : "buttonAppearance",
+        "paramQualifiedType" : "ButtonAppearance",
+        "paramSimpleType" : "ButtonAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ButtonAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "checkBoxStyle",
+        "methodName" : "checkboxAppearance",
+        "paramName" : "checkboxAppearance",
+        "paramQualifiedType" : "CheckboxAppearance",
+        "paramSimpleType" : "CheckboxAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CheckboxAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "radioBoxStyle",
+        "methodName" : "radioboxAppearance",
+        "paramName" : "radioboxAppearance",
+        "paramQualifiedType" : "RadioboxAppearance",
+        "paramSimpleType" : "RadioboxAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "RadioboxAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "switchStyle",
+        "methodName" : "switchAppearance",
+        "paramName" : "switchAppearance",
+        "paramQualifiedType" : "SwitchAppearance",
+        "paramSimpleType" : "SwitchAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "SwitchAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "disclosureIcon",
+        "methodName" : "disclosureImage",
+        "paramName" : "disclosureImage",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "labelColor",
+        "paramName" : "labelColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "titleColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "subtitleColor",
+        "methodName" : "subtitleColor",
+        "paramName" : "subtitleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "disclosureTextColor",
+        "methodName" : "disclosureTextColor",
+        "paramName" : "disclosureTextColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "disclosureIconColor",
+        "methodName" : "disclosureImageColor",
+        "paramName" : "disclosureImageColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CellAppearance",
+    "resolvedTypes" : [
+      "AvatarAppearance",
+      "ButtonAppearance",
+      "CGFloat",
+      "CheckboxAppearance",
+      "Image",
+      "RadioboxAppearance",
+      "StatefulFillStyle",
+      "SwitchAppearance",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CellAppearance"
+  },
+  {
+    "componentName" : "Checkbox",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "togglePadding",
+        "methodName" : "togglePaddings",
+        "paramName" : "togglePaddings",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleBorderWidth",
+        "methodName" : "lineWidth",
+        "paramName" : "lineWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleWidth",
+        "methodName" : "width",
+        "paramName" : "width",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleHeight",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleIconWidth",
+        "methodName" : "toggleCheckedIconWidth",
+        "paramName" : "toggleCheckedIconWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleIconHeight",
+        "methodName" : "toggleCheckedIconHeight",
+        "paramName" : "toggleCheckedIconHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textPadding",
+        "methodName" : "horizontalGap",
+        "paramName" : "horizontalGap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "descriptionPadding",
+        "methodName" : "verticalGap",
+        "paramName" : "verticalGap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleIndeterminateWidth",
+        "methodName" : "toggleIndeterminateIconWidth",
+        "paramName" : "toggleIndeterminateIconWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleIndeterminateHeight",
+        "methodName" : "toggleIndeterminateIconHeight",
+        "paramName" : "toggleIndeterminateIconHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionStyle",
+        "methodName" : "subtitleTypography",
+        "paramName" : "subtitleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "toggleIndeterminateIconColor",
+        "methodName" : "toggleIndeterminateIconColor",
+        "paramName" : "toggleIndeterminateIconColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleColor",
+        "methodName" : "toggleColor",
+        "paramName" : "toggleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleBorderColor",
+        "methodName" : "borderColor",
+        "paramName" : "borderColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionColor",
+        "methodName" : "subtitleColor",
+        "paramName" : "subtitleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleIconColor",
+        "methodName" : "checkedIconColor",
+        "paramName" : "checkedIconColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CheckboxAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "PathDrawer",
+      "StatefulFillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CheckboxAppearance"
+  },
+  {
+    "componentName" : "CheckboxGroup",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "itemOffset",
+        "methodName" : "horizontalIndent",
+        "paramName" : "horizontalIndent",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "itemSpacing",
+        "methodName" : "verticalSpacing",
+        "paramName" : "verticalSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "checkBoxStyle",
+        "methodName" : "checkboxAppearance",
+        "paramName" : "checkboxAppearance",
+        "paramQualifiedType" : "CheckboxAppearance",
+        "paramSimpleType" : "CheckboxAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CheckboxAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CheckboxGroupAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CheckboxAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CheckboxGroupAppearance"
+  },
+  {
+    "componentName" : "Chip",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "cornerRadius",
+        "paramName" : "cornerRadius",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "height",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "leadingInset",
+        "paramName" : "leadingInset",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "trailingInset",
+        "paramName" : "trailingInset",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "minWidth",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "iconSize",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "contentStartSize",
+        "methodName" : "iconImageSize",
+        "paramName" : "iconImageSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "contentStartPadding",
+        "methodName" : "contentStartPadding",
+        "paramName" : "contentStartPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentEndSize",
+        "methodName" : "buttonImageSize",
+        "paramName" : "buttonImageSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "contentEndPadding",
+        "methodName" : "contentEndPadding",
+        "paramName" : "contentEndPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "contentEndColor",
+        "methodName" : "buttonTintColor",
+        "paramName" : "buttonTintColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "contentStartColor",
+        "methodName" : "imageTintColor",
+        "paramName" : "imageTintColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ChipAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CGSize",
+      "StatefulFillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ChipAppearance"
+  },
+  {
+    "componentName" : "ChipGroup",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "gap",
+        "methodName" : "gap",
+        "paramName" : "gap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "lineSpacing",
+        "methodName" : "lineSpacing",
+        "paramName" : "lineSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "chipStyle",
+        "methodName" : "chipAppearance",
+        "paramName" : "chipAppearance",
+        "paramQualifiedType" : "ChipAppearance",
+        "paramSimpleType" : "ChipAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ChipAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ChipGroupAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ChipAppearance",
+      "ChipGroupAlignment",
+      "ChipGroupGap",
+      "Int"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ChipGroupAppearance"
+  },
+  {
+    "componentName" : "CircularProgressBar",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "width",
+        "methodName" : "width",
+        "paramName" : "width",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "height",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "trackThickness",
+        "methodName" : "trackThickness",
+        "paramName" : "trackThickness",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "progressThickness",
+        "methodName" : "progressThickness",
+        "paramName" : "progressThickness",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "valueStyle",
+        "methodName" : "valueTypography",
+        "paramName" : "valueTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "valueColor",
+        "methodName" : "valueColor",
+        "paramName" : "valueColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "valueEnabled",
+        "methodName" : "valueEnabled",
+        "paramName" : "valueEnabled",
+        "paramQualifiedType" : "Bool",
+        "paramSimpleType" : "Bool",
+        "type" : "boolean",
+        "valueQualifiedType" : "Bool"
+      },
+      {
+        "group" : "root",
+        "id" : "trackColor",
+        "methodName" : "trackColor",
+        "paramName" : "trackColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorColor",
+        "methodName" : "indicatorColor",
+        "paramName" : "indicatorColor",
+        "paramQualifiedType" : "FillStyle",
+        "paramSimpleType" : "FillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "FillStyle"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CircularProgressBarAppearance",
+    "resolvedTypes" : [
+      "Bool",
+      "CGFloat",
+      "ColorToken",
+      "FillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CircularProgressBarAppearance"
+  },
+  {
+    "componentName" : "CodeField",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "itemSpacing",
+        "methodName" : "itemSpacing",
+        "paramName" : "itemSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "groupSpacing",
+        "methodName" : "groupSpacing",
+        "paramName" : "groupSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "valueColor",
+        "methodName" : "valueColor",
+        "paramName" : "valueColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "cursorColor",
+        "methodName" : "cursorColor",
+        "paramName" : "cursorColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "captionColor",
+        "methodName" : "captionColor",
+        "paramName" : "captionColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "dotColor",
+        "methodName" : "dotColor",
+        "paramName" : "dotColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "itemShape",
+        "methodName" : "itemShape",
+        "paramName" : "itemShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "groupShape",
+        "methodName" : "groupShape",
+        "paramName" : "groupShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "captionSpacing",
+        "methodName" : "captionSpacing",
+        "paramName" : "captionSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "dotSize",
+        "methodName" : "dotSize",
+        "paramName" : "dotSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "width",
+        "methodName" : "width",
+        "paramName" : "width",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "height",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "captionStyle",
+        "methodName" : "captionTypography",
+        "paramName" : "captionTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "valueStyle",
+        "methodName" : "valueTypography",
+        "paramName" : "valueTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CodeFieldAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CodeFieldAppearance"
+  },
+  {
+    "componentName" : "CodeInput",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "codeColor",
+        "methodName" : "codeColor",
+        "paramName" : "codeColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "captionColor",
+        "methodName" : "captionColor",
+        "paramName" : "captionColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "strokeColor",
+        "methodName" : "strokeColor",
+        "paramName" : "strokeColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "fillColor",
+        "methodName" : "fillColor",
+        "paramName" : "fillColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "fillColorError",
+        "methodName" : "fillColorError",
+        "paramName" : "fillColorError",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "itemHeight",
+        "methodName" : "itemHeight",
+        "paramName" : "itemHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "itemWidth",
+        "methodName" : "itemWidth",
+        "paramName" : "itemWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "dotSize",
+        "methodName" : "dotSize",
+        "paramName" : "dotSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "strokeWidth",
+        "methodName" : "strokeWidth",
+        "paramName" : "strokeWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "itemSpacing",
+        "methodName" : "itemSpacing",
+        "paramName" : "itemSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "groupSpacing",
+        "methodName" : "groupSpacing",
+        "paramName" : "groupSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "captionPadding",
+        "methodName" : "captionPadding",
+        "paramName" : "captionPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "codeStyle",
+        "methodName" : "codeTypography",
+        "paramName" : "codeTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "captionStyle",
+        "methodName" : "captionTypography",
+        "paramName" : "captionTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CodeInputAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CodeInputAppearance"
+  },
+  {
+    "componentName" : "CollapsingNavigationBar",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backIconColor",
+        "methodName" : "backIconColor",
+        "paramName" : "backIconColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "actionStartColor",
+        "methodName" : "actionStartColor",
+        "paramName" : "actionStartColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "actionEndColor",
+        "methodName" : "actionEndColor",
+        "paramName" : "actionEndColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "titleColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionColor",
+        "methodName" : "descriptionColor",
+        "paramName" : "descriptionColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backIcon",
+        "methodName" : "backIcon",
+        "paramName" : "backIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "actionButtonAppearance",
+        "methodName" : "actionButtonAppearance",
+        "paramName" : "actionButtonAppearance",
+        "paramQualifiedType" : "ButtonAppearance?",
+        "paramSimpleType" : "ButtonAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ButtonAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "textTypography",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "titleTypography",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "titleTypographyCollapsed",
+        "methodName" : "titleTypographyCollapsed",
+        "paramName" : "titleTypographyCollapsed",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "titleStatefulTypography",
+        "id" : "applyTypography",
+        "methodName" : "applyTypography",
+        "paramName" : "applyTypography",
+        "paramQualifiedType" : "(Any) -> TypographyToken?",
+        "paramSimpleType" : "(Any) -> TypographyToken?",
+        "type" : "typography",
+        "valueQualifiedType" : "(Any) -> TypographyToken?"
+      },
+      {
+        "group" : "titleStatefulTypography",
+        "id" : "original",
+        "methodName" : "original",
+        "paramName" : "original",
+        "paramQualifiedType" : "Any",
+        "paramSimpleType" : "Any",
+        "type" : "value",
+        "valueQualifiedType" : "Any"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionTypography",
+        "methodName" : "descriptionTypography",
+        "paramName" : "descriptionTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionTypographyCollapsed",
+        "methodName" : "descriptionTypographyCollapsed",
+        "paramName" : "descriptionTypographyCollapsed",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "descriptionStatefulTypography",
+        "id" : "applyTypography",
+        "methodName" : "applyTypography",
+        "paramName" : "applyTypography",
+        "paramQualifiedType" : "(Any) -> TypographyToken?",
+        "paramSimpleType" : "(Any) -> TypographyToken?",
+        "type" : "typography",
+        "valueQualifiedType" : "(Any) -> TypographyToken?"
+      },
+      {
+        "group" : "descriptionStatefulTypography",
+        "id" : "original",
+        "methodName" : "original",
+        "paramName" : "original",
+        "paramQualifiedType" : "Any",
+        "paramSimpleType" : "Any",
+        "type" : "value",
+        "valueQualifiedType" : "Any"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      },
+      {
+        "group" : "size",
+        "id" : "backIconMargin",
+        "methodName" : "backIconMargin",
+        "paramName" : "backIconMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "descriptionPadding",
+        "methodName" : "descriptionPadding",
+        "paramName" : "descriptionPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "descriptionPaddingCollapsed",
+        "methodName" : "descriptionPaddingCollapsed",
+        "paramName" : "descriptionPaddingCollapsed",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "horizontalSpacing",
+        "methodName" : "horizontalSpacing",
+        "paramName" : "horizontalSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textBlockTopMargin",
+        "methodName" : "textBlockTopMargin",
+        "paramName" : "textBlockTopMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "bottomShape",
+        "methodName" : "bottomShape",
+        "paramName" : "bottomShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CollapsingNavigationBarAppearance",
+    "resolvedTypes" : [
+      "(Any) -> TypographyToken?",
+      "Any",
+      "ButtonAppearance",
+      "CGFloat",
+      "ColorToken",
+      "Image",
+      "PathDrawer",
+      "ShadowToken",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CollapsingNavigationBarAppearance"
+  },
+  {
+    "componentName" : "Counter",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "minWidth",
+        "methodName" : "width",
+        "paramName" : "width",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "minHeight",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "paddingLeft",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "paddingRight",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "paddingTop",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "paddingBottom",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.CounterAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "EdgeInsets",
+      "StatefulFillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.CounterAppearance"
+  },
+  {
+    "componentName" : "Divider",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "thickness",
+        "methodName" : "thickness",
+        "paramName" : "thickness",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.DividerAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "DividerSizeConfiguration",
+      "PathDrawer"
+    ],
+    "styleQualifiedName" : "SDDSComponents.DividerAppearance"
+  },
+  {
+    "componentName" : "Drawer",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "closeColor",
+        "methodName" : "closeColor",
+        "paramName" : "closeColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "closeIcon",
+        "methodName" : "closeIcon",
+        "paramName" : "closeIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken?",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "closeIconHeaderPadding",
+        "methodName" : "closeIconHeaderPadding",
+        "paramName" : "closeIconHeaderPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "closeIconOffsetX",
+        "methodName" : "closeIconOffsetX",
+        "paramName" : "closeIconOffsetX",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "closeIconOffsetY",
+        "methodName" : "closeIconOffsetY",
+        "paramName" : "closeIconOffsetY",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "closeIconPlacement",
+        "methodName" : "closeIconPlacement",
+        "paramName" : "closeIconPlacement",
+        "paramQualifiedType" : "DrawerCloseIconPlacement",
+        "paramSimpleType" : "DrawerCloseIconPlacement",
+        "type" : "icon",
+        "valueQualifiedType" : "DrawerCloseIconPlacement"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.DrawerAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "DrawerCloseIconPlacement",
+      "Image",
+      "ShadowToken"
+    ],
+    "styleQualifiedName" : "SDDSComponents.DrawerAppearance"
+  },
+  {
+    "componentName" : "DropdownMenu",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "listStyle",
+        "methodName" : "listAppearance",
+        "paramName" : "listAppearance",
+        "paramQualifiedType" : "ListAppearance",
+        "paramSimpleType" : "ListAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ListAppearance"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "width",
+        "methodName" : "width",
+        "paramName" : "width",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "dividerStyle",
+        "methodName" : "dividerAppearance",
+        "paramName" : "dividerAppearance",
+        "paramQualifiedType" : "DividerAppearance?",
+        "paramSimpleType" : "DividerAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "DividerAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "offset",
+        "methodName" : "offset",
+        "paramName" : "offset",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.DropdownMenuAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "DividerAppearance",
+      "ListAppearance",
+      "PathDrawer",
+      "ShadowToken"
+    ],
+    "styleQualifiedName" : "SDDSComponents.DropdownMenuAppearance"
+  },
+  {
+    "componentName" : "Editable",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "iconColor",
+        "methodName" : "iconColorDefault",
+        "paramName" : "iconColorDefault",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "cursorColor",
+        "methodName" : "cursorColor",
+        "paramName" : "cursorColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "iconSize",
+        "methodName" : "iconSize",
+        "paramName" : "iconSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "iconMargin",
+        "methodName" : "iconMargin",
+        "paramName" : "iconMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.EditableAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.EditableAppearance"
+  },
+  {
+    "componentName" : "FormItem",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "formItemType",
+        "methodName" : "formType",
+        "paramName" : "formType",
+        "paramQualifiedType" : "FormType",
+        "paramSimpleType" : "FormType",
+        "type" : "value",
+        "valueQualifiedType" : "FormType"
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disableAlpha",
+        "paramName" : "disableAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "hintIcon",
+        "methodName" : "hintIcon",
+        "paramName" : "hintIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "hintColor",
+        "methodName" : "hintColor",
+        "paramName" : "hintColor",
+        "paramQualifiedType" : "StatefulColor",
+        "paramSimpleType" : "StatefulColor",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulColor"
+      },
+      {
+        "group" : "size",
+        "id" : "hintWidth",
+        "methodName" : "hintWidth",
+        "paramName" : "hintWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "hintHeight",
+        "methodName" : "hintHeight",
+        "paramName" : "hintHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "optionalStyle",
+        "methodName" : "optionalTypography",
+        "paramName" : "optionalTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "optionalColor",
+        "methodName" : "optionalColor",
+        "paramName" : "optionalColor",
+        "paramQualifiedType" : "StatefulColor",
+        "paramSimpleType" : "StatefulColor",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulColor"
+      },
+      {
+        "group" : "size",
+        "id" : "titleBlockWidth",
+        "methodName" : "titleBlockWidth",
+        "paramName" : "titleBlockWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "titleBlockPadding",
+        "methodName" : "titleBlockPadding",
+        "paramName" : "titleBlockPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "titleStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "titleColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "StatefulColor",
+        "paramSimpleType" : "StatefulColor",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulColor"
+      },
+      {
+        "group" : "root",
+        "id" : "titlePlacement",
+        "methodName" : "titlePlacement",
+        "paramName" : "titlePlacement",
+        "paramQualifiedType" : "FormTitlePlacement",
+        "paramSimpleType" : "FormTitlePlacement",
+        "type" : "value",
+        "valueQualifiedType" : "FormTitlePlacement"
+      },
+      {
+        "group" : "size",
+        "id" : "titleBlockSpacing",
+        "methodName" : "titleBlockSpacing",
+        "paramName" : "titleBlockSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "titleCaptionPadding",
+        "methodName" : "titleCaptionPadding",
+        "paramName" : "titleCaptionPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "titleCaptionStyle",
+        "methodName" : "titleCaptionTypography",
+        "paramName" : "titleCaptionTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "titleCaptionColor",
+        "methodName" : "titleCaptionColor",
+        "paramName" : "titleCaptionColor",
+        "paramQualifiedType" : "StatefulColor",
+        "paramSimpleType" : "StatefulColor",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulColor"
+      },
+      {
+        "group" : "size",
+        "id" : "captionPadding",
+        "methodName" : "captionPadding",
+        "paramName" : "captionPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "captionStyle",
+        "methodName" : "captionTypography",
+        "paramName" : "captionTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "captionColor",
+        "methodName" : "captionColor",
+        "paramName" : "captionColor",
+        "paramQualifiedType" : "StatefulColor",
+        "paramSimpleType" : "StatefulColor",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulColor"
+      },
+      {
+        "group" : "root",
+        "id" : "counterStyle",
+        "methodName" : "counterTypography",
+        "paramName" : "counterTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "counterColor",
+        "methodName" : "counterColor",
+        "paramName" : "counterColor",
+        "paramQualifiedType" : "StatefulColor",
+        "paramSimpleType" : "StatefulColor",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulColor"
+      },
+      {
+        "group" : "size",
+        "id" : "counterPadding",
+        "methodName" : "counterPadding",
+        "paramName" : "counterPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "topTextAlignment",
+        "methodName" : "topTextAlignment",
+        "paramName" : "topTextAlignment",
+        "paramQualifiedType" : "FormTextAlignment",
+        "paramSimpleType" : "FormTextAlignment",
+        "type" : "value",
+        "valueQualifiedType" : "FormTextAlignment"
+      },
+      {
+        "group" : "root",
+        "id" : "bottomTextAlignment",
+        "methodName" : "bottomTextAlignment",
+        "paramName" : "bottomTextAlignment",
+        "paramQualifiedType" : "FormTextAlignment",
+        "paramSimpleType" : "FormTextAlignment",
+        "type" : "value",
+        "valueQualifiedType" : "FormTextAlignment"
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorOffsetX",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorOffsetY",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorAlignmentMode",
+        "methodName" : "indicatorAlignmentMode",
+        "paramName" : "indicatorAlignmentMode",
+        "paramQualifiedType" : "FormIndicatorAlignmentMode",
+        "paramSimpleType" : "FormIndicatorAlignmentMode",
+        "type" : "value",
+        "valueQualifiedType" : "FormIndicatorAlignmentMode"
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorAlignment",
+        "methodName" : "indicatorAlignment",
+        "paramName" : "indicatorAlignment",
+        "paramQualifiedType" : "FormIndicatorAlignment",
+        "paramSimpleType" : "FormIndicatorAlignment",
+        "type" : "value",
+        "valueQualifiedType" : "FormIndicatorAlignment"
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorStyle",
+        "methodName" : "indicatorAppearance",
+        "paramName" : "indicatorAppearance",
+        "paramQualifiedType" : "IndicatorAppearance",
+        "paramSimpleType" : "IndicatorAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "IndicatorAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.FormItemAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CGPoint",
+      "FormIndicatorAlignment",
+      "FormIndicatorAlignmentMode",
+      "FormTextAlignment",
+      "FormTitlePlacement",
+      "FormType",
+      "Image",
+      "IndicatorAppearance",
+      "StatefulColor",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.FormItemAppearance"
+  },
+  {
+    "componentName" : "Image",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "width",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "height",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ImageAppearance",
+    "resolvedTypes" : [
+      "ImageSizeConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ImageAppearance"
+  },
+  {
+    "componentName" : "Indicator",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "height",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "width",
+        "methodName" : "width",
+        "paramName" : "width",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.IndicatorAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "PathDrawer",
+      "StatefulFillStyle"
+    ],
+    "styleQualifiedName" : "SDDSComponents.IndicatorAppearance"
+  },
+  {
+    "componentName" : "List",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "listItemStyle",
+        "methodName" : "listItemAppearance",
+        "paramName" : "listItemAppearance",
+        "paramQualifiedType" : "ListItemAppearance",
+        "paramSimpleType" : "ListItemAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ListItemAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "dividerStyle",
+        "methodName" : "dividerAppearance",
+        "paramName" : "dividerAppearance",
+        "paramQualifiedType" : "DividerAppearance",
+        "paramSimpleType" : "DividerAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "DividerAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "scrollBarStyle",
+        "methodName" : "scrollBarAppearance",
+        "paramName" : "scrollBarAppearance",
+        "paramQualifiedType" : "ScrollbarAppearance",
+        "paramSimpleType" : "ScrollbarAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ScrollbarAppearance"
+      },
+      {
+        "group" : "size",
+        "id" : "gap",
+        "methodName" : "gap",
+        "paramName" : "gap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ListAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "DividerAppearance",
+      "ListItemAppearance",
+      "PathDrawer",
+      "ScrollbarAppearance",
+      "StatefulFillStyle"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ListAppearance"
+  },
+  {
+    "componentName" : "ListItem",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "height",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "labelTypography",
+        "paramName" : "labelTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "subtitleStyle",
+        "methodName" : "subtitleTypography",
+        "paramName" : "subtitleTypography",
+        "paramQualifiedType" : "TypographyConfiguration?",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingEnd",
+        "methodName" : "contentPaddingEnd",
+        "paramName" : "contentPaddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingStart",
+        "methodName" : "contentPaddingStart",
+        "paramName" : "contentPaddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "titleStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "disclosureIcon",
+        "methodName" : "disclosureIcon",
+        "paramName" : "disclosureIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "labelColor",
+        "paramName" : "labelColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "titleColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "subtitleColor",
+        "methodName" : "subtitleColor",
+        "paramName" : "subtitleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "disclosureIconColor",
+        "methodName" : "disclosureIconColor",
+        "paramName" : "disclosureIconColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "counterStyle",
+        "methodName" : "counterAppearance",
+        "paramName" : "counterAppearance",
+        "paramQualifiedType" : "CounterAppearance?",
+        "paramSimpleType" : "CounterAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CounterAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ListItemAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CounterAppearance",
+      "Image",
+      "PathDrawer",
+      "StatefulFillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ListItemAppearance"
+  },
+  {
+    "componentName" : "Loader",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "spinnerStyle",
+        "methodName" : "spinnerAppearance",
+        "paramName" : "spinnerAppearance",
+        "paramQualifiedType" : "SpinnerAppearance?",
+        "paramSimpleType" : "SpinnerAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "SpinnerAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "circularProgressStyle",
+        "methodName" : "circularProgressAppearance",
+        "paramName" : "circularProgressAppearance",
+        "paramQualifiedType" : "CircularProgressBarAppearance?",
+        "paramSimpleType" : "CircularProgressBarAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CircularProgressBarAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.LoaderAppearance",
+    "resolvedTypes" : [
+      "CircularProgressBarAppearance",
+      "LoaderSizeConfiguration",
+      "SpinnerAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.LoaderAppearance"
+  },
+  {
+    "componentName" : "Modal",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "closeColor",
+        "methodName" : "closeColor",
+        "paramName" : "closeColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "closeSize",
+        "methodName" : "closeSize",
+        "paramName" : "closeSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ModalAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer",
+      "ShadowToken"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ModalAppearance"
+  },
+  {
+    "componentName" : "NavigationBarInternalPage",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backIconColor",
+        "methodName" : "backIconColor",
+        "paramName" : "backIconColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "actionStartColor",
+        "methodName" : "actionStartColor",
+        "paramName" : "actionStartColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "actionEndColor",
+        "methodName" : "actionEndColor",
+        "paramName" : "actionEndColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "backIcon",
+        "methodName" : "backIcon",
+        "paramName" : "backIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "size",
+        "id" : "backIconMargin",
+        "methodName" : "backIconMargin",
+        "paramName" : "backIconMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "horizontalSpacing",
+        "methodName" : "horizontalSpacing",
+        "paramName" : "horizontalSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textBlockTopMargin",
+        "methodName" : "textBlockTopMargin",
+        "paramName" : "textBlockTopMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "bottomShape",
+        "methodName" : "bottomShape",
+        "paramName" : "bottomShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.NavigationBarInternalPageAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "Image",
+      "PathDrawer",
+      "ShadowToken",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.NavigationBarInternalPageAppearance"
+  },
+  {
+    "componentName" : "NavigationBarMainPage",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "actionStartColor",
+        "methodName" : "actionStartColor",
+        "paramName" : "actionStartColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "actionEndColor",
+        "methodName" : "actionEndColor",
+        "paramName" : "actionEndColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "horizontalSpacing",
+        "methodName" : "horizontalSpacing",
+        "paramName" : "horizontalSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textBlockTopMargin",
+        "methodName" : "textBlockTopMargin",
+        "paramName" : "textBlockTopMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "bottomShape",
+        "methodName" : "bottomShape",
+        "paramName" : "bottomShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.NavigationBarMainPageAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer",
+      "ShadowToken",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.NavigationBarMainPageAppearance"
+  },
+  {
+    "componentName" : "Note",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "iconColor",
+        "methodName" : "iconColor",
+        "paramName" : "iconColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "closeColor",
+        "methodName" : "closeColor",
+        "paramName" : "closeColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "titleColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "titleStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "titlePaddingEnd",
+        "methodName" : "titlePaddingEnd",
+        "paramName" : "titlePaddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "iconSize",
+        "methodName" : "iconSize",
+        "paramName" : "iconSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentBeforeEndMargin",
+        "methodName" : "contentBeforeEndMargin",
+        "paramName" : "contentBeforeEndMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textTopMargin",
+        "methodName" : "textTopMargin",
+        "paramName" : "textTopMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "actionTopMargin",
+        "methodName" : "actionTopMargin",
+        "paramName" : "actionTopMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "closeTopMargin",
+        "methodName" : "closeTopMargin",
+        "paramName" : "closeTopMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "closeEndMargin",
+        "methodName" : "closeEndMargin",
+        "paramName" : "closeEndMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "closeSize",
+        "methodName" : "closeSize",
+        "paramName" : "closeSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentBeforeArrangement",
+        "methodName" : "contentBeforeArrangement",
+        "paramName" : "contentBeforeArrangement",
+        "paramQualifiedType" : "NoteContentBeforeArrangement",
+        "paramSimpleType" : "NoteContentBeforeArrangement",
+        "type" : "value",
+        "valueQualifiedType" : "NoteContentBeforeArrangement"
+      },
+      {
+        "group" : "root",
+        "id" : "closeIcon",
+        "methodName" : "closeIcon",
+        "paramName" : "closeIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "linkButtonStyle",
+        "methodName" : "linkButtonAppearance",
+        "paramName" : "linkButtonAppearance",
+        "paramQualifiedType" : "ButtonAppearance?",
+        "paramSimpleType" : "ButtonAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ButtonAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.NoteAppearance",
+    "resolvedTypes" : [
+      "ButtonAppearance",
+      "CGFloat",
+      "ColorToken",
+      "Image",
+      "NoteContentBeforeArrangement",
+      "PathDrawer",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.NoteAppearance"
+  },
+  {
+    "componentName" : "NoteCompact",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "iconColor",
+        "methodName" : "iconColor",
+        "paramName" : "iconColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "closeColor",
+        "methodName" : "closeColor",
+        "paramName" : "closeColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "titleColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "titleStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "iconSize",
+        "methodName" : "iconSize",
+        "paramName" : "iconSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentBeforeEndMargin",
+        "methodName" : "contentBeforeEndMargin",
+        "paramName" : "contentBeforeEndMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textTopMargin",
+        "methodName" : "textTopMargin",
+        "paramName" : "textTopMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "actionStartMargin",
+        "methodName" : "actionStartMargin",
+        "paramName" : "actionStartMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "actionEndMargin",
+        "methodName" : "actionEndMargin",
+        "paramName" : "actionEndMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "closeStartMargin",
+        "methodName" : "closeStartMargin",
+        "paramName" : "closeStartMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "closeSize",
+        "methodName" : "closeSize",
+        "paramName" : "closeSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentBeforeArrangement",
+        "methodName" : "contentBeforeArrangement",
+        "paramName" : "contentBeforeArrangement",
+        "paramQualifiedType" : "NoteCompactContentBeforeArrangement",
+        "paramSimpleType" : "NoteCompactContentBeforeArrangement",
+        "type" : "value",
+        "valueQualifiedType" : "NoteCompactContentBeforeArrangement"
+      },
+      {
+        "group" : "root",
+        "id" : "closeIcon",
+        "methodName" : "closeIcon",
+        "paramName" : "closeIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "linkButtonStyle",
+        "methodName" : "linkButtonAppearance",
+        "paramName" : "linkButtonAppearance",
+        "paramQualifiedType" : "ButtonAppearance?",
+        "paramSimpleType" : "ButtonAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ButtonAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.NoteCompactAppearance",
+    "resolvedTypes" : [
+      "ButtonAppearance",
+      "CGFloat",
+      "ColorToken",
+      "Image",
+      "NoteCompactContentBeforeArrangement",
+      "PathDrawer",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.NoteCompactAppearance"
+  },
+  {
+    "componentName" : "Notification",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "closeColor",
+        "methodName" : "closeColor",
+        "paramName" : "closeColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "closeAlignment",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "value",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "closeSize",
+        "methodName" : "closeSize",
+        "paramName" : "closeSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.NotificationAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer"
+    ],
+    "styleQualifiedName" : "SDDSComponents.NotificationAppearance"
+  },
+  {
+    "componentName" : "NotificationContent",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "iconColor",
+        "methodName" : "iconColor",
+        "paramName" : "iconColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "titleColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "iconSize",
+        "methodName" : "iconSize",
+        "paramName" : "iconSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "buttonGroupTopPadding",
+        "methodName" : "buttonGroupTopPadding",
+        "paramName" : "buttonGroupTopPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textPadding",
+        "methodName" : "textPadding",
+        "paramName" : "textPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textBoxBottomPadding",
+        "methodName" : "textBoxBottomPadding",
+        "paramName" : "textBoxBottomPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentTopPadding",
+        "methodName" : "contentTopPadding",
+        "paramName" : "contentTopPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentStartPadding",
+        "methodName" : "contentStartPadding",
+        "paramName" : "contentStartPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentEndPadding",
+        "methodName" : "contentEndPadding",
+        "paramName" : "contentEndPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "iconMargin",
+        "methodName" : "iconMargin",
+        "paramName" : "iconMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textBoxStartPadding",
+        "methodName" : "textBoxStartPadding",
+        "paramName" : "textBoxStartPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textBoxTopPadding",
+        "methodName" : "textBoxTopPadding",
+        "paramName" : "textBoxTopPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "buttonGroupStartPadding",
+        "methodName" : "buttonGroupStartPadding",
+        "paramName" : "buttonGroupStartPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "titleStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "buttonLayout",
+        "methodName" : "buttonLayout",
+        "paramName" : "buttonLayout",
+        "paramQualifiedType" : "NotificationContentButtonLayout",
+        "paramSimpleType" : "NotificationContentButtonLayout",
+        "type" : "value",
+        "valueQualifiedType" : "NotificationContentButtonLayout"
+      },
+      {
+        "group" : "root",
+        "id" : "iconPlacement",
+        "methodName" : "iconPlacement",
+        "paramName" : "iconPlacement",
+        "paramQualifiedType" : "NotificationContentIconPlacement",
+        "paramSimpleType" : "NotificationContentIconPlacement",
+        "type" : "icon",
+        "valueQualifiedType" : "NotificationContentIconPlacement"
+      },
+      {
+        "group" : "root",
+        "id" : "buttonGroupStyle",
+        "methodName" : "buttonGroupAppearance",
+        "paramName" : "buttonGroupAppearance",
+        "paramQualifiedType" : "ButtonGroupAppearance?",
+        "paramSimpleType" : "ButtonGroupAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ButtonGroupAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.NotificationContentAppearance",
+    "resolvedTypes" : [
+      "ButtonGroupAppearance",
+      "CGFloat",
+      "ColorToken",
+      "NotificationContentButtonLayout",
+      "NotificationContentIconPlacement",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.NotificationContentAppearance"
+  },
+  {
+    "componentName" : "Overlay",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "FillStyle",
+        "paramSimpleType" : "FillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "FillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "blurRadius",
+        "methodName" : "blurRadius",
+        "paramName" : "blurRadius",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.OverlayAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "FillStyle",
+      "OverlaySizeConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.OverlayAppearance"
+  },
+  {
+    "componentName" : "PaginationDots",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "orientation",
+        "methodName" : "orientation",
+        "paramName" : "orientation",
+        "paramQualifiedType" : "PaginationDotsOrientation",
+        "paramSimpleType" : "PaginationDotsOrientation",
+        "type" : "value",
+        "valueQualifiedType" : "PaginationDotsOrientation"
+      },
+      {
+        "group" : "size",
+        "id" : "gap",
+        "methodName" : "gap",
+        "paramName" : "gap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "edgeShrinkFactor",
+        "methodName" : "edgeShrinkFactor",
+        "paramName" : "edgeShrinkFactor",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "dotBackgroundColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "dotWidth",
+        "methodName" : "dotWidth",
+        "paramName" : "dotWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "dotHeight",
+        "methodName" : "dotHeight",
+        "paramName" : "dotHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "edgeCount",
+        "methodName" : "edgeCount",
+        "paramName" : "edgeCount",
+        "paramQualifiedType" : "Int",
+        "paramSimpleType" : "Int",
+        "type" : "int",
+        "valueQualifiedType" : "Int"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.PaginationDotsAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "Int",
+      "PaginationDotsOrientation"
+    ],
+    "styleQualifiedName" : "SDDSComponents.PaginationDotsAppearance"
+  },
+  {
+    "componentName" : "Popover",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "width",
+        "methodName" : "width",
+        "paramName" : "width",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "tailWidth",
+        "methodName" : "tailWidth",
+        "paramName" : "tailWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "tailHeight",
+        "methodName" : "tailHeight",
+        "paramName" : "tailHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "tailPadding",
+        "methodName" : "tailPadding",
+        "paramName" : "tailPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "offset",
+        "methodName" : "offset",
+        "paramName" : "offset",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      },
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.PopoverAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer",
+      "ShadowToken"
+    ],
+    "styleQualifiedName" : "SDDSComponents.PopoverAppearance"
+  },
+  {
+    "componentName" : "ProgressBar",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "indicatorColor",
+        "methodName" : "tintFillStyle",
+        "paramName" : "tintFillStyle",
+        "paramQualifiedType" : "FillStyle",
+        "paramSimpleType" : "FillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "FillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "trackColor",
+        "paramName" : "trackColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorShape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundShape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "backgroundHeight",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "indicatorHeight",
+        "methodName" : "indicatorHeight",
+        "paramName" : "indicatorHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ProgressBarAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "FillStyle",
+      "PathDrawer"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ProgressBarAppearance"
+  },
+  {
+    "componentName" : "Radiobox",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "togglePadding",
+        "methodName" : "togglePaddings",
+        "paramName" : "togglePaddings",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleBorderWidth",
+        "methodName" : "lineWidth",
+        "paramName" : "lineWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleWidth",
+        "methodName" : "width",
+        "paramName" : "width",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleHeight",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleIconWidth",
+        "methodName" : "toggleCheckedIconWidth",
+        "paramName" : "toggleCheckedIconWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleIconHeight",
+        "methodName" : "toggleCheckedIconHeight",
+        "paramName" : "toggleCheckedIconHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "textPadding",
+        "methodName" : "horizontalGap",
+        "paramName" : "horizontalGap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "descriptionPadding",
+        "methodName" : "verticalGap",
+        "paramName" : "verticalGap",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleIndeterminateWidth",
+        "methodName" : "toggleIndeterminateIconWidth",
+        "paramName" : "toggleIndeterminateIconWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleIndeterminateHeight",
+        "methodName" : "toggleIndeterminateIconHeight",
+        "paramName" : "toggleIndeterminateIconHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionStyle",
+        "methodName" : "subtitleTypography",
+        "paramName" : "subtitleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "toggleIndeterminateIconColor",
+        "methodName" : "toggleIndeterminateIconColor",
+        "paramName" : "toggleIndeterminateIconColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleColor",
+        "methodName" : "toggleColor",
+        "paramName" : "toggleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleBorderColor",
+        "methodName" : "borderColor",
+        "paramName" : "borderColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionColor",
+        "methodName" : "subtitleColor",
+        "paramName" : "subtitleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleIconColor",
+        "methodName" : "checkedIconColor",
+        "paramName" : "checkedIconColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.RadioboxAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "PathDrawer",
+      "StatefulFillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.RadioboxAppearance"
+  },
+  {
+    "componentName" : "RadioboxGroup",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "itemSpacing",
+        "methodName" : "verticalSpacing",
+        "paramName" : "verticalSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "radioBoxStyle",
+        "methodName" : "radioboxAppearance",
+        "paramName" : "radioboxAppearance",
+        "paramQualifiedType" : "RadioboxAppearance",
+        "paramSimpleType" : "RadioboxAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "RadioboxAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.RadioboxGroupAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "RadioboxAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.RadioboxGroupAppearance"
+  },
+  {
+    "componentName" : "Scrollbar",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "thumbColor",
+        "methodName" : "thumbColor",
+        "paramName" : "thumbColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "trackColor",
+        "methodName" : "trackColor",
+        "paramName" : "trackColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "width",
+        "methodName" : "width",
+        "paramName" : "width",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "hoverExpandFactor",
+        "methodName" : "hoverExpandFactor",
+        "paramName" : "hoverExpandFactor",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ScrollbarAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ScrollbarAppearance"
+  },
+  {
+    "componentName" : "Segment",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "segmentItemStyle",
+        "methodName" : "segmentItemAppearance",
+        "paramName" : "segmentItemAppearance",
+        "paramQualifiedType" : "SegmentItemAppearance",
+        "paramSimpleType" : "SegmentItemAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "SegmentItemAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "paddingStart",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "paddingEnd",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "paddingTop",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "paddingBottom",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.SegmentAppearance",
+    "resolvedTypes" : [
+      "EdgeInsets",
+      "PathDrawer",
+      "SegmentItemAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.SegmentAppearance"
+  },
+  {
+    "componentName" : "SegmentItem",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "shapeStyle",
+        "paramName" : "shapeStyle",
+        "paramQualifiedType" : "ComponentShapeStyle",
+        "paramSimpleType" : "ComponentShapeStyle",
+        "type" : "shape",
+        "valueQualifiedType" : "ComponentShapeStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "valueColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "startContentColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "endContentColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "paddingStart",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "paddingEnd",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "minHeight",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "minWidth",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "startContentSize",
+        "methodName" : "startContentSize",
+        "paramName" : "startContentSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "endContentSize",
+        "methodName" : "endContentSize",
+        "paramName" : "endContentSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "root",
+        "id" : "iconMargin",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "counterMargin",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "valueMargin",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "valueStyle",
+        "methodName" : "subtitleTypography",
+        "paramName" : "subtitleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "counterStyle",
+        "methodName" : "counterAppearance",
+        "paramName" : "counterAppearance",
+        "paramQualifiedType" : "CounterAppearance",
+        "paramSimpleType" : "CounterAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CounterAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.SegmentItemAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CGSize",
+      "ComponentShapeStyle",
+      "CounterAppearance",
+      "EdgeInsets",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.SegmentItemAppearance"
+  },
+  {
+    "componentName" : "Select",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "dropdownStyle",
+        "methodName" : "dropdownAppearance",
+        "paramName" : "dropdownAppearance",
+        "paramQualifiedType" : "DropdownMenuAppearance",
+        "paramSimpleType" : "DropdownMenuAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "DropdownMenuAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "textFieldStyle",
+        "methodName" : "textFieldAppearance",
+        "paramName" : "textFieldAppearance",
+        "paramQualifiedType" : "TextFieldAppearance",
+        "paramSimpleType" : "TextFieldAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "TextFieldAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "buttonStyle",
+        "methodName" : "buttonAppearance",
+        "paramName" : "buttonAppearance",
+        "paramQualifiedType" : "ButtonAppearance",
+        "paramSimpleType" : "ButtonAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ButtonAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "selectItemStyle",
+        "methodName" : "selectItemAppearance",
+        "paramName" : "selectItemAppearance",
+        "paramQualifiedType" : "SelectItemAppearance",
+        "paramSimpleType" : "SelectItemAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "SelectItemAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.SelectAppearance",
+    "resolvedTypes" : [
+      "ButtonAppearance",
+      "DropdownMenuAppearance",
+      "SelectItemAppearance",
+      "SelectSizeConfiguration",
+      "TextFieldAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.SelectAppearance"
+  },
+  {
+    "componentName" : "SelectItem",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "itemType",
+        "methodName" : "itemType",
+        "paramName" : "itemType",
+        "paramQualifiedType" : "SelectItemType",
+        "paramSimpleType" : "SelectItemType",
+        "type" : "value",
+        "valueQualifiedType" : "SelectItemType"
+      },
+      {
+        "group" : "root",
+        "id" : "iconColor",
+        "methodName" : "iconColor",
+        "paramName" : "iconColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "height",
+        "methodName" : "height",
+        "paramName" : "height",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "controlMargin",
+        "methodName" : "controlMargin",
+        "paramName" : "controlMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "controlSize",
+        "methodName" : "controlSize",
+        "paramName" : "controlSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "cellStyle",
+        "methodName" : "cellAppearance",
+        "paramName" : "cellAppearance",
+        "paramQualifiedType" : "CellAppearance",
+        "paramSimpleType" : "CellAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CellAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "checkboxStyle",
+        "methodName" : "checkboxAppearance",
+        "paramName" : "checkboxAppearance",
+        "paramQualifiedType" : "CheckboxAppearance?",
+        "paramSimpleType" : "CheckboxAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CheckboxAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "icon",
+        "methodName" : "icon",
+        "paramName" : "icon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.SelectItemAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CellAppearance",
+      "CheckboxAppearance",
+      "ColorToken",
+      "Image",
+      "PathDrawer",
+      "SelectItemType"
+    ],
+    "styleQualifiedName" : "SDDSComponents.SelectItemAppearance"
+  },
+  {
+    "componentName" : "Skeleton",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "root",
+        "id" : "gradient",
+        "methodName" : "gradient",
+        "paramName" : "gradient",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "duration",
+        "methodName" : "duration",
+        "paramName" : "duration",
+        "paramQualifiedType" : "Double",
+        "paramSimpleType" : "Double",
+        "type" : "dimension",
+        "valueQualifiedType" : "Double"
+      },
+      {
+        "group" : "root",
+        "id" : "hoverExpandFactor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.SkeletonAppearance",
+    "resolvedTypes" : [
+      "Double",
+      "PathDrawer",
+      "SkeletonSizeConfiguration",
+      "StatefulFillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.SkeletonAppearance"
+  },
+  {
+    "componentName" : "Spinner",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "size",
+        "id" : "angle",
+        "methodName" : "angle",
+        "paramName" : "angle",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "strokeCap",
+        "methodName" : "strokeCap",
+        "paramName" : "strokeCap",
+        "paramQualifiedType" : "StrokeCap",
+        "paramSimpleType" : "StrokeCap",
+        "type" : "value",
+        "valueQualifiedType" : "StrokeCap"
+      },
+      {
+        "group" : "size",
+        "id" : "size",
+        "methodName" : "size",
+        "paramName" : "size",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "padding",
+        "methodName" : "padding",
+        "paramName" : "padding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "startColor",
+        "methodName" : "startColor",
+        "paramName" : "startColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "endColor",
+        "methodName" : "endColor",
+        "paramName" : "endColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.SpinnerAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "StatefulFillStyle",
+      "StrokeCap"
+    ],
+    "styleQualifiedName" : "SDDSComponents.SpinnerAppearance"
+  },
+  {
+    "componentName" : "Switch",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "textPadding",
+        "methodName" : "textPadding",
+        "paramName" : "textPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionStyle",
+        "methodName" : "subtitleTypography",
+        "paramName" : "subtitleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "descriptionPadding",
+        "methodName" : "descriptionPadding",
+        "paramName" : "descriptionPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "toggleTrackColor",
+        "paramName" : "toggleTrackColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionColor",
+        "methodName" : "subtitleColor",
+        "paramName" : "subtitleColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleThumbHeight",
+        "methodName" : "toggleThumbHeight",
+        "paramName" : "toggleThumbHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleThumbPadding",
+        "methodName" : "toggleThumbPadding",
+        "paramName" : "toggleThumbPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleThumbWidth",
+        "methodName" : "toggleThumbWidth",
+        "paramName" : "toggleThumbWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleThumbColor",
+        "methodName" : "toggleThumbColor",
+        "paramName" : "toggleThumbColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleThumbShape",
+        "methodName" : "toggleThumbColor",
+        "paramName" : "toggleThumbColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleTrackHeight",
+        "methodName" : "toggleTrackHeight",
+        "paramName" : "toggleTrackHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "toggleTrackWidth",
+        "methodName" : "toggleTrackWidth",
+        "paramName" : "toggleTrackWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleTrackColor",
+        "methodName" : "toggleTrackColor",
+        "paramName" : "toggleTrackColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleTrackBorderColor",
+        "methodName" : "toggleTrackBorderColor",
+        "paramName" : "toggleTrackBorderColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "toggleTrackShape",
+        "methodName" : "toggleTrackColor",
+        "paramName" : "toggleTrackColor",
+        "paramQualifiedType" : "StatefulFillStyle",
+        "paramSimpleType" : "StatefulFillStyle",
+        "type" : "color",
+        "valueQualifiedType" : "StatefulFillStyle"
+      },
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.SwitchAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "PathDrawer",
+      "StatefulFillStyle",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.SwitchAppearance"
+  },
+  {
+    "componentName" : "TabBar",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "contentPaddingStart",
+        "methodName" : "contentPaddingStart",
+        "paramName" : "contentPaddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingEnd",
+        "methodName" : "contentPaddingEnd",
+        "paramName" : "contentPaddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingTop",
+        "methodName" : "contentPaddingTop",
+        "paramName" : "contentPaddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingBottom",
+        "methodName" : "contentPaddingBottom",
+        "paramName" : "contentPaddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "itemSpacing",
+        "methodName" : "itemSpacing",
+        "paramName" : "itemSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundBlurColor",
+        "methodName" : "backgroundBlurColor",
+        "paramName" : "backgroundBlurColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundBlurRadius",
+        "methodName" : "backgroundBlurRadius",
+        "paramName" : "backgroundBlurRadius",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "topShape",
+        "methodName" : "topShape",
+        "paramName" : "topShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      },
+      {
+        "group" : "size",
+        "id" : "dividerThickness",
+        "methodName" : "dividerThickness",
+        "paramName" : "dividerThickness",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "dividerColor",
+        "methodName" : "dividerColor",
+        "paramName" : "dividerColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "tabBarItemStyle",
+        "methodName" : "tabBarItemAppearance",
+        "paramName" : "tabBarItemAppearance",
+        "paramQualifiedType" : "TabBarItemAppearance",
+        "paramSimpleType" : "TabBarItemAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "TabBarItemAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.TabBarAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer",
+      "ShadowToken",
+      "TabBarItemAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.TabBarAppearance"
+  },
+  {
+    "componentName" : "TabBarIsland",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "topShape",
+        "methodName" : "topShape",
+        "paramName" : "topShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "bottomShape",
+        "methodName" : "bottomShape",
+        "paramName" : "bottomShape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingStart",
+        "methodName" : "contentPaddingStart",
+        "paramName" : "contentPaddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingEnd",
+        "methodName" : "contentPaddingEnd",
+        "paramName" : "contentPaddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingTop",
+        "methodName" : "contentPaddingTop",
+        "paramName" : "contentPaddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentPaddingBottom",
+        "methodName" : "contentPaddingBottom",
+        "paramName" : "contentPaddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "itemSpacing",
+        "methodName" : "itemSpacing",
+        "paramName" : "itemSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundBlurColor",
+        "methodName" : "backgroundBlurColor",
+        "paramName" : "backgroundBlurColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundBlurRadius",
+        "methodName" : "backgroundBlurRadius",
+        "paramName" : "backgroundBlurRadius",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      },
+      {
+        "group" : "root",
+        "id" : "tabBarItemStyle",
+        "methodName" : "tabBarItemAppearance",
+        "paramName" : "tabBarItemAppearance",
+        "paramQualifiedType" : "TabBarItemAppearance",
+        "paramSimpleType" : "TabBarItemAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "TabBarItemAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.TabBarIslandAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer",
+      "ShadowToken",
+      "TabBarItemAppearance"
+    ],
+    "styleQualifiedName" : "SDDSComponents.TabBarIslandAppearance"
+  },
+  {
+    "componentName" : "TabBarItem",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "labelTypography",
+        "paramName" : "labelTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "iconColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "labelTypography",
+        "paramName" : "labelTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "labelPlacement",
+        "methodName" : "labelPlacement",
+        "paramName" : "labelPlacement",
+        "paramQualifiedType" : "TabBarItemLabelPlacement",
+        "paramSimpleType" : "TabBarItemLabelPlacement",
+        "type" : "value",
+        "valueQualifiedType" : "TabBarItemLabelPlacement"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "minHeight",
+        "methodName" : "minHeight",
+        "paramName" : "minHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "iconSize",
+        "methodName" : "iconSize",
+        "paramName" : "iconSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "labelPadding",
+        "methodName" : "labelPadding",
+        "paramName" : "labelPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "counterStyle",
+        "methodName" : "counterAppearance",
+        "paramName" : "counterAppearance",
+        "paramQualifiedType" : "CounterAppearance?",
+        "paramSimpleType" : "CounterAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CounterAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorStyle",
+        "methodName" : "indicatorAppearance",
+        "paramName" : "indicatorAppearance",
+        "paramQualifiedType" : "IndicatorAppearance?",
+        "paramSimpleType" : "IndicatorAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "IndicatorAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.TabBarItemAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CounterAppearance",
+      "IndicatorAppearance",
+      "PathDrawer",
+      "TabBarItemLabelPlacement",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.TabBarItemAppearance"
+  },
+  {
+    "componentName" : "TabItem",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "disableAlpha",
+        "methodName" : "disableAlpha",
+        "paramName" : "disableAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "minHeight",
+        "methodName" : "minHeight",
+        "paramName" : "minHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "startContentSize",
+        "methodName" : "startContentSize",
+        "paramName" : "startContentSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "endContentSize",
+        "methodName" : "endContentSize",
+        "paramName" : "endContentSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "startContentPadding",
+        "methodName" : "startContentPadding",
+        "paramName" : "startContentPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "valuePadding",
+        "methodName" : "valuePadding",
+        "paramName" : "valuePadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "counterPadding",
+        "methodName" : "counterPadding",
+        "paramName" : "counterPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "actionPadding",
+        "methodName" : "actionPadding",
+        "paramName" : "actionPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "iconPadding",
+        "methodName" : "iconPadding",
+        "paramName" : "iconPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "actionSize",
+        "methodName" : "actionSize",
+        "paramName" : "actionSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "actionIconSize",
+        "methodName" : "actionIconSize",
+        "paramName" : "actionIconSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "counterOffsetX",
+        "methodName" : "counterOffsetX",
+        "paramName" : "counterOffsetX",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "counterOffsetY",
+        "methodName" : "counterOffsetY",
+        "paramName" : "counterOffsetY",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelTypography",
+        "methodName" : "labelTypography",
+        "paramName" : "labelTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "valueTypography",
+        "methodName" : "valueTypography",
+        "paramName" : "valueTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "counterAppearance",
+        "methodName" : "counterAppearance",
+        "paramName" : "counterAppearance",
+        "paramQualifiedType" : "CounterAppearance?",
+        "paramSimpleType" : "CounterAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "CounterAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "actionIcon",
+        "methodName" : "actionIcon",
+        "paramName" : "actionIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorColor",
+        "methodName" : "indicatorColor",
+        "paramName" : "indicatorColor",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.TabItemAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "CounterAppearance",
+      "Image",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.TabItemAppearance"
+  },
+  {
+    "componentName" : "Tabs",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "dividerEnabled",
+        "methodName" : "dividerEnabled",
+        "paramName" : "dividerEnabled",
+        "paramQualifiedType" : "Bool",
+        "paramSimpleType" : "Bool",
+        "type" : "boolean",
+        "valueQualifiedType" : "Bool"
+      },
+      {
+        "group" : "size",
+        "id" : "indicatorEnabled",
+        "methodName" : "indicatorEnabled",
+        "paramName" : "indicatorEnabled",
+        "paramQualifiedType" : "Bool",
+        "paramSimpleType" : "Bool",
+        "type" : "boolean",
+        "valueQualifiedType" : "Bool"
+      },
+      {
+        "group" : "size",
+        "id" : "indicatorThickness",
+        "methodName" : "indicatorThickness",
+        "paramName" : "indicatorThickness",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "minSpacing",
+        "methodName" : "minSpacing",
+        "paramName" : "minSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "orientation",
+        "methodName" : "orientation",
+        "paramName" : "orientation",
+        "paramQualifiedType" : "TabsOrientation",
+        "paramSimpleType" : "TabsOrientation",
+        "type" : "value",
+        "valueQualifiedType" : "TabsOrientation"
+      },
+      {
+        "group" : "size",
+        "id" : "overflowIconSize",
+        "methodName" : "overflowIconSize",
+        "paramName" : "overflowIconSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "disclosureIconSize",
+        "methodName" : "disclosureIconSize",
+        "paramName" : "disclosureIconSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorColor",
+        "methodName" : "indicatorColor",
+        "paramName" : "indicatorColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "overflowNextIcon",
+        "methodName" : "overflowNextIcon",
+        "paramName" : "overflowNextIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "overflowNextIconColor",
+        "methodName" : "overflowNextIconColor",
+        "paramName" : "overflowNextIconColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "overflowPrevIcon",
+        "methodName" : "overflowPrevIcon",
+        "paramName" : "overflowPrevIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "overflowPrevIconColor",
+        "methodName" : "overflowPrevIconColor",
+        "paramName" : "overflowPrevIconColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "dividerAppearance",
+        "methodName" : "dividerAppearance",
+        "paramName" : "dividerAppearance",
+        "paramQualifiedType" : "DividerAppearance?",
+        "paramSimpleType" : "DividerAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "DividerAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "tabItemAppearance",
+        "methodName" : "tabItemAppearance",
+        "paramName" : "tabItemAppearance",
+        "paramQualifiedType" : "TabItemAppearance",
+        "paramSimpleType" : "TabItemAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "TabItemAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "dropdownMenuAppearance",
+        "methodName" : "dropdownMenuAppearance",
+        "paramName" : "dropdownMenuAppearance",
+        "paramQualifiedType" : "DropdownMenuAppearance?",
+        "paramSimpleType" : "DropdownMenuAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "DropdownMenuAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "disclosureTextTypography",
+        "methodName" : "disclosureTextTypography",
+        "paramName" : "disclosureTextTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "disclosureIcon",
+        "methodName" : "disclosureIcon",
+        "paramName" : "disclosureIcon",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.TabsAppearance",
+    "resolvedTypes" : [
+      "Bool",
+      "CGFloat",
+      "ColorToken",
+      "DividerAppearance",
+      "DropdownMenuAppearance",
+      "Image",
+      "TabItemAppearance",
+      "TabsOrientation",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.TabsAppearance"
+  },
+  {
+    "componentName" : "TextArea",
+    "params" : [
+      {
+        "group" : "size",
+        "id" : "titleBottomPadding",
+        "methodName" : "titleBottomPadding",
+        "paramName" : "titleBottomPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "titleInnerPadding",
+        "methodName" : "titleInnerPadding",
+        "paramName" : "titleInnerPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "boxLeadingPadding",
+        "methodName" : "boxLeadingPadding",
+        "paramName" : "boxLeadingPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "boxTrailingPadding",
+        "methodName" : "boxTrailingPadding",
+        "paramName" : "boxTrailingPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "boxPaddingBottom",
+        "methodName" : "boxPaddingBottom",
+        "paramName" : "boxPaddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "boxPaddingTop",
+        "methodName" : "boxPaddingTop",
+        "paramName" : "boxPaddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "captionTopPadding",
+        "methodName" : "captionTopPadding",
+        "paramName" : "captionTopPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "captionBottomPadding",
+        "methodName" : "captionBottomPadding",
+        "paramName" : "captionBottomPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "optionalPadding",
+        "methodName" : "optionalPadding",
+        "paramName" : "optionalPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "cornerRadius",
+        "methodName" : "cornerRadius",
+        "paramName" : "cornerRadius",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "iconActionPadding",
+        "methodName" : "iconActionPadding",
+        "paramName" : "iconActionPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "iconActionSize",
+        "methodName" : "iconActionSize",
+        "paramName" : "iconActionSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "chipContainerHorizontalPadding",
+        "methodName" : "chipContainerHorizontalPadding",
+        "paramName" : "chipContainerHorizontalPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "chipsPadding",
+        "methodName" : "chipsPadding",
+        "paramName" : "chipsPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "fieldHeight",
+        "methodName" : "fieldHeight",
+        "paramName" : "fieldHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "indicatorOffset",
+        "methodName" : "indicatorOffset",
+        "paramName" : "indicatorOffset",
+        "paramQualifiedType" : "CGPoint",
+        "paramSimpleType" : "CGPoint",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGPoint"
+      },
+      {
+        "group" : "size",
+        "id" : "indicatorSize",
+        "methodName" : "indicatorSize",
+        "paramName" : "indicatorSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "endContentPadding",
+        "methodName" : "endContentPadding",
+        "paramName" : "endContentPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "scrollBarThickness",
+        "methodName" : "scrollBarThickness",
+        "paramName" : "scrollBarThickness",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "scrollBarPaddingTop",
+        "methodName" : "scrollBarPaddingTop",
+        "paramName" : "scrollBarPaddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "scrollBarPaddingBottom",
+        "methodName" : "scrollBarPaddingBottom",
+        "paramName" : "scrollBarPaddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "scrollBarPaddingEnd",
+        "methodName" : "scrollBarPaddingEnd",
+        "paramName" : "scrollBarPaddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "chipAppearance",
+        "methodName" : "chipAppearance",
+        "paramName" : "chipAppearance",
+        "paramQualifiedType" : "ChipAppearance",
+        "paramSimpleType" : "ChipAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ChipAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "chipGroupAppearance",
+        "methodName" : "chipGroupAppearance",
+        "paramName" : "chipGroupAppearance",
+        "paramQualifiedType" : "ChipGroupAppearance",
+        "paramSimpleType" : "ChipGroupAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ChipGroupAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "labelPlacement",
+        "methodName" : "labelPlacement",
+        "paramName" : "labelPlacement",
+        "paramQualifiedType" : "TextAreaLabelPlacement",
+        "paramSimpleType" : "TextAreaLabelPlacement",
+        "type" : "value",
+        "valueQualifiedType" : "TextAreaLabelPlacement"
+      },
+      {
+        "group" : "root",
+        "id" : "requiredPlacement",
+        "methodName" : "requiredPlacement",
+        "paramName" : "requiredPlacement",
+        "paramQualifiedType" : "TextAreaRequiredPlacement",
+        "paramSimpleType" : "TextAreaRequiredPlacement",
+        "type" : "value",
+        "valueQualifiedType" : "TextAreaRequiredPlacement"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColorFocused",
+        "methodName" : "backgroundColorFocused",
+        "paramName" : "backgroundColorFocused",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColorReadOnly",
+        "methodName" : "backgroundColorReadOnly",
+        "paramName" : "backgroundColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "borderColor",
+        "methodName" : "borderColor",
+        "paramName" : "borderColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "captionColor",
+        "methodName" : "captionColor",
+        "paramName" : "captionColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "captionColorFocused",
+        "methodName" : "captionColorFocused",
+        "paramName" : "captionColorFocused",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "captionColorReadOnly",
+        "methodName" : "captionColorReadOnly",
+        "paramName" : "captionColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "captionTypography",
+        "methodName" : "captionTypography",
+        "paramName" : "captionTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "counterColor",
+        "methodName" : "counterColor",
+        "paramName" : "counterColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "counterColorReadOnly",
+        "methodName" : "counterColorReadOnly",
+        "paramName" : "counterColorReadOnly",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "counterTypography",
+        "methodName" : "counterTypography",
+        "paramName" : "counterTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "cursorColor",
+        "methodName" : "cursorColor",
+        "paramName" : "cursorColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "disabledAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "endContentColor",
+        "methodName" : "endContentColor",
+        "paramName" : "endContentColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "endContentColorReadOnly",
+        "methodName" : "endContentColorReadOnly",
+        "paramName" : "endContentColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "endContentColorFocused",
+        "methodName" : "endContentColorFocused",
+        "paramName" : "endContentColorFocused",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "innerTitleTextAlignment",
+        "methodName" : "innerTitleTextAlignment",
+        "paramName" : "innerTitleTextAlignment",
+        "paramQualifiedType" : "TextAlignment",
+        "paramSimpleType" : "TextAlignment",
+        "type" : "value",
+        "valueQualifiedType" : "TextAlignment"
+      },
+      {
+        "group" : "root",
+        "id" : "innerTitleTypography",
+        "methodName" : "innerTitleTypography",
+        "paramName" : "innerTitleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "inputTextAlignment",
+        "methodName" : "inputTextAlignment",
+        "paramName" : "inputTextAlignment",
+        "paramQualifiedType" : "TextAlignment",
+        "paramSimpleType" : "TextAlignment",
+        "type" : "value",
+        "valueQualifiedType" : "TextAlignment"
+      },
+      {
+        "group" : "root",
+        "id" : "lineColor",
+        "methodName" : "lineColor",
+        "paramName" : "lineColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "lineColorFocused",
+        "methodName" : "lineColorFocused",
+        "paramName" : "lineColorFocused",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "lineColorReadOnly",
+        "methodName" : "lineColorReadOnly",
+        "paramName" : "lineColorReadOnly",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "optionalTitleColor",
+        "methodName" : "optionalTitleColor",
+        "paramName" : "optionalTitleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "placeholderColor",
+        "methodName" : "placeholderColor",
+        "paramName" : "placeholderColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "placeholderColorFocused",
+        "methodName" : "placeholderColorFocused",
+        "paramName" : "placeholderColorFocused",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "placeholderColorReadOnly",
+        "methodName" : "placeholderColorReadOnly",
+        "paramName" : "placeholderColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "requiredIndicatorColor",
+        "methodName" : "requiredIndicatorColor",
+        "paramName" : "requiredIndicatorColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "startContentColor",
+        "methodName" : "startContentColor",
+        "paramName" : "startContentColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "startContentColorReadOnly",
+        "methodName" : "startContentColorReadOnly",
+        "paramName" : "startContentColorReadOnly",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColorFocused",
+        "methodName" : "textColorFocused",
+        "paramName" : "textColorFocused",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColorReadOnly",
+        "methodName" : "textColorReadOnly",
+        "paramName" : "textColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textTypography",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "titleColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "titleTextAlignment",
+        "methodName" : "titleTextAlignment",
+        "paramName" : "titleTextAlignment",
+        "paramQualifiedType" : "TextAlignment",
+        "paramSimpleType" : "TextAlignment",
+        "type" : "value",
+        "valueQualifiedType" : "TextAlignment"
+      },
+      {
+        "group" : "root",
+        "id" : "titleTypography",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "scrollBarTrackColor",
+        "methodName" : "scrollBarTrackColor",
+        "paramName" : "scrollBarTrackColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "scrollBarThumbColor",
+        "methodName" : "scrollBarThumbColor",
+        "paramName" : "scrollBarThumbColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.TextAreaAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CGPoint",
+      "CGSize",
+      "ChipAppearance",
+      "ChipGroupAppearance",
+      "ColorToken",
+      "TextAlignment",
+      "TextAreaLabelPlacement",
+      "TextAreaRequiredPlacement",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.TextAreaAppearance"
+  },
+  {
+    "componentName" : "TextField",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "disableAlpha",
+        "methodName" : "disabledAlpha",
+        "paramName" : "disabledAlpha",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "prefixPadding",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "suffixPadding",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "optionalPadding",
+        "methodName" : "optionalPadding",
+        "paramName" : "optionalPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "helperTextPadding",
+        "methodName" : "captionTopPadding",
+        "paramName" : "captionTopPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "chipsPadding",
+        "methodName" : "chipsPadding",
+        "paramName" : "chipsPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "captionPlacement",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "value",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "counterPlacement",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "value",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "captionStyle",
+        "methodName" : "captionTypography",
+        "paramName" : "captionTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "counterStyle",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "value",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "chipGroupStyle",
+        "methodName" : "chipGroupAppearance",
+        "paramName" : "chipGroupAppearance",
+        "paramQualifiedType" : "ChipGroupAppearance",
+        "paramSimpleType" : "ChipGroupAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ChipGroupAppearance"
+      },
+      {
+        "group" : "root",
+        "id" : "valueColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "valueColorReadOnly",
+        "methodName" : "textColorReadOnly",
+        "paramName" : "textColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "startContentColor",
+        "methodName" : "startContentColor",
+        "paramName" : "startContentColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "startContentColorReadOnly",
+        "methodName" : "startContentColorReadOnly",
+        "paramName" : "startContentColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "endContentColor",
+        "methodName" : "endContentColor",
+        "paramName" : "endContentColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "endContentColorReadOnly",
+        "methodName" : "endContentColorReadOnly",
+        "paramName" : "endContentColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "optionalColor",
+        "methodName" : "optionalTitleColor",
+        "paramName" : "optionalTitleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "counterColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "captionColor",
+        "methodName" : "captionColor",
+        "paramName" : "captionColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "captionColorReadOnly",
+        "methodName" : "captionColorReadOnly",
+        "paramName" : "captionColorReadOnly",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "placeholderColor",
+        "methodName" : "placeholderColor",
+        "paramName" : "placeholderColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "placeholderColorReadOnly",
+        "methodName" : "placeholderColorReadOnly",
+        "paramName" : "placeholderColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "backgroundColorReadOnly",
+        "methodName" : "backgroundColorReadOnly",
+        "paramName" : "backgroundColorReadOnly",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorColor",
+        "methodName" : "requiredIndicatorColor",
+        "paramName" : "requiredIndicatorColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "cursorColor",
+        "methodName" : "cursorColor",
+        "paramName" : "cursorColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "dividerColor",
+        "methodName" : "lineColor",
+        "paramName" : "lineColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "dividerColorReadOnly",
+        "methodName" : "lineColorReadOnly",
+        "paramName" : "lineColorReadOnly",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "lineColor",
+        "methodName" : "lineColor",
+        "paramName" : "lineColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "labelPlacement",
+        "methodName" : "labelPlacement",
+        "paramName" : "labelPlacement",
+        "paramQualifiedType" : "TextFieldLabelPlacement",
+        "paramSimpleType" : "TextFieldLabelPlacement",
+        "type" : "value",
+        "valueQualifiedType" : "TextFieldLabelPlacement"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "cornerRadius",
+        "paramName" : "cornerRadius",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "chipStyle",
+        "methodName" : "chipAppearance",
+        "paramName" : "chipAppearance",
+        "paramQualifiedType" : "ChipAppearance",
+        "paramSimpleType" : "ChipAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "ChipAppearance"
+      },
+      {
+        "group" : "size",
+        "id" : "boxPaddingStart",
+        "methodName" : "boxLeadingPadding",
+        "paramName" : "boxLeadingPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "boxPaddingEnd",
+        "methodName" : "boxTrailingPadding",
+        "paramName" : "boxTrailingPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "boxPaddingTop",
+        "methodName" : "boxPaddingTop",
+        "paramName" : "boxPaddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "boxPaddingBottom",
+        "methodName" : "boxPaddingBottom",
+        "paramName" : "boxPaddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "startContentPadding",
+        "methodName" : "iconPadding",
+        "paramName" : "iconPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "endContentPadding",
+        "methodName" : "iconActionPadding",
+        "paramName" : "iconActionPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "boxMinHeight",
+        "methodName" : "fieldHeight",
+        "paramName" : "fieldHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "alignmentMinHeight",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "startContentSize",
+        "methodName" : "iconSize",
+        "paramName" : "iconSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "size",
+        "id" : "endContentSize",
+        "methodName" : "iconActionSize",
+        "paramName" : "iconActionSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "root",
+        "id" : "valueStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "placeholderStyle",
+        "methodName" : "placeholderColor",
+        "paramName" : "placeholderColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "fieldType",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "value",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "indicatorSize",
+        "methodName" : "indicatorSize",
+        "paramName" : "indicatorSize",
+        "paramQualifiedType" : "CGSize",
+        "paramSimpleType" : "CGSize",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGSize"
+      },
+      {
+        "group" : "root",
+        "id" : "labelColor",
+        "methodName" : "titleColor",
+        "paramName" : "titleColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "labelPadding",
+        "methodName" : "titleBottomPadding",
+        "paramName" : "titleBottomPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "labelStyle",
+        "methodName" : "titleTypography",
+        "paramName" : "titleTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "optionalStyle",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "value",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorOffsetX",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "indicatorOffsetY",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "scrollBarThickness",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "scrollBarPaddingTop",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "scrollBarPaddingBottom",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "scrollBarPaddingEnd",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "dimension",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "scrollBarTrackColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "root",
+        "id" : "scrollBarThumbColor",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "color",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.TextFieldAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "CGPoint",
+      "CGSize",
+      "ChipAppearance",
+      "ChipGroupAppearance",
+      "ColorToken",
+      "TextAlignment",
+      "TextFieldLabelPlacement",
+      "TextFieldRequiredPlacement",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.TextFieldAppearance"
+  },
+  {
+    "componentName" : "Toast",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken?",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "contentStartColor",
+        "methodName" : "contentStartColor",
+        "paramName" : "contentStartColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "contentEndColor",
+        "methodName" : "contentEndColor",
+        "paramName" : "contentEndColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "contentStartSize",
+        "methodName" : "contentStartSize",
+        "paramName" : "contentStartSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentEndSize",
+        "methodName" : "contentEndSize",
+        "paramName" : "contentEndSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentStartPadding",
+        "methodName" : "contentStartPadding",
+        "paramName" : "contentStartPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentEndPadding",
+        "methodName" : "contentEndPadding",
+        "paramName" : "contentEndPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration?",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ToastAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ToastAppearance"
+  },
+  {
+    "componentName" : "Toolbar",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "dividerStyle",
+        "methodName" : "dividerAppearance",
+        "paramName" : "dividerAppearance",
+        "paramQualifiedType" : "DividerAppearance?",
+        "paramSimpleType" : "DividerAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "DividerAppearance"
+      },
+      {
+        "group" : "size",
+        "id" : "orientation",
+        "methodName" : "orientation",
+        "paramName" : "orientation",
+        "paramQualifiedType" : "TabsOrientation",
+        "paramSimpleType" : "TabsOrientation",
+        "type" : "value",
+        "valueQualifiedType" : "TabsOrientation"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "shape",
+        "methodName" : "shape",
+        "paramName" : "shape",
+        "paramQualifiedType" : "PathDrawer",
+        "paramSimpleType" : "PathDrawer",
+        "type" : "value",
+        "valueQualifiedType" : "PathDrawer"
+      },
+      {
+        "group" : "size",
+        "id" : "slotPadding",
+        "methodName" : "slotPadding",
+        "paramName" : "slotPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "dividerMargin",
+        "methodName" : "dividerMargin",
+        "paramName" : "dividerMargin",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.ToolbarAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "DividerAppearance",
+      "PathDrawer",
+      "ShadowToken",
+      "TabsOrientation"
+    ],
+    "styleQualifiedName" : "SDDSComponents.ToolbarAppearance"
+  },
+  {
+    "componentName" : "Tooltip",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "backgroundColor",
+        "methodName" : "backgroundColor",
+        "paramName" : "backgroundColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "textColor",
+        "methodName" : "textColor",
+        "paramName" : "textColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "contentStartColor",
+        "methodName" : "contentStartColor",
+        "paramName" : "contentStartColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "size",
+        "id" : "contentStartSize",
+        "methodName" : "contentStartSize",
+        "paramName" : "contentStartSize",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "shadow",
+        "methodName" : "shadow",
+        "paramName" : "shadow",
+        "paramQualifiedType" : "ShadowToken",
+        "paramSimpleType" : "ShadowToken",
+        "type" : "shadow",
+        "valueQualifiedType" : "ShadowToken"
+      },
+      {
+        "group" : "root",
+        "id" : "shape",
+        "methodName" : "",
+        "paramName" : "",
+        "paramQualifiedType" : "",
+        "paramSimpleType" : "",
+        "type" : "shape",
+        "unmapped" : true,
+        "valueQualifiedType" : ""
+      },
+      {
+        "group" : "size",
+        "id" : "tailPadding",
+        "methodName" : "tailPadding",
+        "paramName" : "tailPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "tailWidth",
+        "methodName" : "tailWidth",
+        "paramName" : "tailWidth",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "tailHeight",
+        "methodName" : "tailHeight",
+        "paramName" : "tailHeight",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "offset",
+        "methodName" : "offset",
+        "paramName" : "offset",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "contentStartPadding",
+        "methodName" : "contentStartPadding",
+        "paramName" : "contentStartPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "root",
+        "id" : "textStyle",
+        "methodName" : "textTypography",
+        "paramName" : "textTypography",
+        "paramQualifiedType" : "TypographyConfiguration?",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingStart",
+        "methodName" : "paddingStart",
+        "paramName" : "paddingStart",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingEnd",
+        "methodName" : "paddingEnd",
+        "paramName" : "paddingEnd",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingTop",
+        "methodName" : "paddingTop",
+        "paramName" : "paddingTop",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "paddingBottom",
+        "methodName" : "paddingBottom",
+        "paramName" : "paddingBottom",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.TooltipAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "PathDrawer",
+      "ShadowToken",
+      "TypographyConfiguration"
+    ],
+    "styleQualifiedName" : "SDDSComponents.TooltipAppearance"
+  },
+  {
+    "componentName" : "Wheel",
+    "params" : [
+      {
+        "group" : "root",
+        "id" : "itemTextColor",
+        "methodName" : "itemTextColor",
+        "paramName" : "itemTextColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "itemTextAfterColor",
+        "methodName" : "itemTextAfterColor",
+        "paramName" : "itemTextAfterColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionColor",
+        "methodName" : "descriptionColor",
+        "paramName" : "descriptionColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "controlIconUpColor",
+        "methodName" : "controlIconUp",
+        "paramName" : "controlIconUp",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "controlIconDownColor",
+        "methodName" : "controlIconDown",
+        "paramName" : "controlIconDown",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "separatorColor",
+        "methodName" : "separatorColor",
+        "paramName" : "separatorColor",
+        "paramQualifiedType" : "ColorToken",
+        "paramSimpleType" : "ColorToken",
+        "type" : "color",
+        "valueQualifiedType" : "ColorToken"
+      },
+      {
+        "group" : "root",
+        "id" : "itemTextStyle",
+        "methodName" : "itemTextTypography",
+        "paramName" : "itemTextTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "itemTextAfterStyle",
+        "methodName" : "itemTextAfterTypography",
+        "paramName" : "itemTextAfterTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "root",
+        "id" : "descriptionStyle",
+        "methodName" : "descriptionTypography",
+        "paramName" : "descriptionTypography",
+        "paramQualifiedType" : "TypographyConfiguration",
+        "paramSimpleType" : "TypographyConfiguration",
+        "type" : "typography",
+        "valueQualifiedType" : "TypographyConfiguration"
+      },
+      {
+        "group" : "size",
+        "id" : "itemTextAfterPadding",
+        "methodName" : "itemTextAfterPadding",
+        "paramName" : "itemTextAfterPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "itemMinSpacing",
+        "methodName" : "itemMinSpacing",
+        "paramName" : "itemMinSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "descriptionPadding",
+        "methodName" : "descriptionPadding",
+        "paramName" : "descriptionPadding",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "separatorSpacing",
+        "methodName" : "separatorSpacing",
+        "paramName" : "separatorSpacing",
+        "paramQualifiedType" : "CGFloat",
+        "paramSimpleType" : "CGFloat",
+        "type" : "dimension",
+        "valueQualifiedType" : "CGFloat"
+      },
+      {
+        "group" : "size",
+        "id" : "itemAlignment",
+        "methodName" : "itemAlignment",
+        "paramName" : "itemAlignment",
+        "paramQualifiedType" : "WheelItemAlignment",
+        "paramSimpleType" : "WheelItemAlignment",
+        "type" : "value",
+        "valueQualifiedType" : "WheelItemAlignment"
+      },
+      {
+        "group" : "root",
+        "id" : "controlIconUp",
+        "methodName" : "controlIconUp",
+        "paramName" : "controlIconUp",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "controlIconDown",
+        "methodName" : "controlIconDown",
+        "paramName" : "controlIconDown",
+        "paramQualifiedType" : "Image?",
+        "paramSimpleType" : "Image",
+        "type" : "icon",
+        "valueQualifiedType" : "Image"
+      },
+      {
+        "group" : "root",
+        "id" : "dividerStyle",
+        "methodName" : "dividerAppearance",
+        "paramName" : "dividerAppearance",
+        "paramQualifiedType" : "DividerAppearance?",
+        "paramSimpleType" : "DividerAppearance",
+        "type" : "component_style",
+        "valueQualifiedType" : "DividerAppearance"
+      }
+    ],
+    "qualifiedName" : "SDDSComponents.WheelAppearance",
+    "resolvedTypes" : [
+      "CGFloat",
+      "ColorToken",
+      "DividerAppearance",
+      "Image",
+      "TypographyConfiguration",
+      "WheelDividerStyle",
+      "WheelItemAlignment"
+    ],
+    "styleQualifiedName" : "SDDSComponents.WheelAppearance"
+  }
+]

--- a/Tools/SDDSApiInfoGenerator/Package.resolved
+++ b/Tools/SDDSApiInfoGenerator/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tools/SDDSApiInfoGenerator/Package.swift
+++ b/Tools/SDDSApiInfoGenerator/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+// Автономный build-tool: сканирует `*Appearance`-структуры SDDSComponents через SwiftSyntax
+// и эмитит `ios-api-meta.json` — iOS-аналог Android `uikit-api-meta.json`
+// (агрегатор API стилей). Держится отдельно от CLI SDDSThemeBuilder (тот собирается
+// через xcodebuild и не тянет SPM-swift-syntax).
+let package = Package(
+    name: "SDDSApiInfoGenerator",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "SDDSApiInfoGenerator",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax")
+            ]
+        )
+    ]
+)

--- a/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/Meta.swift
+++ b/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/Meta.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Схема `ios-api-meta.json` (массив компонентов):
+/// - `qualifiedName`/`styleQualifiedName` — Swift-тип `*Appearance`;
+/// - `methodName` — имя stored-property;
+/// - `paramName` — имя аргумента memberwise-init (совпадает с property);
+/// - `valueQualifiedType` — Swift-тип значения (для группы — тип под-структуры).
+struct ComponentApiMeta: Codable {
+    let componentName: String
+    let qualifiedName: String
+    let styleQualifiedName: String
+    let resolvedTypes: [String]
+    let stateEnum: StateEnum?
+    let params: [Param]
+}
+
+/// enum кастомных состояний компонента.
+struct StateEnum: Codable {
+    let qualifiedName: String
+    let simpleName: String
+    let values: [Value]
+
+    struct Value: Codable {
+        let name: String
+    }
+}
+
+/// Одно настраиваемое свойство компонента.
+struct Param: Codable {
+    /// Категория (`color`/`shape`/`typography`/`dimension`/`shadow`/`icon`/
+    /// `component_style`/`boolean`/`int`/`float`/`value`).
+    let type: String
+    /// Имя свойства в конфиге (`// sdds:apiName=<id>` либо имя property).
+    let id: String
+    /// Имя stored-property (iOS-аналог `methodName` билдера).
+    let methodName: String
+    /// Имя аргумента memberwise-init (= property).
+    let paramName: String
+    /// Полный Swift-тип property.
+    let paramQualifiedType: String
+    /// Короткое имя типа property.
+    let paramSimpleType: String
+    /// Тип значения (для группы — тип под-структуры/протокола).
+    let valueQualifiedType: String
+    /// Dotted-путь группы (`root` для верхнего уровня, иначе `size`, `indicator.colors`, …).
+    let group: String
+    /// `true`, если у config-id нет пары в iOS `Appearance` (пустой `methodName`):
+    /// либо свойства на iOS нет, либо структурный кейс (split → EdgeInsets/CGPoint).
+    /// Эмитится только когда `true` (иначе поля нет).
+    let unmapped: Bool?
+
+    /// Источник декларации свойства (для вставки маркеров) — НЕ сериализуется в JSON.
+    var sourceFile: String? = nil
+    var sourceLine: Int? = nil
+
+    private enum CodingKeys: String, CodingKey {
+        case type, id, methodName, paramName, paramQualifiedType, paramSimpleType, valueQualifiedType, group, unmapped
+    }
+
+    init(type: String, id: String, methodName: String, paramName: String,
+         paramQualifiedType: String, paramSimpleType: String, valueQualifiedType: String, group: String,
+         unmapped: Bool? = nil, sourceFile: String? = nil, sourceLine: Int? = nil) {
+        self.type = type; self.id = id; self.methodName = methodName; self.paramName = paramName
+        self.paramQualifiedType = paramQualifiedType; self.paramSimpleType = paramSimpleType
+        self.valueQualifiedType = valueQualifiedType; self.group = group
+        self.unmapped = unmapped
+        self.sourceFile = sourceFile; self.sourceLine = sourceLine
+    }
+}

--- a/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/PropsCatalog.swift
+++ b/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/PropsCatalog.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Одно свойство конфига (поле `<Component>Props`) — это `id`, который видит
+/// универсальный генератор в JSON-конфиге.
+struct PropsField {
+    let id: String
+    /// Категория, выведенная из типа поля (`ColorKeyValue`→color, `KeyValue<Double>`→dimension, …).
+    let category: String
+    /// Вложенный Props-тип для `ComponentStyleKeyValue<X>` / `KeyValue<XProps>`.
+    let nestedProps: String?
+}
+
+/// Каталог config-id по компонентам, собранный из неизменённых `*Props`-структур
+/// (`SDDSThemeBuilderCore/Model/Props`). Это авторитетный словарь свойств конфига —
+/// тул сопоставляет его с Appearance, ничего не переименовывая в исходниках.
+final class PropsCatalog {
+    /// norm(componentName) → поля.
+    private(set) var byComponent: [String: [PropsField]] = [:]
+
+    init(table: SymbolTable) {
+        for (name, decl) in table.types where decl.kind == .structOrClass && name.hasSuffix("Props") {
+            let component = String(name.dropLast("Props".count))
+            let fields = decl.properties.map { property in
+                PropsField(
+                    id: property.name,
+                    category: Self.category(simpleType: property.simpleType, generic: property.genericArgument),
+                    nestedProps: (property.genericArgument?.hasSuffix("Props") ?? false) ? property.genericArgument : nil
+                )
+            }
+            if !fields.isEmpty {
+                byComponent[Self.norm(component)] = fields
+            }
+        }
+    }
+
+    func fields(forComponent componentName: String) -> [PropsField]? {
+        byComponent[Self.norm(componentName)]
+    }
+
+    static func norm(_ s: String) -> String {
+        s.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    /// Категория config-свойства по типу поля Props.
+    private static func category(simpleType: String, generic: String?) -> String {
+        switch simpleType {
+        case "ColorKeyValue": return "color"
+        case "ShapeKeyValue": return "shape"
+        case "ShadowKeyValue": return "shadow"
+        case "ComponentStyleKeyValue": return "component_style"
+        case "KeyValue":
+            switch generic {
+            case "Double", "CGFloat": return "dimension"
+            case "Bool": return "boolean"
+            case .some(let g) where g.hasSuffix("Props"): return "component_style"
+            default: return "value" // String: типографика/enum — уточняется по матчу с Appearance
+            }
+        default:
+            return generic?.hasSuffix("Props") == true ? "component_style" : "value"
+        }
+    }
+}

--- a/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/Reconciler.swift
+++ b/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/Reconciler.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// Диагностика сверки одного компонента.
+struct ReconcileReport {
+    let component: String
+    let matched: Int
+    let total: Int
+    let gaps: [String]   // config-id без цели в Appearance (структурные/отсутствующие)
+    let drift: [String]  // Appearance-свойства без config-id (потенциальный дрифт)
+}
+
+/// Сопоставляет config-id (`Props`) с целями Appearance, ничего не переименовывая.
+/// На выходе — params, ключёванные по config-id, с координатами кода из Appearance
+/// (`methodName`/`group`/`valueQualifiedType`). Пробелы помечаются пустым `methodName`.
+struct Reconciler {
+    /// Суффиксы-категории, отбрасываемые при сравнении «базы» имени.
+    private static let categorySuffixes = ["typography", "appearance", "fillstyle", "brush", "style", "color", "shape"]
+
+    /// Безопасные синонимы-эквиваленты (только однозначные, напр. опечаточные варианты).
+    /// Семантические синонимы (label↔title и т.п.) НЕ включаем — они требуют явного
+    /// `// sdds:apiName=` на свойстве Appearance.
+    private static let synonyms: [String: String] = [
+        "disabledalpha": "disablealpha"
+    ]
+
+    static func normalize(_ s: String) -> String {
+        let n = s.lowercased().filter { $0.isLetter || $0.isNumber }
+        return synonyms[n] ?? n
+    }
+
+    private static func base(_ normalized: String) -> String {
+        for suffix in categorySuffixes where normalized.hasSuffix(suffix) && normalized.count > suffix.count {
+            return String(normalized.dropLast(suffix.count))
+        }
+        return normalized
+    }
+
+    /// Реконсайлит один компонент. `overrides` — курируемая таблица `configId → имя
+    /// свойства/группы Appearance` (sidecar, без правок Swift), имеет высший приоритет.
+    func reconcile(
+        meta: ComponentApiMeta,
+        fields: [PropsField],
+        overrides: [String: String] = [:]
+    ) -> (ComponentApiMeta, ReconcileReport) {
+        // Индекс Appearance-параметров по нормализованным methodName и id (id несёт marker-override).
+        var index: [String: [Param]] = [:]
+        for param in meta.params {
+            for key in Set([Self.normalize(param.methodName), Self.normalize(param.id)]) {
+                index[key, default: []].append(param)
+            }
+        }
+
+        var usedParamKeys = Set<String>()
+        var newParams: [Param] = []
+        var gaps: [String] = []
+
+        for field in fields {
+            // Маркер `// sdds:apiName=<configId>` на свойстве Appearance проставил param.id —
+            // это точное объявление config-id, высший приоритет.
+            // Только для реально размеченных свойств (id != имя property), чтобы случайно
+            // одноимённое свойство не перехватило вложенный компонент (напр. Wheel.dividerStyle).
+            if let match = index[Self.normalize(field.id)]?.first(where: {
+                Self.normalize($0.id) == Self.normalize(field.id) && $0.id != $0.methodName
+            }) {
+                usedParamKeys.insert(Self.normalize(match.methodName))
+                newParams.append(Param(
+                    type: match.type, id: field.id, methodName: match.methodName, paramName: match.paramName,
+                    paramQualifiedType: match.paramQualifiedType, paramSimpleType: match.paramSimpleType,
+                    valueQualifiedType: match.valueQualifiedType, group: match.group
+                ))
+                continue
+            }
+            // Курируемый override (sidecar) — для структурных исключений, если заданы.
+            if let target = overrides[field.id],
+               let match = index[Self.normalize(target)]?.first {
+                usedParamKeys.insert(Self.normalize(match.methodName))
+                newParams.append(Param(
+                    type: match.type, id: field.id, methodName: match.methodName, paramName: match.paramName,
+                    paramQualifiedType: match.paramQualifiedType, paramSimpleType: match.paramSimpleType,
+                    valueQualifiedType: match.valueQualifiedType, group: match.group
+                ))
+                continue
+            }
+            if let match = bestMatch(for: field, in: index) {
+                usedParamKeys.insert(Self.normalize(match.methodName))
+                newParams.append(Param(
+                    type: match.type,
+                    id: field.id,
+                    methodName: match.methodName,
+                    paramName: match.paramName,
+                    paramQualifiedType: match.paramQualifiedType,
+                    paramSimpleType: match.paramSimpleType,
+                    valueQualifiedType: match.valueQualifiedType,
+                    group: match.group
+                ))
+            } else {
+                gaps.append(field.id)
+                newParams.append(Param(
+                    type: field.category,
+                    id: field.id,
+                    methodName: "",
+                    paramName: "",
+                    paramQualifiedType: "",
+                    paramSimpleType: "",
+                    valueQualifiedType: field.nestedProps ?? "",
+                    group: "root",
+                    unmapped: true
+                ))
+            }
+        }
+
+        let drift = meta.params
+            .filter { !usedParamKeys.contains(Self.normalize($0.methodName)) }
+            .map { $0.id }
+
+        let reconciled = ComponentApiMeta(
+            componentName: meta.componentName,
+            qualifiedName: meta.qualifiedName,
+            styleQualifiedName: meta.styleQualifiedName,
+            resolvedTypes: meta.resolvedTypes,
+            stateEnum: meta.stateEnum,
+            params: newParams
+        )
+        let report = ReconcileReport(
+            component: meta.componentName,
+            matched: fields.count - gaps.count,
+            total: fields.count,
+            gaps: gaps,
+            drift: Array(Set(drift)).sorted()
+        )
+        return (reconciled, report)
+    }
+
+    /// Лучший Appearance-параметр для config-поля: exact → alias(Style↔Typography/Appearance)
+    /// → совпадение базы + категории.
+    private func bestMatch(for field: PropsField, in index: [String: [Param]]) -> Param? {
+        let fnorm = Self.normalize(field.id)
+        let fbase = Self.base(fnorm)
+
+        var best: Param?
+        var bestScore = 0
+        for (_, params) in index {
+            for param in params {
+                let pnorm = Self.normalize(param.methodName)
+                let pbase = Self.base(pnorm)
+                var score = 0
+                if pnorm == fnorm { score = 100 }
+                else if pbase == fbase && !fbase.isEmpty { score = 80 }
+                else if !fbase.isEmpty && (pbase.contains(fbase) || fbase.contains(pbase)) { score = 40 }
+                if param.type == field.category { score += 15 }
+                // Согласование alias по категориям (config `*Style` ↔ Appearance typography/component_style).
+                if field.id.lowercased().hasSuffix("style") && (param.type == "typography" || param.type == "component_style") { score += 10 }
+                if score > bestScore { bestScore = score; best = param }
+            }
+        }
+        return bestScore >= 80 ? best : nil
+    }
+}

--- a/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/Scanner.swift
+++ b/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/Scanner.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Строит `ios-api-meta.json` из таблицы символов: для каждого `*Appearance`
+/// (или помеченного `// sdds:component=`) рекурсивно раскрывает свойства в params,
+/// уходя в под-структуры/протоколы как в группы.
+struct Scanner {
+    let table: SymbolTable
+    let moduleName: String
+    /// Максимальная глубина раскрытия групп (защита от циклов/глубины).
+    let maxDepth = 6
+
+    /// Суффикс, по которому struct считается стилем компонента.
+    private let appearanceSuffix = "Appearance"
+
+    func scan(only: Set<String>?) -> [ComponentApiMeta] {
+        var result: [ComponentApiMeta] = []
+        for (name, decl) in table.types {
+            guard decl.kind == .structOrClass, !decl.ignored else { continue }
+            // opt-in: компонент — только с `// sdds:apiInfo`
+            // (или явным `// sdds:component=`). Авто-детект по суффиксу отключён.
+            let isComponent = decl.apiInfo || decl.componentOverride != nil
+            guard isComponent else { continue }
+            let derived = name.hasSuffix(appearanceSuffix) ? String(name.dropLast(appearanceSuffix.count)) : name
+            let componentName = decl.componentOverride ?? derived
+            if let only, !only.contains(componentName), !only.contains(name) { continue }
+            guard !componentName.isEmpty else { continue }
+
+            var params: [Param] = []
+            var visited: Set<String> = [name]
+            expand(typeName: name, group: "root", depth: 0, visited: &visited, into: &params)
+
+            let resolved = Set(params.map { $0.valueQualifiedType }).sorted()
+            result.append(ComponentApiMeta(
+                componentName: componentName,
+                qualifiedName: "\(moduleName).\(name)",
+                styleQualifiedName: "\(moduleName).\(name)",
+                resolvedTypes: resolved,
+                stateEnum: stateEnum(for: decl),
+                params: params
+            ))
+        }
+        return result.sorted { $0.componentName < $1.componentName }
+    }
+
+    /// Раскрывает свойства типа `typeName` в params под группой `group`.
+    private func expand(typeName: String, group: String, depth: Int, visited: inout Set<String>, into params: inout [Param]) {
+        guard let decl = table.types[typeName], depth <= maxDepth else { return }
+        for property in decl.properties {
+            guard !property.ignored else { continue }
+            let id = property.apiNameOverride ?? property.name
+
+            // 1) Явный override категории — лист.
+            if let override = property.typeOverride {
+                params.append(leaf(property: property, id: id, category: override, group: group, file: decl.file))
+                continue
+            }
+            // 2) Терминальный токен-тип — лист.
+            if let category = TypeCategory.terminalCategory(simpleType: property.simpleType) {
+                params.append(leaf(property: property, id: id, category: category, group: group, file: decl.file))
+                continue
+            }
+            // 2b) Вложенный компонент (тип `*Appearance`) — ОДИН `component_style`-лист,
+            //     НЕ разворачиваем (в конфиге это единый `ComponentStyleKeyValue<XProps>`).
+            //     Разворачиваем только группировочные конфиги (`*SizeConfiguration`).
+            if property.simpleType.hasSuffix("Appearance") {
+                params.append(leaf(property: property, id: id, category: "component_style", group: group, file: decl.file))
+                continue
+            }
+            // 3) Композит из дерева — рекурсия как группа (имя группы = id, чтобы
+            //    `// sdds:apiName=` на контейнерном свойстве переименовывал группу).
+            let childGroup = (group == "root") ? id : "\(group).\(id)"
+            if let nested = table.types[property.simpleType], canExpand(nested), !visited.contains(property.simpleType) {
+                visited.insert(property.simpleType)
+                expand(typeName: property.simpleType, group: childGroup, depth: depth + 1, visited: &visited, into: &params)
+                visited.remove(property.simpleType)
+                continue
+            }
+            // 3b) Дженерик-обёртка (напр. Variation<X>) — рекурсия в аргумент.
+            if let generic = property.genericArgument,
+               let nested = table.types[generic], canExpand(nested), !visited.contains(generic) {
+                visited.insert(generic)
+                expand(typeName: generic, group: childGroup, depth: depth + 1, visited: &visited, into: &params)
+                visited.remove(generic)
+                continue
+            }
+            // 4) enum из дерева — лист-`value`.
+            if let nested = table.types[property.simpleType], nested.kind == .enumeration {
+                params.append(leaf(property: property, id: id, category: "value", group: group, file: decl.file))
+                continue
+            }
+            // 5) Неизвестный внешний тип — лист с fallback-категорией.
+            params.append(leaf(property: property, id: id, category: TypeCategory.fallback(simpleType: property.simpleType), group: group, file: decl.file))
+        }
+    }
+
+    private func canExpand(_ decl: TypeDecl) -> Bool {
+        (decl.kind == .structOrClass || decl.kind == .proto) && !decl.properties.isEmpty && !decl.ignored
+    }
+
+    private func leaf(property: PropertyDecl, id: String, category: String, group: String, file: String) -> Param {
+        Param(
+            type: category,
+            id: id,
+            methodName: property.name,
+            paramName: property.name,
+            paramQualifiedType: property.qualifiedType,
+            paramSimpleType: property.simpleType,
+            valueQualifiedType: property.genericArgument ?? property.simpleType,
+            group: group,
+            sourceFile: file,
+            sourceLine: property.line
+        )
+    }
+
+    /// Состояния компонента: `// sdds:stateEnum=<EnumName>` на struct → берём enum из дерева.
+    private func stateEnum(for decl: TypeDecl) -> StateEnum? {
+        guard let enumName = decl.stateEnumName,
+              let enumDecl = table.types[enumName], enumDecl.kind == .enumeration else { return nil }
+        return StateEnum(
+            qualifiedName: "\(moduleName).\(enumName)",
+            simpleName: enumName,
+            values: enumDecl.enumCases.map { StateEnum.Value(name: $0) }
+        )
+    }
+}

--- a/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/SymbolTable.swift
+++ b/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/SymbolTable.swift
@@ -1,0 +1,245 @@
+import Foundation
+import SwiftSyntax
+import SwiftParser
+
+/// Свойство типа (stored для struct/class, требование для protocol).
+struct PropertyDecl {
+    let name: String
+    /// Короткое имя типа, развёрнутое из Optional/дженериков.
+    let simpleType: String
+    /// Тип как написан в исходнике.
+    let qualifiedType: String
+    /// Первый generic-аргумент (напр. `IndicatorProps` в `ComponentStyleKeyValue<IndicatorProps>`).
+    let genericArgument: String?
+    /// Override имени в конфиге (`// sdds:apiName=<id>`).
+    let apiNameOverride: String?
+    /// Override категории (`// sdds:type=<category>`).
+    let typeOverride: String?
+    /// Пропустить свойство (`// sdds:ignore`).
+    let ignored: Bool
+    /// Строка декларации свойства (1-based) — для точной вставки маркеров.
+    let line: Int
+}
+
+/// Декларация типа в дереве исходников.
+struct TypeDecl {
+    enum Kind { case structOrClass, proto, enumeration }
+    let name: String
+    let kind: Kind
+    let properties: [PropertyDecl]
+    let enumCases: [String]
+    /// Override имени компонента (`// sdds:component=<Name>`) на struct.
+    let componentOverride: String?
+    /// Имя enum состояний (`// sdds:stateEnum=<Name>`) на struct.
+    let stateEnumName: String?
+    /// Не считать компонентом/не рекурсить (`// sdds:ignore`) на struct.
+    let ignored: Bool
+    /// Помечен ли `// sdds:apiInfo` (компонент-аннотация, opt-in).
+    let apiInfo: Bool
+    /// Путь к файлу, где объявлен тип — для вставки маркеров.
+    let file: String
+}
+
+/// Индекс всех типов проекта: имя типа → декларация.
+final class SymbolTable {
+    private(set) var types: [String: TypeDecl] = [:]
+
+    func ingest(source: String, path: String = "<memory>") {
+        let tree = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: path, tree: tree)
+        let collector = SymbolCollector(file: path, converter: converter)
+        collector.walk(tree)
+        for decl in collector.decls {
+            // Первая встреченная декларация имени выигрывает (partial extensions игнорируем).
+            if types[decl.name] == nil {
+                types[decl.name] = decl
+            }
+        }
+    }
+}
+
+// MARK: - Извлечение marker-комментов и имён типов
+
+enum SyntaxSupport {
+    /// Собирает все строки line/block-комментов из trivia.
+    static func comments(from trivia: Trivia) -> [String] {
+        trivia.compactMap { piece in
+            switch piece {
+            case .lineComment(let text), .blockComment(let text):
+                return text
+            case .docLineComment(let text), .docBlockComment(let text):
+                return text
+            default:
+                return nil
+            }
+        }
+    }
+
+    /// Ищет `sdds:<key>=<value>` в списке комментов.
+    static func marker(_ key: String, in comments: [String]) -> String? {
+        let needle = "sdds:\(key)="
+        for comment in comments {
+            guard let range = comment.range(of: needle) else { continue }
+            let tail = comment[range.upperBound...]
+            let value = tail.prefix { $0 != " " && $0 != "\t" && $0 != "*" && $0 != "/" }
+            let trimmed = value.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty { return trimmed }
+        }
+        return nil
+    }
+
+    /// Есть ли флаг `sdds:<flag>` (без значения) в комментах.
+    static func flag(_ flag: String, in comments: [String]) -> Bool {
+        let needle = "sdds:\(flag)"
+        return comments.contains { $0.contains(needle) && marker(flag, in: [$0]) == nil }
+    }
+
+    /// Короткое имя типа + первый generic-аргумент, развёрнутое из Optional/IUO/массивов.
+    static func unwrap(_ type: TypeSyntax) -> (simple: String, generic: String?) {
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return unwrap(optional.wrappedType)
+        }
+        if let iuo = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return unwrap(iuo.wrappedType)
+        }
+        if let array = type.as(ArrayTypeSyntax.self) {
+            let inner = unwrap(array.element)
+            return ("Array", inner.simple)
+        }
+        if let identifier = type.as(IdentifierTypeSyntax.self) {
+            let name = identifier.name.text
+            var generic: String?
+            if let args = identifier.genericArgumentClause?.arguments.first?.argument.as(TypeSyntax.self) {
+                generic = unwrap(args).simple
+            }
+            return (name, generic)
+        }
+        if let member = type.as(MemberTypeSyntax.self) {
+            return (member.name.text, nil)
+        }
+        // Функции, кортежи и прочее — как есть, без раскрытия.
+        return (type.trimmedDescription, nil)
+    }
+}
+
+// MARK: - Обход дерева
+
+private final class SymbolCollector: SyntaxVisitor {
+    var decls: [TypeDecl] = []
+    let file: String
+    let converter: SourceLocationConverter
+
+    init(file: String, converter: SourceLocationConverter) {
+        self.file = file
+        self.converter = converter
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        collect(name: node.name.text, kind: .structOrClass, members: node.memberBlock, leading: node.leadingTrivia)
+        return .visitChildren
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        collect(name: node.name.text, kind: .structOrClass, members: node.memberBlock, leading: node.leadingTrivia)
+        return .visitChildren
+    }
+
+    override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+        collect(name: node.name.text, kind: .proto, members: node.memberBlock, leading: node.leadingTrivia)
+        return .visitChildren
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        var cases: [String] = []
+        for member in node.memberBlock.members {
+            guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else { continue }
+            for element in caseDecl.elements {
+                cases.append(element.name.text)
+            }
+        }
+        let comments = SyntaxSupport.comments(from: node.leadingTrivia)
+        decls.append(TypeDecl(
+            name: node.name.text,
+            kind: .enumeration,
+            properties: [],
+            enumCases: cases,
+            componentOverride: SyntaxSupport.marker("component", in: comments),
+            stateEnumName: SyntaxSupport.marker("stateEnum", in: comments),
+            ignored: SyntaxSupport.flag("ignore", in: comments),
+            apiInfo: SyntaxSupport.flag("apiInfo", in: comments),
+            file: file
+        ))
+        return .visitChildren
+    }
+
+    private func collect(name: String, kind: TypeDecl.Kind, members: MemberBlockSyntax, leading: Trivia) {
+        let isProtocol = (kind == .proto)
+        var properties: [PropertyDecl] = []
+        for member in members.members {
+            guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+            if isStatic(variable) { continue }
+            if isDeprecated(variable) { continue }
+            let comments = SyntaxSupport.comments(from: variable.leadingTrivia)
+                + SyntaxSupport.comments(from: variable.trailingTrivia)
+            let line = converter.location(for: variable.positionAfterSkippingLeadingTrivia).line
+            for binding in variable.bindings {
+                guard let idPattern = binding.pattern.as(IdentifierPatternSyntax.self),
+                      let type = binding.typeAnnotation?.type else { continue }
+                // struct/class: только stored; protocol: все требования-var.
+                if !isProtocol && isComputed(binding) { continue }
+                let unwrapped = SyntaxSupport.unwrap(type)
+                properties.append(PropertyDecl(
+                    name: idPattern.identifier.text,
+                    simpleType: unwrapped.simple,
+                    qualifiedType: type.trimmedDescription,
+                    genericArgument: unwrapped.generic,
+                    apiNameOverride: SyntaxSupport.marker("apiName", in: comments),
+                    typeOverride: SyntaxSupport.marker("type", in: comments),
+                    ignored: SyntaxSupport.flag("ignore", in: comments),
+                    line: line
+                ))
+            }
+        }
+        let comments = SyntaxSupport.comments(from: leading)
+        decls.append(TypeDecl(
+            name: name,
+            kind: kind,
+            properties: properties,
+            enumCases: [],
+            componentOverride: SyntaxSupport.marker("component", in: comments),
+            stateEnumName: SyntaxSupport.marker("stateEnum", in: comments),
+            ignored: SyntaxSupport.flag("ignore", in: comments),
+            apiInfo: SyntaxSupport.flag("apiInfo", in: comments),
+            file: file
+        ))
+    }
+
+    private func isStatic(_ variable: VariableDeclSyntax) -> Bool {
+        variable.modifiers.contains { $0.name.tokenKind == .keyword(.static) || $0.name.tokenKind == .keyword(.class) }
+    }
+
+    private func isDeprecated(_ variable: VariableDeclSyntax) -> Bool {
+        variable.attributes.contains { attr in
+            attr.as(AttributeSyntax.self)?.trimmedDescription.contains("deprecated") ?? false
+        }
+    }
+
+    /// Computed = есть accessor-блок с геттером или кодом (не только willSet/didSet).
+    private func isComputed(_ binding: PatternBindingSyntax) -> Bool {
+        guard let accessor = binding.accessorBlock else { return false }
+        switch accessor.accessors {
+        case .getter:
+            return true
+        case .accessors(let list):
+            return list.contains { acc in
+                switch acc.accessorSpecifier.tokenKind {
+                case .keyword(.get), .keyword(._read), .keyword(.unsafeAddress):
+                    return true
+                default:
+                    return false
+                }
+            }
+        }
+    }
+}

--- a/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/TypeCategory.swift
+++ b/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/TypeCategory.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Классификатор Swift-типа property в категорию `Param.type`.
+///
+/// Логика: сначала явные «терминальные» токен-типы (по точному короткому имени),
+/// затем эвристики по ключевым словам, затем скаляры. Всё, что не терминально и
+/// известно как struct/protocol в дереве исходников, будет рекурсивно раскрыто
+/// как группа (решение принимает `Scanner`, не классификатор).
+enum TypeCategory {
+    /// Терминальные типы, которые никогда не рекурсим (даже будучи struct'ами).
+    /// Ключ — короткое имя типа, значение — категория.
+    static let terminalExact: [String: String] = [
+        "StatefulColor": "color",
+        "StatefulFillStyle": "color",
+        "ButtonColor": "color",
+        "Color": "color",
+        "FillStyle": "color",
+        "InteractiveColor": "color",
+        "TypographyConfiguration": "typography",
+        "TextStyle": "typography",
+        "ShapeToken": "shape",
+        "ShadowToken": "shadow",
+        "Image": "icon"
+    ]
+
+    /// Скаляры и геометрия.
+    static let scalarExact: [String: String] = [
+        "CGFloat": "dimension",
+        "Double": "dimension",
+        "CGSize": "dimension",
+        "CGPoint": "dimension",
+        "CGRect": "dimension",
+        "EdgeInsets": "dimension",
+        "Angle": "dimension",
+        "Float": "float",
+        "Bool": "boolean",
+        "Int": "int",
+        "String": "value",
+        "TextAlignment": "value",
+        "Alignment": "value",
+        "HorizontalAlignment": "value",
+        "VerticalAlignment": "value"
+    ]
+
+    /// Эвристики по вхождению подстроки в короткое имя типа (по убыванию приоритета).
+    private static let keywordRules: [(needle: String, category: String)] = [
+        ("Typography", "typography"),
+        ("Shadow", "shadow"),
+        ("Shape", "shape"),
+        ("Brush", "color"),
+        ("Color", "color"),
+        ("FillStyle", "color"),
+        ("Gradient", "color"),
+        ("Icon", "icon"),
+        ("Image", "icon")
+    ]
+
+    /// Возвращает категорию для «листа», либо `nil`, если тип стоит попробовать
+    /// раскрыть рекурсивно (композит).
+    static func terminalCategory(simpleType: String) -> String? {
+        if let exact = terminalExact[simpleType] { return exact }
+        if let scalar = scalarExact[simpleType] { return scalar }
+        for rule in keywordRules where simpleType.contains(rule.needle) {
+            return rule.category
+        }
+        return nil
+    }
+
+    /// Дефолтная категория для нераскрытого/внешнего типа: композит-стиль, если имя
+    /// похоже на style-тип, иначе — сырое `value`.
+    static func fallback(simpleType: String) -> String {
+        let compositeSuffixes = ["Appearance", "Style", "Configuration", "Props"]
+        if compositeSuffixes.contains(where: { simpleType.hasSuffix($0) }) {
+            return "component_style"
+        }
+        return "value"
+    }
+}

--- a/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/main.swift
+++ b/Tools/SDDSApiInfoGenerator/Sources/SDDSApiInfoGenerator/main.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+// MARK: - Разбор аргументов
+
+func argValue(_ name: String, in args: [String]) -> String? {
+    guard let index = args.firstIndex(of: name), index + 1 < args.count else { return nil }
+    return args[index + 1]
+}
+
+let args = Array(CommandLine.arguments.dropFirst())
+
+if args.contains("--help") || args.contains("-h") {
+    print("""
+    sdds-api-info — генератор ios-api-meta.json (агрегатор API стилей).
+
+    Опции:
+      --sources <dir[,dir...]>  Каталоги исходников для скана (default: SDDSComponents/Sources)
+      --props   <dir>           Каталог *Props для сверки config-id (default: SDDSThemeBuilder/SDDSThemeBuilderCore/Model/Props; "" — выключить)
+      --output  <file>          Куда писать JSON (default: stdout)
+      --module  <name>          Имя модуля для qualifiedName (default: SDDSComponents)
+      --only    <A,B,...>       Ограничить набор компонентов (по имени компонента или типа)
+      --report                  Печатать диагностику сверки (matched/gaps/drift) в stderr
+      --help                    Показать справку
+    """)
+    exit(0)
+}
+
+let sourcesArg = argValue("--sources", in: args) ?? "SDDSComponents/Sources"
+let propsArg = argValue("--props", in: args) ?? "SDDSThemeBuilder/SDDSThemeBuilderCore/Model/Props"
+let overridesArg = argValue("--overrides", in: args) ?? "SDDSThemeBuilder/.sdds/ios-api-meta.overrides.json"
+let outputPath = argValue("--output", in: args)
+let moduleName = argValue("--module", in: args) ?? "SDDSComponents"
+let wantReport = args.contains("--report")
+let onlyFilter: Set<String>? = argValue("--only", in: args).map { value in
+    Set(value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) })
+}
+
+let sourceDirs = sourcesArg.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
+
+// MARK: - Обход .swift-файлов
+
+let fileManager = FileManager.default
+let skipDirs: Set<String> = [".build", "build", ".git", ".claude", "worktrees", "DerivedData", ".swiftpm"]
+
+func swiftFiles(in directory: String) -> [String] {
+    var result: [String] = []
+    guard let enumerator = fileManager.enumerator(atPath: directory) else { return result }
+    for case let path as String in enumerator {
+        let components = path.split(separator: "/").map(String.init)
+        if components.contains(where: { skipDirs.contains($0) }) {
+            continue
+        }
+        if path.hasSuffix(".swift") {
+            result.append((directory as NSString).appendingPathComponent(path))
+        }
+    }
+    return result
+}
+
+let table = SymbolTable()
+var fileCount = 0
+for dir in sourceDirs {
+    var isDir: ObjCBool = false
+    guard fileManager.fileExists(atPath: dir, isDirectory: &isDir), isDir.boolValue else {
+        FileHandle.standardError.write(Data("warning: каталог не найден: \(dir)\n".utf8))
+        continue
+    }
+    for file in swiftFiles(in: dir) {
+        guard let source = try? String(contentsOfFile: file, encoding: .utf8) else { continue }
+        table.ingest(source: source, path: file)
+        fileCount += 1
+    }
+}
+
+// MARK: - Каталог config-id из *Props (для сверки)
+
+var propsCatalog: PropsCatalog?
+if !propsArg.isEmpty {
+    var isDir: ObjCBool = false
+    if fileManager.fileExists(atPath: propsArg, isDirectory: &isDir), isDir.boolValue {
+        let propsTable = SymbolTable()
+        for file in swiftFiles(in: propsArg) {
+            if let source = try? String(contentsOfFile: file, encoding: .utf8) {
+                propsTable.ingest(source: source)
+            }
+        }
+        propsCatalog = PropsCatalog(table: propsTable)
+    } else {
+        FileHandle.standardError.write(Data("warning: каталог Props не найден: \(propsArg) (сверка выключена)\n".utf8))
+    }
+}
+
+// MARK: - Курируемые override'ы (sidecar, без правок Swift)
+
+var overrides: [String: [String: String]] = [:]
+if let data = try? Data(contentsOf: URL(fileURLWithPath: overridesArg)),
+   let decoded = try? JSONDecoder().decode([String: [String: String]].self, from: data) {
+    overrides = decoded
+}
+
+// MARK: - Скан + сверка + сериализация
+
+let scanner = Scanner(table: table, moduleName: moduleName)
+let scanned = scanner.scan(only: onlyFilter)
+
+// MARK: - Режим --emit-marker-plan: где разместить `// sdds:apiName=` для миграции таблицы в аннотации
+
+if args.contains("--emit-marker-plan") {
+    struct MarkerPlanItem: Codable {
+        let component: String
+        let configId: String
+        let property: String
+        let file: String
+        let line: Int
+    }
+    var plan: [MarkerPlanItem] = []
+    var unresolved: [String] = []
+    let scannedByComponent = Dictionary(scanned.map { ($0.componentName, $0) }, uniquingKeysWith: { a, _ in a })
+    for (component, mapping) in overrides {
+        guard let meta = scannedByComponent[component] else {
+            unresolved.append("\(component): нет в скане"); continue
+        }
+        for (configId, targetProperty) in mapping {
+            let matches = meta.params.filter { $0.methodName == targetProperty }
+            guard let match = matches.first, let file = match.sourceFile, let line = match.sourceLine else {
+                unresolved.append("\(component).\(configId) → \(targetProperty): свойство не найдено"); continue
+            }
+            if Set(matches.map { "\($0.sourceFile ?? ""):\($0.sourceLine ?? -1)" }).count > 1 {
+                unresolved.append("\(component).\(configId) → \(targetProperty): неоднозначно (\(matches.count))"); continue
+            }
+            plan.append(MarkerPlanItem(component: component, configId: configId, property: targetProperty, file: file, line: line))
+        }
+    }
+    let enc = JSONEncoder(); enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+    FileHandle.standardOutput.write((try? enc.encode(plan)) ?? Data())
+    FileHandle.standardOutput.write(Data("\n".utf8))
+    if !unresolved.isEmpty {
+        FileHandle.standardError.write(Data(("НЕ разрешено (\(unresolved.count)):\n" + unresolved.sorted().joined(separator: "\n") + "\n").utf8))
+    }
+    FileHandle.standardError.write(Data("marker-plan: \(plan.count) маркеров\n".utf8))
+    exit(0)
+}
+
+var components: [ComponentApiMeta] = []
+var reports: [ReconcileReport] = []
+let reconciler = Reconciler()
+for meta in scanned {
+    if let fields = propsCatalog?.fields(forComponent: meta.componentName), !fields.isEmpty {
+        let (reconciled, report) = reconciler.reconcile(
+            meta: meta,
+            fields: fields,
+            overrides: overrides[meta.componentName] ?? [:]
+        )
+        components.append(reconciled)
+        reports.append(report)
+    } else {
+        components.append(meta)
+    }
+}
+
+if wantReport && !reports.isEmpty {
+    let matched = reports.reduce(0) { $0 + $1.matched }
+    let totalFields = reports.reduce(0) { $0 + $1.total }
+    let pct = totalFields > 0 ? matched * 100 / totalFields : 0
+    FileHandle.standardError.write(Data("\n=== Сверка config-id ↔ Appearance: \(matched)/\(totalFields) (\(pct)%) по \(reports.count) компонентам ===\n".utf8))
+    for report in reports.sorted(by: { $0.gaps.count > $1.gaps.count }) where !report.gaps.isEmpty || !report.drift.isEmpty {
+        var line = "\(report.component): \(report.matched)/\(report.total)"
+        if !report.gaps.isEmpty { line += " | gaps: \(report.gaps.joined(separator: ","))" }
+        if !report.drift.isEmpty { line += " | drift: \(report.drift.joined(separator: ","))" }
+        FileHandle.standardError.write(Data((line + "\n").utf8))
+    }
+}
+
+let encoder = JSONEncoder()
+encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+let data = try encoder.encode(components)
+
+if let outputPath {
+    try data.write(to: URL(fileURLWithPath: outputPath))
+    FileHandle.standardError.write(Data("ok: \(components.count) компонентов из \(fileCount) файлов → \(outputPath)\n".utf8))
+} else {
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+    FileHandle.standardError.write(Data("ok: \(components.count) компонентов из \(fileCount) файлов\n".utf8))
+}

--- a/scripts/generate_api_meta.sh
+++ b/scripts/generate_api_meta.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Генерирует ios-api-meta.json — мету API стилей компонентов
+# (агрегатор API стилей). Сканирует *Appearance-структуры SDDSComponents через
+# SwiftSyntax-тул Tools/SDDSApiInfoGenerator и пишет результат в трекаемый файл.
+#
+# Использование:
+#   scripts/generate_api_meta.sh              # полная перегенерация
+#   scripts/generate_api_meta.sh --only FormItem,Counter   # подмножество (в stdout)
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOL_DIR="$REPO_ROOT/Tools/SDDSApiInfoGenerator"
+SOURCES="$REPO_ROOT/SDDSComponents/Sources"
+PROPS="$REPO_ROOT/SDDSThemeBuilder/SDDSThemeBuilderCore/Model/Props"
+OUTPUT="$REPO_ROOT/SDDSThemeBuilder/.sdds/ios-api-meta.json"
+
+echo "==> Сборка сканера (release)…"
+swift build --package-path "$TOOL_DIR" -c release >/dev/null
+BIN="$TOOL_DIR/.build/release/SDDSApiInfoGenerator"
+
+if [[ "${1:-}" == "--only" ]]; then
+    # Подмножество → в stdout с диагностикой сверки в stderr (удобно для ревью).
+    "$BIN" --sources "$SOURCES" --props "$PROPS" --only "${2:-}" --report
+    exit 0
+fi
+
+echo "==> Скан $SOURCES (+ сверка с Props, + override'ы)"
+mkdir -p "$(dirname "$OUTPUT")"
+"$BIN" --sources "$SOURCES" --props "$PROPS" --output "$OUTPUT" --report
+echo "==> Готово: $OUTPUT"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded editable-field appearance customization with icon colors (default/readonly), cursor color, disabled-state transparency, typography, and sizing options (with an explicit initializer and defaults).
* **Documentation**
  * Improved and expanded API metadata annotations across many component appearance definitions to keep naming and discovery consistent.
* **Chores**
  * Added an automated API-metadata generator tool and script, and updated the generated iOS theme appearance metadata (including marking previously-unmapped params).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->